### PR TITLE
Fix some memory leakage in asn1c found by Valgrind

### DIFF
--- a/libasn1fix/asn1fix_retrieve.c
+++ b/libasn1fix/asn1fix_retrieve.c
@@ -319,30 +319,33 @@ asn1f_lookup_symbol_impl(arg_t *arg, asn1p_module_t *mod, asn1p_expr_t *rhs_pspe
 	 */
 	{
 		/* Search inside standard module */
-		static asn1p_oid_t *uioc_oid;
-		if(!uioc_oid) {
-			asn1p_oid_arc_t arcs[] = {
-				{ 1, "iso" },
-				{ 3, "org" },
-				{ 6, "dod" },
-				{ 1, "internet" },
-				{ 4, "private" },
-				{ 1, "enterprise" },
-				{ 9363, "spelio" },
-				{ 1, "software" },
-				{ 5, "asn1c" },
-				{ 3, "standard-modules" },
-				{ 0, "auto-imported" },
-				{ 1, 0 }
-			};
+		asn1p_oid_t *uioc_oid;
+		asn1p_oid_arc_t arcs[] = {
+			{ 1, "iso" },
+			{ 3, "org" },
+			{ 6, "dod" },
+			{ 1, "internet" },
+			{ 4, "private" },
+			{ 1, "enterprise" },
+			{ 9363, "spelio" },
+			{ 1, "software" },
+			{ 5, "asn1c" },
+			{ 3, "standard-modules" },
+			{ 0, "auto-imported" },
+			{ 1, 0 }
+		};
+
+		if(!imports_from) {
 			uioc_oid = asn1p_oid_construct(arcs,
 				sizeof(arcs)/sizeof(arcs[0]));
-		}
-		if(!imports_from && (!mod->module_oid
-		|| asn1p_oid_compare(mod->module_oid, uioc_oid))) {
-			imports_from = asn1f_lookup_module(arg,
-				"ASN1C-UsefulInformationObjectClasses",
-				uioc_oid);
+
+			if(!mod->module_oid
+				|| asn1p_oid_compare(mod->module_oid, uioc_oid))
+				imports_from = asn1f_lookup_module(arg,
+					"ASN1C-UsefulInformationObjectClasses",
+					uioc_oid);
+
+			asn1p_oid_free(uioc_oid);
 			if(imports_from) goto importing;
 		}
 	}

--- a/libasn1parser/asn1p_class.c
+++ b/libasn1parser/asn1p_class.c
@@ -42,8 +42,21 @@ asn1p_ioc_row_new(asn1p_expr_t *oclass) {
 
 void
 asn1p_ioc_row_delete(asn1p_ioc_row_t *row) {
+	int i;
 	if(row) {
 		if(row->column) {
+			for(i = 0; i < row->columns; i++) {
+				if(row->column[i].new_expr) {
+					/* 
+					 * Field 'reference' comes from asn1fix_cws.c :
+					 * TQ_FIRST(&cell->field->members)->reference
+					 * so it should not be freed here.
+					 */
+
+					row->column[i].value->reference = NULL;
+					asn1p_expr_free(row->column[i].value);
+				}
+			}
 			free(row->column);
 		}
 		free(row);

--- a/libasn1parser/asn1p_class.h
+++ b/libasn1parser/asn1p_class.h
@@ -12,6 +12,7 @@ typedef struct asn1p_ioc_row_s {
 	struct asn1p_ioc_cell_s {
 		struct asn1p_expr_s *field;	/* may never be NULL */
 		struct asn1p_expr_s *value;	/* may be left uninitialized */
+		int new_expr;
 	} *column;
 	int columns;
 	int max_identifier_length;

--- a/libasn1parser/asn1p_expr.c
+++ b/libasn1parser/asn1p_expr.c
@@ -267,6 +267,21 @@ asn1p_expr_free(asn1p_expr_t *expr) {
 			asn1p_value_free(expr->marker.default_value);
 		if(expr->with_syntax)
 			asn1p_wsyntx_free(expr->with_syntax);
+		if(expr->specializations.pspec) {
+			int pspec;
+			for(pspec = 0; pspec < expr->specializations.pspecs_count; pspec++) {
+				asn1p_expr_free(expr->specializations.pspec[pspec].rhs_pspecs);
+				asn1p_expr_free(expr->specializations.pspec[pspec].my_clone);
+			}
+			free(expr->specializations.pspec);
+		}
+		if(expr->object_class_matrix.row) {
+			int row;
+			for(row = 0; row < expr->object_class_matrix.rows; row++) {
+				asn1p_ioc_row_delete(expr->object_class_matrix.row[row]);
+			}
+			free(expr->object_class_matrix.row);
+		}
 
 		if(expr->data && expr->data_free)
 			expr->data_free(expr->data);


### PR DESCRIPTION
I know code generation by `asn1c` is a one time process.
So, compared with if any leak found in encoder/decoder, the memory leak found inside `asn1c` is not that important.
However, it is still be a good practice to reduce them as much as possible.

By the way, even applying this PR, there still be some leakages reported by Valgrind, especially those allocated in asn1p_y.c and asn1p_l.c, which I don't know how to resolve. Ref to : [Valgrind log](https://gist.github.com/brchiu/045c954a46243aefbc48b7eb67ddf0b5)