### PR TITLE
Replace op->free_struct with macro for branch 115

### DIFF
--- a/asn1c/tests/check-src/check-119.-fwide-types.-gen-PER.c
+++ b/asn1c/tests/check-src/check-119.-fwide-types.-gen-PER.c
@@ -129,7 +129,7 @@ load_object_from(const char *fname, enum expectation expectation, unsigned char 
 			" chunks %zd\n",
 			size, fname, how==AS_PER?"PER":"XER", csize);
 
-		if(st) asn_DEF_PDU.op->free_struct(&asn_DEF_PDU, st, 0);
+		if(st) ASN_STRUCT_FREE(asn_DEF_PDU, st);
 		st = 0;
 
 		do {
@@ -200,7 +200,7 @@ load_object_from(const char *fname, enum expectation expectation, unsigned char 
 		} else {
 			assert(rval.code != RC_OK);
 			fprintf(stderr, "Failed, but this was expected\n");
-			asn_DEF_PDU.op->free_struct(&asn_DEF_PDU, st, 0);
+			ASN_STRUCT_FREE(asn_DEF_PDU, st);
 			st = 0;	/* ignore leak for now */
 		}
 	}
@@ -289,7 +289,7 @@ process_XER_data(const char *fname, enum expectation expectation, unsigned char 
 		break;
 	}
 
-	asn_DEF_PDU.op->free_struct(&asn_DEF_PDU, st, 0);
+	ASN_STRUCT_FREE(asn_DEF_PDU, st);
 }
 
 /*

--- a/asn1c/tests/check-src/check-119.-gen-PER.c
+++ b/asn1c/tests/check-src/check-119.-gen-PER.c
@@ -129,7 +129,7 @@ load_object_from(const char *fname, enum expectation expectation, unsigned char 
 			" chunks %zd\n",
 			size, fname, how==AS_PER?"PER":"XER", csize);
 
-		if(st) asn_DEF_PDU.op->free_struct(&asn_DEF_PDU, st, 0);
+		if(st) ASN_STRUCT_FREE(asn_DEF_PDU, st);
 		st = 0;
 
 		do {
@@ -200,7 +200,7 @@ load_object_from(const char *fname, enum expectation expectation, unsigned char 
 		} else {
 			assert(rval.code != RC_OK);
 			fprintf(stderr, "Failed, but this was expected\n");
-			asn_DEF_PDU.op->free_struct(&asn_DEF_PDU, st, 0);
+			ASN_STRUCT_FREE(asn_DEF_PDU, st);
 			st = 0;	/* ignore leak for now */
 		}
 	}
@@ -291,7 +291,7 @@ process_XER_data(const char *fname, enum expectation expectation, unsigned char 
 		break;
 	}
 
-	asn_DEF_PDU.op->free_struct(&asn_DEF_PDU, st, 0);
+	ASN_STRUCT_FREE(asn_DEF_PDU, st);
 }
 
 /*

--- a/asn1c/tests/check-src/check-126.-gen-PER.c
+++ b/asn1c/tests/check-src/check-126.-gen-PER.c
@@ -110,7 +110,7 @@ load_object_from(const char *fname, unsigned char *fbuf, size_t size, enum encty
 			" chunks %zd\n",
 			size, fname, how==AS_PER?"PER":"XER", csize);
 
-		if(st) asn_DEF_PDU.op->free_struct(&asn_DEF_PDU, st, 0);
+		if(st) ASN_STRUCT_FREE(asn_DEF_PDU, st);
 		st = 0;
 
 		do {
@@ -308,7 +308,7 @@ process_XER_data(const char *fname, unsigned char *fbuf, size_t size) {
 	else
 		assert(xer_encoding_equal((char *)fbuf, size, (char *)buf, buf_offset));
 
-	asn_DEF_PDU.op->free_struct(&asn_DEF_PDU, st, 0);
+	ASN_STRUCT_FREE(asn_DEF_PDU, st);
 }
 
 /*

--- a/asn1c/tests/check-src/check-135.c
+++ b/asn1c/tests/check-src/check-135.c
@@ -123,13 +123,13 @@ main(int ac, char **av) {
 	check(&t, buf1, sizeof(buf1), sizeof(buf1));
 	compare(&t, buf1_reconstr, sizeof(buf1_reconstr));
 	asn_fprint(stderr, &asn_DEF_T, &t);
-	asn_DEF_T.op->free_struct(&asn_DEF_T, &t, 1);
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 
 	/* Check slightly more than buf1 */
 	check(&t, buf1, sizeof(buf1) + 10, sizeof(buf1));
 	compare(&t, buf1_reconstr, sizeof(buf1_reconstr));
 	asn_fprint(stderr, &asn_DEF_T, &t);
-	asn_DEF_T.op->free_struct(&asn_DEF_T, &t, 1);
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 
 	return 0;
 }

--- a/asn1c/tests/check-src/check-136.-gen-PER.c
+++ b/asn1c/tests/check-src/check-136.-gen-PER.c
@@ -118,7 +118,7 @@ load_object_from(const char *fname, unsigned char *fbuf, size_t size, enum encty
 			" chunks %zd\n",
 			size, fname, how==AS_UPER?"UPER":"XER", csize);
 
-		if(st) asn_DEF_PDU.free_struct(&asn_DEF_PDU, st, 0);
+		if(st) ASN_STRUCT_FREE(asn_DEF_PDU, st);
 		st = 0;
 
 		do {
@@ -353,7 +353,7 @@ process_XER_data(const char *fname, unsigned char *fbuf, size_t size) {
 	else
 		assert(xer_encoding_equal((char *)fbuf, size, (char *)buf, buf_offset));
 
-	asn_DEF_PDU.free_struct(&asn_DEF_PDU, st, 0);
+	ASN_STRUCT_FREE(asn_DEF_PDU, st);
 }
 
 /*

--- a/asn1c/tests/check-src/check-25.-fwide-types.c
+++ b/asn1c/tests/check-src/check-25.-fwide-types.c
@@ -136,7 +136,7 @@ check(int is_ok, uint8_t *buf, size_t size, size_t consumed) {
 		assert(rval.consumed <= consumed);
 	}
 
-	asn_DEF_T.op->free_struct(&asn_DEF_T, &t, 1);
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 }
 
 static void
@@ -237,7 +237,7 @@ partial_read(uint8_t *buf, size_t size) {
 			assert(rval.code == RC_OK);
 			assert(rval.consumed == size3);
 
-			asn_DEF_T.op->free_struct(&asn_DEF_T, &t, 1);
+			ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 		}
 	}
 }

--- a/asn1c/tests/check-src/check-31.-fwide-types.c
+++ b/asn1c/tests/check-src/check-31.-fwide-types.c
@@ -138,7 +138,7 @@ check(int is_ok, uint8_t *buf, size_t size, size_t consumed) {
 	asn_fprint(stderr, &asn_DEF_Forest, &t);
 	xer_fprint(stderr, &asn_DEF_Forest, &t);
 
-	asn_DEF_Forest.op->free_struct(&asn_DEF_Forest, &t, 1);
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_Forest, &t);
 }
 
 static char xer_buf[512];

--- a/asn1c/tests/check-src/check-35.c
+++ b/asn1c/tests/check-src/check-35.c
@@ -265,7 +265,7 @@ partial_read(uint8_t *data, size_t size) {
 			assert(rval.code == RC_OK);
 			assert(rval.consumed == size3);
 
-			asn_DEF_T.op->free_struct(&asn_DEF_T, &t, 1);
+			ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 		}
 	}
 }
@@ -315,12 +315,12 @@ main(int ac, char **av) {
 
 	check(&t, buf1, sizeof(buf1) + 10, sizeof(buf1));
 	compare(&t, buf1_reconstr, sizeof(buf1_reconstr));
-	asn_DEF_T.op->free_struct(&asn_DEF_T, &t, 1);
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 	check_xer(buf1, sizeof(buf1), "<T><c><false/></c><b><b2>z</b2></b><a>=&lt;&amp;&gt;</a><d><r-oid>85.79</r-oid></d></T>");
 
 	check(&t, buf2, sizeof(buf2) + 10, sizeof(buf2));
 	compare(&t, buf2_reconstr, sizeof(buf2_reconstr));
-	asn_DEF_T.op->free_struct(&asn_DEF_T, &t, 1);
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 	check_xer(buf2, sizeof(buf2), "<T><c><true/></c><b><b1>z</b1></b><a>=&lt;&amp;&gt;</a><d><oid>2.1</oid></d></T>");
 
 	/* Split the buffer in parts and check decoder restartability */

--- a/asn1c/tests/check-src/check-41.-fwide-types.c
+++ b/asn1c/tests/check-src/check-41.-fwide-types.c
@@ -281,7 +281,7 @@ partial_read(uint8_t *data, size_t size) {
 			assert(rval.code == RC_OK);
 			assert(rval.consumed == size3);
 
-			asn_DEF_T.op->free_struct(&asn_DEF_T, &t, 1);
+			ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 		}
 	}
 }
@@ -293,27 +293,27 @@ main() {
 	/* Check exact buf0 */
 	check(&t, buf0, sizeof(buf0), sizeof(buf0));
 	compare(&t, buf0_reconstr, sizeof(buf0_reconstr));
-	asn_DEF_T.op->free_struct(&asn_DEF_T, &t, 1);
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 
 	/* Check exact buf1 */
 	check(&t, buf1, sizeof(buf1), sizeof(buf1));
 	compare(&t, buf1_reconstr, sizeof(buf1_reconstr));
-	asn_DEF_T.op->free_struct(&asn_DEF_T, &t, 1);
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 
 	/* Check slightly more than buf1 */
 	check(&t, buf1, sizeof(buf1) + 10, sizeof(buf1));
 	compare(&t, buf1_reconstr, sizeof(buf1_reconstr));
-	asn_DEF_T.op->free_struct(&asn_DEF_T, &t, 1);
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 
 	/* Check exact buf2 */
 	check(&t, buf2, sizeof(buf2), sizeof(buf2));
 	compare(&t, buf2_reconstr, sizeof(buf2_reconstr));
-	asn_DEF_T.op->free_struct(&asn_DEF_T, &t, 1);
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 
 	/* Check slightly more than buf2 */
 	check(&t, buf2, sizeof(buf2) + 10, sizeof(buf2));
 	compare(&t, buf2_reconstr, sizeof(buf2_reconstr));
-	asn_DEF_T.op->free_struct(&asn_DEF_T, &t, 1);
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 
 	/* Split the buffer in parts and check decoder restartability */
 	partial_read(buf0, sizeof(buf0));

--- a/asn1c/tests/check-src/check-41.c
+++ b/asn1c/tests/check-src/check-41.c
@@ -188,7 +188,7 @@ partial_read(uint8_t *buf_0, size_t size) {
 			assert(rval.code == RC_OK);
 			assert(rval.consumed == size3);
 
-			asn_DEF_T.op->free_struct(&asn_DEF_T, &t, 1);
+			ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 		}
 	}
 }
@@ -204,13 +204,13 @@ main(int ac, char **av) {
 	check(&t, buf1, sizeof(buf1), sizeof(buf1));
 	compare(&t, buf1_reconstr, sizeof(buf1_reconstr));
 	asn_fprint(stderr, &asn_DEF_T, &t);
-	asn_DEF_T.op->free_struct(&asn_DEF_T, &t, 1);
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 
 	/* Check slightly more than buf1 */
 	check(&t, buf1, sizeof(buf1) + 10, sizeof(buf1));
 	compare(&t, buf1_reconstr, sizeof(buf1_reconstr));
 	asn_fprint(stderr, &asn_DEF_T, &t);
-	asn_DEF_T.op->free_struct(&asn_DEF_T, &t, 1);
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_T, &t);
 
 	/* Split the buffer in parts and check decoder restartability */
 	partial_read(buf1, sizeof(buf1));

--- a/asn1c/tests/check-src/check-42.c
+++ b/asn1c/tests/check-src/check-42.c
@@ -66,7 +66,7 @@ check(LogLine_t *tp, uint8_t *ptr, size_t size, size_t consumed) {
 	assert(rval.code == RC_OK);
 	assert(rval.consumed == consumed);
 	asn_fprint(stderr, &asn_DEF_LogLine, tp);
-	asn_DEF_LogLine.op->free_struct(&asn_DEF_LogLine, tp, 1);
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_LogLine, tp);
 }
 
 uint8_t *buf;

--- a/asn1c/tests/check-src/check-62.c
+++ b/asn1c/tests/check-src/check-62.c
@@ -78,7 +78,7 @@ load_object(enum expectation expectation, unsigned char *fbuf, size_t size) {
 		int fbuf_left = size;
 		int fbuf_chunk = csize;
 
-		if(st) asn_DEF_T.op->free_struct(&asn_DEF_T, st, 0);
+		if(st) ASN_STRUCT_FREE(asn_DEF_T, st);
 		st = 0;
 
 		do {
@@ -102,7 +102,7 @@ load_object(enum expectation expectation, unsigned char *fbuf, size_t size) {
 		} else {
 			assert(rval.code != RC_OK);
 			fprintf(stderr, "Failed, but this was expected\n");
-			asn_DEF_T.op->free_struct(&asn_DEF_T, st, 0);
+			ASN_STRUCT_FREE(asn_DEF_T, st);
 			st = 0;	/* ignore leak for now */
 		}
 	}
@@ -142,7 +142,7 @@ process_data(enum expectation expectation, unsigned char *fbuf, ssize_t size) {
 		break;
 	}
 
-	asn_DEF_T.op->free_struct(&asn_DEF_T, st, 0);
+	ASN_STRUCT_FREE(asn_DEF_T, st);
 }
 
 /*

--- a/asn1c/tests/check-src/check-70.-fwide-types.c
+++ b/asn1c/tests/check-src/check-70.-fwide-types.c
@@ -121,7 +121,7 @@ load_object_from(enum expectation expectation, unsigned char *fbuf, size_t size,
 		fprintf(stderr, "LOADING OBJECT OF SIZE %zd, chunks %zd\n",
 			size, csize);
 
-		if(st) asn_DEF_PDU.op->free_struct(&asn_DEF_PDU, st, 0);
+		if(st) ASN_STRUCT_FREE(asn_DEF_PDU, st);
 		st = 0;
 
 		do {
@@ -165,7 +165,7 @@ load_object_from(enum expectation expectation, unsigned char *fbuf, size_t size,
 		} else {
 			assert(rval.code != RC_OK);
 			fprintf(stderr, "Failed, but this was expected\n");
-			asn_DEF_PDU.op->free_struct(&asn_DEF_PDU, st, 0);
+			ASN_STRUCT_FREE(asn_DEF_PDU, st);
 			st = 0;	/* ignore leak for now */
 		}
 	}
@@ -252,7 +252,7 @@ process_XER_data(enum expectation expectation, unsigned char *fbuf, size_t size)
 		break;
 	}
 
-	asn_DEF_PDU.op->free_struct(&asn_DEF_PDU, st, 0);
+	ASN_STRUCT_FREE(asn_DEF_PDU, st);
 }
 
 /*

--- a/asn1c/tests/check-src/check-70.c
+++ b/asn1c/tests/check-src/check-70.c
@@ -110,7 +110,7 @@ load_object_from(enum expectation expectation, unsigned char *fbuf, size_t size,
 		fprintf(stderr, "LOADING OBJECT OF SIZE %zd, chunks %zd\n",
 			size, csize);
 
-		if(st) asn_DEF_PDU.op->free_struct(&asn_DEF_PDU, st, 0);
+		if(st) ASN_STRUCT_FREE(asn_DEF_PDU, st);
 		st = 0;
 
 		do {
@@ -154,7 +154,7 @@ load_object_from(enum expectation expectation, unsigned char *fbuf, size_t size,
 		} else {
 			assert(rval.code != RC_OK);
 			fprintf(stderr, "Failed, but this was expected\n");
-			asn_DEF_PDU.op->free_struct(&asn_DEF_PDU, st, 0);
+			ASN_STRUCT_FREE(asn_DEF_PDU, st);
 			st = 0;	/* ignore leak for now */
 		}
 	}
@@ -228,7 +228,7 @@ process_XER_data(enum expectation expectation, unsigned char *fbuf, size_t size)
 		break;
 	}
 
-	asn_DEF_PDU.op->free_struct(&asn_DEF_PDU, st, 0);
+	ASN_STRUCT_FREE(asn_DEF_PDU, st);
 }
 
 /*

--- a/skeletons/tests/check-INTEGER.c
+++ b/skeletons/tests/check-INTEGER.c
@@ -166,7 +166,7 @@ check_xer(int tofail, char *xmldata, long long orig_value) {
 
 	assert(value == orig_value);
 
-	asn_DEF_INTEGER.op->free_struct(&asn_DEF_INTEGER, st, 0);
+	ASN_STRUCT_FREE(asn_DEF_INTEGER, st);
 }
 
 int

--- a/skeletons/tests/check-PER-OCTET_STRING.c
+++ b/skeletons/tests/check-PER-OCTET_STRING.c
@@ -64,14 +64,14 @@ check_per_encode_constrained(
 	//assert(8 * enc_len == enc_rval.encoded);
 	assert(0 == memcmp(buf, enc_val, buf_offset));
 
-	asn_DEF_OCTET_STRING.free_struct(&asn_DEF_OCTET_STRING, &st, 1);
+	ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_OCTET_STRING, &st);
 
 	dec_rval = aper_decode(0, &asn_DEF_OCTET_STRING, (void**) &reconstructed_st, enc_val, enc_len, 0, 0);
 	assert(0 == dec_rval.code);
 	//assert(enc_len * 8 == dec_rval.consumed);
 	assert(0 == memcmp(dec_val, reconstructed_st->buf, reconstructed_st->size));
 
-	asn_DEF_OCTET_STRING.free_struct(&asn_DEF_OCTET_STRING, reconstructed_st, 0);
+	ASN_STRUCT_FREE(asn_DEF_OCTET_STRING, reconstructed_st);
 
 }
 

--- a/skeletons/tests/check-length.c
+++ b/skeletons/tests/check-length.c
@@ -74,8 +74,8 @@ check(size_t size) {
 	}
 
 
-	asn_DEF_OCTET_STRING.op->free_struct(&asn_DEF_OCTET_STRING, os, 0);
-	asn_DEF_OCTET_STRING.op->free_struct(&asn_DEF_OCTET_STRING, nos, 0);
+	ASN_STRUCT_FREE(asn_DEF_OCTET_STRING, os);
+	ASN_STRUCT_FREE(asn_DEF_OCTET_STRING, nos);
 }
 
 int

--- a/tests/136-OCTET-STRING-OK.asn1.-Pgen-PER
+++ b/tests/136-OCTET-STRING-OK.asn1.-Pgen-PER
@@ -127,18 +127,8 @@ static asn_SEQUENCE_specifics_t asn_SPC_PDU_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_PDU = {
 	"PDU",
 	"PDU",
-	SEQUENCE_free,
-	SEQUENCE_print,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	SEQUENCE_decode_uper,
-	SEQUENCE_encode_uper,
-	SEQUENCE_decode_aper,
-	SEQUENCE_encode_aper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_PDU_tags_1,
 	sizeof(asn_DEF_PDU_tags_1)
 		/sizeof(asn_DEF_PDU_tags_1[0]), /* 1 */
@@ -256,18 +246,8 @@ static /* Use -fall-defs-global to expose */
 asn_TYPE_descriptor_t asn_DEF_encoding_5 = {
 	"encoding",
 	"encoding",
-	CHOICE_free,
-	CHOICE_print,
+	&asn_OP_CHOICE,
 	CHOICE_constraint,
-	CHOICE_decode_ber,
-	CHOICE_encode_der,
-	CHOICE_decode_xer,
-	CHOICE_encode_xer,
-	CHOICE_decode_uper,
-	CHOICE_encode_uper,
-	CHOICE_decode_aper,
-	CHOICE_encode_aper,
-	CHOICE_outmost_tag,
 	0,	/* No effective tags (pointer) */
 	0,	/* No effective tags (count) */
 	0,	/* No tags (pointer) */
@@ -342,18 +322,8 @@ static asn_SEQUENCE_specifics_t asn_SPC_EXTERNAL_specs_1 = {
 asn_TYPE_descriptor_t asn_DEF_EXTERNAL = {
 	"EXTERNAL",
 	"EXTERNAL",
-	SEQUENCE_free,
-	SEQUENCE_print,
+	&asn_OP_SEQUENCE,
 	SEQUENCE_constraint,
-	SEQUENCE_decode_ber,
-	SEQUENCE_encode_der,
-	SEQUENCE_decode_xer,
-	SEQUENCE_encode_xer,
-	SEQUENCE_decode_uper,
-	SEQUENCE_encode_uper,
-	SEQUENCE_decode_aper,
-	SEQUENCE_encode_aper,
-	0,	/* Use generic outmost tag fetcher */
 	asn_DEF_EXTERNAL_tags_1,
 	sizeof(asn_DEF_EXTERNAL_tags_1)
 		/sizeof(asn_DEF_EXTERNAL_tags_1[0]) - 1, /* 1 */


### PR DESCRIPTION
Replace op->free_struct with ASN_STRUCT_FREE or ASN_STRUCT_FREE_CONTENT_ONLY macro.

This PR is for branch 115.