### PR TITLE
Fix segmentation fault when [au]per_encode is called with null consume_bytes_cb

### DIFF
--- a/asn1c/tests/check-src/check-136.-gen-PER.c
+++ b/asn1c/tests/check-src/check-136.-gen-PER.c
@@ -61,6 +61,7 @@ enum enctype {
 static void
 save_object_as(PDU_t *st, enum enctype how) {
 	asn_enc_rval_t rval; /* Return value */
+	asn_enc_rval_t rval2;
 
 	buf_offset = 0;
 
@@ -69,13 +70,17 @@ save_object_as(PDU_t *st, enum enctype how) {
 	 */
 	switch(how) {
 	case AS_UPER:
+		rval2 = uper_encode(&asn_DEF_PDU, st, 0, 0);
 		rval = uper_encode(&asn_DEF_PDU, st, _buf_writer, 0);
 		assert(rval.encoded > 0);
+		assert(rval2.encoded == rval.encoded);
 		ASN_DEBUG("SAVED OBJECT IN SIZE %d\n", buf_offset);
 		return;
 	case AS_APER:
+		rval2 = aper_encode(&asn_DEF_PDU, st, 0, 0);
 		rval = aper_encode(&asn_DEF_PDU, st, _buf_writer, 0);
 		assert(rval.encoded > 0);
+		assert(rval2.encoded == rval.encoded);
 		ASN_DEBUG("SAVED OBJECT IN SIZE %d\n", buf_offset);
 		return;
 	case AS_DER:

--- a/skeletons/per_encoder.c
+++ b/skeletons/per_encoder.c
@@ -160,7 +160,10 @@ _uper_encode_flush_outp(asn_per_outp_t *po) {
 		buf++;
 	}
 
-	return po->outper(po->tmpspace, buf - po->tmpspace, po->op_key);
+	if (po->outper) {
+		return po->outper(po->tmpspace, buf - po->tmpspace, po->op_key);
+	}
+	return 0;
 }
 
 static int
@@ -177,7 +180,10 @@ _aper_encode_flush_outp(asn_per_outp_t *po) {
 		buf++;
 	}
 
-	return po->outper(po->tmpspace, buf - po->tmpspace, po->op_key);
+	if (po->outper) {
+		return po->outper(po->tmpspace, buf - po->tmpspace, po->op_key);
+	}
+	return 0;
 }
 
 static asn_enc_rval_t

--- a/skeletons/per_support.c
+++ b/skeletons/per_support.c
@@ -441,7 +441,7 @@ per_put_few_bits(asn_per_outp_t *po, uint32_t bits, int obits) {
 		int complete_bytes = (po->buffer - po->tmpspace);
 		ASN_DEBUG("[PER output %ld complete + %ld]",
 			(long)complete_bytes, (long)po->flushed_bytes);
-		if(po->outper(po->tmpspace, complete_bytes, po->op_key) < 0)
+		if(po->outper && (po->outper(po->tmpspace, complete_bytes, po->op_key) < 0))
 			return -1;
 		if(po->nboff)
 			po->tmpspace[0] = po->buffer[0];


### PR DESCRIPTION
Similar to `der_encode` the `[au]per_encode` methods should return the exact size of the buffer required to [AU]PER-encode the given PDU, which later should be convert to bytes like 
```c
size_t bytes_needed = (ret.encoded + 7)/8;
```

vlm/asn1c#137
mouse07410/asn1c#6