### PR TITLE
Fix issue 147 of vlm's repository

### DIFF
--- a/libasn1fix/asn1fix_cws.c
+++ b/libasn1fix/asn1fix_cws.c
@@ -6,6 +6,7 @@ static int _asn1f_parse_class_object_data(arg_t *, asn1p_expr_t *eclass,
 		uint8_t *buf, const uint8_t *bend,
 		int optional_mode, uint8_t **newpos);
 static int _asn1f_assign_cell_value(arg_t *arg, struct asn1p_ioc_row_s *row, struct asn1p_ioc_cell_s *cell, uint8_t *buf, const uint8_t *bend);
+static asn1p_wsyntx_chunk_t *asn1f_next_literal_chunk(asn1p_wsyntx_t *syntax, asn1p_wsyntx_chunk_t *chunk, uint8_t *buf);
 
 int
 asn1f_check_class_object(arg_t *arg) {
@@ -143,37 +144,24 @@ _asn1f_parse_class_object_data(arg_t *arg, asn1p_expr_t *eclass,
 		case WC_WHITESPACE: break;	/* Ignore whitespace */
 		case WC_FIELD: {
 			struct asn1p_ioc_cell_s *cell;
-			int lbraces = 0;
-			int lquotes = 0;
-			uint8_t *p;
+			asn1p_wsyntx_chunk_t *next_literal;
+			uint8_t *buf_old = buf;
+			uint8_t *p = 0;
 
 			SKIPSPACES;
 
-			p = buf;
-			if(p < bend && *p == '{')
-				lbraces = 1, p++;
-			if(p < bend && *p == '"')
-				lquotes = 1, p++;
-			for(; p < bend; p++) {
-				if(lbraces) {
-					/* Search the terminating brace */
-					switch(*p) {
-					case '}': lbraces--; break;
-					case '{': lbraces++; break;
-					}
-				} else if (lquotes) {
-					if (*p == '"')
-						lquotes--;
-				} else if(isspace(*p) || *p == ',') {
-					break;
+			next_literal = asn1f_next_literal_chunk(syntax, chunk, buf);
+			if(!next_literal) {
+				p += (bend - p);
+			} else {
+				p = (uint8_t *)strstr((char *)buf, (char *)next_literal->content.token);
+				if(!p) {
+					if (!optional_mode)
+						FATAL("Next literal \"%s\" not found !", next_literal->content.token);
+
+					if(newpos) *newpos = buf_old;
+					return -1;
 				}
-			}
-			if(lbraces || lquotes) {
-				FATAL("Field reference %s found in class value definition for %s at line %d can not be satisfied by broken value \"%s\"",
-				chunk->content.token,
-				arg->expr->Identifier, arg->expr->_lineno, buf);
-				if(newpos) *newpos = buf;
-				return -1;
 			}
 			cell = asn1p_ioc_row_cell_fetch(row,
 					chunk->content.token);
@@ -215,12 +203,14 @@ static int
 _asn1f_assign_cell_value(arg_t *arg, struct asn1p_ioc_row_s *row, struct asn1p_ioc_cell_s *cell,
 		uint8_t *buf, const uint8_t *bend) {
 	asn1p_expr_t *expr = (asn1p_expr_t *)NULL;
-	asn1p_ref_t *ref = (asn1p_ref_t *)NULL;
 	int idLength;
 	char *p;
-	int new_expr = 1;
-	uint8_t *p_dot;
-	asn1p_module_t *ext_module = (asn1p_module_t *)NULL;
+	int new_ref = 1;
+	asn1p_t *asn;
+	asn1p_module_t *mod;
+	asn1p_expr_t *type_expr = (asn1p_expr_t *)NULL;
+	int i, ret = 0, psize;
+	char *pp;
 
 	if((bend - buf) <= 0) {
 		FATAL("Assignment warning: empty string is being assigned into %s for %s at line %d",
@@ -229,74 +219,94 @@ _asn1f_assign_cell_value(arg_t *arg, struct asn1p_ioc_row_s *row, struct asn1p_i
 		return -1;
 	}
 
-	p_dot = memchr(buf, '.', bend - buf);
-	if (p_dot) {
-		/* parse Module.xxxx */
-		*p_dot = '\0';
-		p = malloc(bend - p_dot);
-		assert(p);
-		memcpy(p, p_dot + 1, bend - p_dot - 1);
-		p[bend - p_dot - 1] = '\0';
+	p = malloc(bend - buf + 1);
+	assert(p);
+	memcpy(p, buf, bend - buf);
+	p[bend - buf] = '\0';
+	/* remove trailing space */
+	for (i = bend - buf - 1; (i > 0) && isspace(p[i]); i--)
+		p[i] = '\0';
 
-		ext_module = asn1f_lookup_module(arg, (const char *)buf, 0);
-	} else {
-		p = malloc(bend - buf + 1);
-		assert(p);
-		memcpy(p, buf, bend - buf);
-		p[bend - buf] = '\0';
+	/* This value 100 should be larger than following formatting string */
+	psize = bend - buf + 100;
+	pp = malloc(psize);
+	if(pp == NULL) {
+		free(p);
+		return -1;
 	}
 
-	if(!isalpha(*p)) {
-		if(isdigit(*p)) {
-			asn1c_integer_t value;
-			if(asn1p_atoi(p, &value)) {
-				FATAL("Value %s at line %d is too large for this compiler! Contact the asn1c author.\n", p, arg->expr->_lineno);
-				free(p);
-				return -1;
-			}
-			expr = asn1p_expr_new(arg->expr->_lineno, arg->expr->module);
-			expr->Identifier = p;
-			expr->meta_type = AMT_VALUE; 
-			expr->expr_type = ASN_BASIC_INTEGER;
-			expr->value = asn1p_value_fromint(value);
-		} else if (*p == '"') {
-			expr = asn1p_expr_new(arg->expr->_lineno, arg->expr->module);
-			expr->Identifier = p;
-			expr->meta_type = AMT_VALUE;
-			expr->expr_type = ASN_BASIC_CHARACTER_STRING;
-			expr->value = asn1p_value_frombuf(p + 1, strlen(p) - 2, 0);
-		} else {
-			WARNING("asn1c is not yet able to parse arbitrary direct values; try converting %s at line %d to a reference.", p, arg->expr->_lineno);
-			free(p);
-			return 1;
-		}
+	if(cell->field->expr_type == A1TC_CLASSFIELD_TFS) {
+		ret = snprintf(pp, psize,
+			"M DEFINITIONS ::=\nBEGIN\n"
+			"V ::= %s\n"
+			"END\n",
+			p
+		);
+	} else if(cell->field->expr_type == A1TC_CLASSFIELD_FTVFS) {
+		type_expr = TQ_FIRST(&(cell->field->members));
+		ret = snprintf(pp, psize,
+				"M DEFINITIONS ::=\nBEGIN\n"
+				"v %s ::= %s\n"
+				"END\n",
+				type_expr->reference ? 
+					type_expr->reference->components[0].name : 
+					_asn1p_expr_type2string(type_expr->expr_type),
+				p
+			);
 	} else {
-		ref = asn1p_ref_new(arg->expr->_lineno, arg->expr->module);
-		asn1p_ref_add_component(ref, p, RLT_UNKNOWN);
-		assert(ref);
+		free(p);
+		free(pp);
+		WARNING("asn1c only be able to parse TypeFieldSpec and FixedTypeValueFieldSpec. Failed when parsing %s at line %d\n", p, arg->expr->_lineno);
+		return -1;
+	}
+	DEBUG("ASN.1 :\n\n%s\n", pp);
 
-		new_expr = 0;
-		expr = asn1f_lookup_symbol(arg, ext_module ? ext_module : arg->mod, arg->expr->rhs_pspecs, ref);
-		if(!expr && TQ_FIRST(&cell->field->members)) {
-			new_expr = 1;
-			expr = asn1p_expr_new(arg->expr->_lineno, arg->expr->module);
+	assert(ret < psize);
+	psize = ret;
+
+	asn = asn1p_parse_buffer(pp, psize, A1P_NOFLAGS);
+	free(pp);
+	if(asn == NULL) {
+		FATAL("Cannot parse Setting token %s "
+			"at line %d",
+			p,
+			arg->expr->_lineno
+		);
+		free(p);
+		return -1;
+	} else {
+		mod = TQ_FIRST(&(asn->modules));
+		assert(mod);
+		expr = TQ_REMOVE(&(mod->members), next);
+		assert(expr);
+
+		free(expr->Identifier);
+		expr->module = arg->expr->module;
+		expr->_lineno = arg->expr->_lineno;
+		if (expr->reference) {
+			expr->reference->module = arg->expr->module;
+			expr->reference->_lineno = arg->expr->_lineno;
+			expr->Identifier = strdup(expr->reference->components[expr->reference->comp_count - 1].name);
+			free(p);
+		} else {
 			expr->Identifier = p;
-			expr->meta_type = AMT_VALUE;
-			expr->expr_type = A1TC_REFERENCE;
-			expr->reference = TQ_FIRST(&cell->field->members)->reference;
-			expr->value = asn1p_value_fromref(ref, 0);
-			if (asn1f_value_resolve(arg, expr, 0)) {
-				expr->Identifier = NULL;
-				expr->reference = NULL;
-				asn1p_expr_free(expr);
-				expr = NULL;
-			}
 		}
-		if (!expr) {
+		asn1p_delete(asn);
+	}
+
+	if(expr->reference &&
+		!asn1f_lookup_symbol(arg, arg->mod, expr->rhs_pspecs, expr->reference)) {
+
+		asn1p_ref_free(expr->reference);
+		new_ref = 0;
+		expr->reference = type_expr->reference;
+		if (asn1f_value_resolve(arg, expr, 0)) {
+			expr->reference = 0;
+			asn1p_expr_free(expr);
+			free(p);
 			FATAL("Cannot find %s referenced by %s at line %d",
 				p, arg->expr->Identifier,
 				arg->expr->_lineno);
-			free(p);
 			return -1;
 		}
 	}
@@ -305,11 +315,7 @@ _asn1f_assign_cell_value(arg_t *arg, struct asn1p_ioc_row_s *row, struct asn1p_i
 		cell->field->Identifier, p, expr->Identifier);
 
 	cell->value = expr;
-	cell->new_expr = new_expr;
-	if(!new_expr) {
-		asn1p_ref_free(ref);
-		free(p);
-	}
+	cell->new_ref = new_ref;
 
 	idLength = strlen(expr->Identifier);
 	if(row->max_identifier_length < idLength)
@@ -318,3 +324,31 @@ _asn1f_assign_cell_value(arg_t *arg, struct asn1p_ioc_row_s *row, struct asn1p_i
 	return 0;
 }
 
+static asn1p_wsyntx_chunk_t *
+asn1f_next_literal_chunk(asn1p_wsyntx_t *syntax, asn1p_wsyntx_chunk_t *chunk, uint8_t *buf)
+{
+	asn1p_wsyntx_chunk_t *next_chunk;
+
+	next_chunk = TQ_NEXT(chunk, next);
+	do {
+		if(next_chunk == (struct asn1p_wsyntx_chunk_s *)0) {
+			if(!syntax->parent)
+				break;
+			next_chunk = TQ_NEXT(syntax->parent, next);
+		} else if(next_chunk->type == WC_LITERAL) {
+			if(strstr((char *)buf, (char *)next_chunk->content.token))
+				break;
+			if(!syntax->parent)
+				break;
+			next_chunk = TQ_NEXT(syntax->parent, next);
+		} else if(next_chunk->type == WC_WHITESPACE) {
+			next_chunk = TQ_NEXT(next_chunk, next);
+		} else if(next_chunk->type == WC_OPTIONALGROUP) {
+			syntax = next_chunk->content.syntax;
+			next_chunk = TQ_FIRST(((&next_chunk->content.syntax->chunks)));
+		} else 
+			break;
+	} while (next_chunk);
+
+	return next_chunk;
+}

--- a/libasn1parser/asn1p_class.c
+++ b/libasn1parser/asn1p_class.c
@@ -46,16 +46,15 @@ asn1p_ioc_row_delete(asn1p_ioc_row_t *row) {
 	if(row) {
 		if(row->column) {
 			for(i = 0; i < row->columns; i++) {
-				if(row->column[i].new_expr) {
+				if(!row->column[i].new_ref && row->column[i].value) {
 					/* 
 					 * Field 'reference' comes from asn1fix_cws.c :
 					 * TQ_FIRST(&cell->field->members)->reference
 					 * so it should not be freed here.
 					 */
-
 					row->column[i].value->reference = NULL;
-					asn1p_expr_free(row->column[i].value);
 				}
+				asn1p_expr_free(row->column[i].value);
 			}
 			free(row->column);
 		}
@@ -195,6 +194,7 @@ asn1p_wsyntx_chunk_fromsyntax(asn1p_wsyntx_t *syntax) {
 	if(wc) {
 		wc->type = WC_OPTIONALGROUP;
 		wc->content.syntax = syntax;
+		syntax->parent = wc;
 	}
 
 	return wc;

--- a/libasn1parser/asn1p_class.h
+++ b/libasn1parser/asn1p_class.h
@@ -12,7 +12,7 @@ typedef struct asn1p_ioc_row_s {
 	struct asn1p_ioc_cell_s {
 		struct asn1p_expr_s *field;	/* may never be NULL */
 		struct asn1p_expr_s *value;	/* may be left uninitialized */
-		int new_expr;
+		int new_ref;
 	} *column;
 	int columns;
 	int max_identifier_length;
@@ -48,6 +48,8 @@ typedef struct asn1p_wsyntx_chunk_s {
 } asn1p_wsyntx_chunk_t;
 
 typedef struct asn1p_wsyntx_s {
+
+	struct asn1p_wsyntx_chunk_s *parent;
 
 	TQ_HEAD(struct asn1p_wsyntx_chunk_s) chunks;
 


### PR DESCRIPTION
Re-write function _asn1f_parse_class_object_data() to use next
next literal token as delimiter.

Take the following example :

```
{
  ID id-S1-Message
  CRITICALITY reject
  TYPE OCTET STRING
  PRESENCE mandatory
}
```

When we use literal token 'TYPE' and 'PRESENCE' to 'cut' the content corresponding
to WC_FIELD (which is called 'Setting' in 11.7 of X.681), then space characters
and even comment will be included in the content. So even 'SET OF xxxx' follows
WC_LITERAL 'TYPE' will not be a problem.

Next we re-write _asn1f_assign_cell_value(), instead of using hand-writing code
to parse the content of 'Setting' done by current code, we use construct a mini-
ASN.1 module in memory buffer and let asn1p_parse_buffer() did the parsing task.

For `A1TC_CLASSFIELD_TFS` case : 
```
M DEFINITIONS ::=
BEGIN
V ::= DL-Power
END
```

For `A1TC_CLASSFIELD_FTVFS` case : 
```
M DEFINITIONS ::=
BEGIN
v ProtocolIE-ID ::= id-CCTrCH-Maximum-DL-Power-RL-AdditionRqstTDD
END
```

This approach mimics function asn1f_BS_unparsed_convert() of asn1fix_bitstring.c
and it is really a clever way. 

Since asn1p_parse() is capable of parse the syntax what asn1c can do, so this
method can hanle various 'Setting' syntax as long as we carefully construct this
mini ASN.1 module.

According to 11.7 of X.681, Setting's BNF is :

```
  Setting ::= Type | Value | ValueSet | Object | ObjectSet
```

Currently only Type (A1TC_CLASSFIELD_TFS) and Value (A1TC_CLASSFIELD_FTVFS) are
implemented.

In addition to test cases performed in 'make check', S1AP, NBAP and DSRC are
used for generating C files. Generated files are the same before applying this fix.

By the way, original code can not handle '{ procedureCode id-cellSetup, ddMode fdd }'
of the following ASN.1 syntax in function _asn1f_assign_cell_value(),

```
cellSetupFDD NBAP-ELEMENTARY-PROCEDURE ::= {
  INITIATING MESSAGE    CellSetupRequestFDD
  SUCCESSFUL OUTCOME    CellSetupResponse
  UNSUCCESSFUL OUTCOME  CellSetupFailure
  MESSAGE DISCRIMINATOR common
  PROCEDURE ID          { procedureCode id-cellSetup, ddMode fdd }
  CRITICALITY           reject
}
```

and warning message :

```
"asn1c is not yet able to parse arbitrary direct values; try converting xxx at
line xx to a reference."
```

is displayed.

Now with the power of asn1p_parse() the aforementioned syntax can be parsed.

Thus this commit solved [issue 147 of vlm's repository.](https://github.com/vlm/asn1c/issues/147)

Q.E.D.