### PR TITLE
Zero out memory when free content only

### DIFF
--- a/skeletons/OCTET_STRING.c
+++ b/skeletons/OCTET_STRING.c
@@ -2104,6 +2104,8 @@ OCTET_STRING_free(asn_TYPE_descriptor_t *td, void *sptr, int contents_only) {
 
 	if(!contents_only) {
 		FREEMEM(st);
+	} else if(td->specifics) {
+		memset(st, 0, ((asn_OCTET_STRING_specifics_t *)(td->specifics))->struct_size);
 	}
 }
 

--- a/skeletons/constr_CHOICE.c
+++ b/skeletons/constr_CHOICE.c
@@ -1225,6 +1225,8 @@ CHOICE_free(asn_TYPE_descriptor_t *td, void *ptr, int contents_only) {
 
 	if(!contents_only) {
 		FREEMEM(ptr);
+	} else if(td->specifics) {
+		memset(ptr, 0, ((asn_CHOICE_specifics_t *)(td->specifics))->struct_size);
 	}
 }
 

--- a/skeletons/constr_SEQUENCE.c
+++ b/skeletons/constr_SEQUENCE.c
@@ -972,6 +972,8 @@ SEQUENCE_free(asn_TYPE_descriptor_t *td, void *sptr, int contents_only) {
 
 	if(!contents_only) {
 		FREEMEM(sptr);
+	} else if(td->specifics) {
+		memset(sptr, 0, ((asn_SEQUENCE_specifics_t *)(td->specifics))->struct_size);
 	}
 }
 

--- a/skeletons/constr_SET.c
+++ b/skeletons/constr_SET.c
@@ -1121,6 +1121,8 @@ SET_free(asn_TYPE_descriptor_t *td, void *ptr, int contents_only) {
 
 	if(!contents_only) {
 		FREEMEM(ptr);
+	} else if(td->specifics) {
+		memset(ptr, 0, ((asn_SET_specifics_t *)(td->specifics))->struct_size);
 	}
 }
 

--- a/skeletons/constr_SET_OF.c
+++ b/skeletons/constr_SET_OF.c
@@ -818,6 +818,8 @@ SET_OF_free(asn_TYPE_descriptor_t *td, void *ptr, int contents_only) {
 
 		if(!contents_only) {
 			FREEMEM(ptr);
+		} else if(td->specifics) {
+			memset(ptr, 0, ((asn_SET_OF_specifics_t *)(td->specifics))->struct_size);
 		}
 	}
 }


### PR DESCRIPTION
When calling SET_free(), SET_OF_free(), SEQUENCE_free(), CHOICE_free() and OCTET_STRING_free() with contents_only = 1, we zero out the memory pointed by ptr for struct_size bytes.

This is trying to solve [Issue #141](https://github.com/vlm/asn1c/issues/141).