### PR TITLE
Fix most memory leakage found till now

### DIFF
--- a/asn1c/asn1c.c
+++ b/asn1c/asn1c.c
@@ -65,6 +65,7 @@ main(int ac, char **av) {
     int ret;                        /* Return value from misc functions */
     int ch;                         /* Command line character */
     int i;                          /* Index in some loops */
+    int exit_code = 0;              /* Exit code */
 
     /*
      * Process command-line options.
@@ -265,7 +266,8 @@ main(int ac, char **av) {
         new_asn = asn1p_parse_file(av[i], asn1_parser_flags);
         if(new_asn == NULL) {
             fprintf(stderr, "Cannot parse \"%s\"\n", av[i]);
-            exit(EX_DATAERR);
+            exit_code = EX_DATAERR;
+            goto cleanup;
         }
 
         /*
@@ -289,7 +291,10 @@ main(int ac, char **av) {
      * Dump the parsed ASN.1 tree if -E specified and -F is NOT given.
      */
     if(print_arg__print_out && !print_arg__fix_n_print) {
-        if(asn1print(asn, asn1_printer_flags)) exit(EX_SOFTWARE);
+        if(asn1print(asn, asn1_printer_flags)) {
+            exit_code = EX_SOFTWARE;
+            goto cleanup;
+        }
         return 0;
     }
 
@@ -297,7 +302,10 @@ main(int ac, char **av) {
      * Read in the files from skeletons/standard-modules
      */
     if(importStandardModules(asn, skeletons_dir)) {
-        if(warnings_as_errors) exit(EX_DATAERR);
+        if(warnings_as_errors) {
+            exit_code = EX_DATAERR;
+            goto cleanup;
+        }
     }
 
     /*
@@ -313,14 +321,18 @@ main(int ac, char **av) {
         case 0:
         break; /* All clear */
     case -1:
-        exit(EX_DATAERR); /* Fatal failure */
+        exit_code = EX_DATAERR; /* Fatal failure */
+        goto cleanup;
     }
 
     /*
      * Dump the parsed ASN.1 tree if -E specified and -F is given.
      */
     if(print_arg__print_out && print_arg__fix_n_print) {
-        if(asn1print(asn, asn1_printer_flags)) exit(EX_SOFTWARE);
+        if(asn1print(asn, asn1_printer_flags)) {
+            exit_code = EX_SOFTWARE;
+            goto cleanup;
+        }
         return 0;
     }
 
@@ -330,10 +342,13 @@ main(int ac, char **av) {
      */
     if(asn1_compile(asn, skeletons_dir, asn1_compiler_flags, ac + optind,
                     optind, av - optind)) {
-        exit(EX_SOFTWARE);
+        exit_code = EX_SOFTWARE;
     }
 
+cleanup:
     asn1p_delete(asn);
+    asn1p_lex_destroy();
+    if (exit_code) exit(exit_code);
 
     return 0;
 }
@@ -418,6 +433,7 @@ importStandardModules(asn1p_t *asn, const char *skeletons_dir) {
             TQ_ADD(&(asn->modules), mod, mod_next);
         }
         asn1p_delete(new_asn);
+        asn1p_lex_destroy();
 
 #ifdef _WIN32
     } while(_findnext(dir, &c_file) == 0);

--- a/libasn1compiler/asn1c_constraint.c
+++ b/libasn1compiler/asn1c_constraint.c
@@ -267,6 +267,7 @@ asn1c_emit_constraint_tables(arg_t *arg, int got_size) {
 		 */
 		assert(range->el_count == 0);
 		/* The full range is specified. Ignore it. */
+		asn1constraint_range_free(range);
 		return 0;
 	}
 

--- a/libasn1fix/asn1fix_constr.c
+++ b/libasn1fix/asn1fix_constr.c
@@ -60,7 +60,7 @@ asn1f_pull_components_of(arg_t *arg) {
 		coft = asn1p_expr_clone(terminal, 1 /* Skip extensions */);
 		if(!coft) return -1;	/* ENOMEM */
 
-		if(0) {
+		if(1) {
 			asn1p_expr_free(memb);	/* Don't need it anymore*/
 		} else {
 			/* Actual removal clashes with constraints... skip. */

--- a/libasn1fix/asn1fix_cws.c
+++ b/libasn1fix/asn1fix_cws.c
@@ -296,6 +296,7 @@ _asn1f_assign_cell_value(arg_t *arg, struct asn1p_ioc_row_s *row, struct asn1p_i
 			FATAL("Cannot find %s referenced by %s at line %d",
 				p, arg->expr->Identifier,
 				arg->expr->_lineno);
+			asn1p_ref_free(ref);
 			free(p);
 			return -1;
 		}

--- a/libasn1fix/asn1fix_misc.c
+++ b/libasn1fix/asn1fix_misc.c
@@ -26,7 +26,7 @@ asn1f_printable_value(asn1p_value_t *v) {
         size_t tmp_len = (len);                     \
         if(tmp_len >= managedptr_len) {             \
             free(managedptr);                       \
-            managedptr = malloc(tmp_len + 1);       \
+            managedptr = calloc(1, tmp_len + 1);    \
             if(managedptr) {                        \
                 managedptr_len = tmp_len;           \
             } else {                                \

--- a/libasn1fix/asn1fix_param.c
+++ b/libasn1fix/asn1fix_param.c
@@ -72,8 +72,13 @@ asn1f_parameterization_fork(arg_t *arg, asn1p_expr_t *expr, asn1p_expr_t *rhs_ps
 
 	/* Passing arguments to members and type references */
 	exc->rhs_pspecs = expr->rhs_pspecs ? expr->rhs_pspecs : rhs_pspecs;
+	if(exc->rhs_pspecs)
+		exc->rhs_pspecs->ref_cnt++;
+
 	TQ_FOR(m, &exc->members, next) {
 		m->rhs_pspecs = exc->rhs_pspecs;
+		if (exc->rhs_pspecs)
+			exc->rhs_pspecs->ref_cnt++;
 	}
 
 	DEBUG("Forked new parameterization for %s", expr->Identifier);

--- a/libasn1parser/asn1p_expr.c
+++ b/libasn1parser/asn1p_expr.c
@@ -222,8 +222,8 @@ void
 asn1p_expr_add_many(asn1p_expr_t *to, asn1p_expr_t *from_what) {
 	asn1p_expr_t *expr;
 	TQ_FOR(expr, &(from_what->members), next) {
-        expr->parent_expr = to;
-    }
+		expr->parent_expr = to;
+	}
 	TQ_CONCAT(&(to->members), &(from_what->members), next);
 }
 
@@ -261,6 +261,8 @@ asn1p_expr_free(asn1p_expr_t *expr) {
 			asn1p_constraint_free(expr->combined_constraints);
 		if(expr->lhs_params)
 			asn1p_paramlist_free(expr->lhs_params);
+		if(expr->rhs_pspecs)
+			asn1p_expr_free(expr->rhs_pspecs);
 		if(expr->value)
 			asn1p_value_free(expr->value);
 		if(expr->marker.default_value)

--- a/libasn1parser/asn1p_l.l
+++ b/libasn1parser/asn1p_l.l
@@ -209,7 +209,7 @@ WSP	[\t\r\v\f\n ]
 
 '[0-9A-F \t\r\v\f\n]+'H {
 		/* " \t\r\n" weren't allowed in ASN.1:1990. */
-		asn1p_lval.tv_str = yytext;
+		asn1p_lval.tv_str = strdup(yytext);
 		return TOK_hstring;
 	}
 

--- a/libasn1parser/asn1p_module.c
+++ b/libasn1parser/asn1p_module.c
@@ -26,11 +26,18 @@ void
 asn1p_module_free(asn1p_module_t *mod) {
 	if(mod) {
 		asn1p_expr_t *expr;
+		asn1p_xports_t *xports;
 
 		free(mod->ModuleName);
 		free(mod->source_file_name);
 
 		asn1p_oid_free(mod->module_oid);
+
+		while((xports = TQ_REMOVE(&(mod->exports), xp_next)))
+			asn1p_xports_free(xports);
+
+		while((xports = TQ_REMOVE(&(mod->imports), xp_next)))
+			asn1p_xports_free(xports);
 
 		while((expr = TQ_REMOVE(&(mod->members), next)))
 			asn1p_expr_free(expr);

--- a/libasn1parser/asn1p_xports.c
+++ b/libasn1parser/asn1p_xports.c
@@ -25,8 +25,14 @@ asn1p_xports_new() {
 void
 asn1p_xports_free(asn1p_xports_t *xp) {
 	if(xp) {
+		asn1p_expr_t *expr;
+
 		free(xp->fromModuleName);
 		asn1p_oid_free(xp->identifier.oid);
+
+		while((expr = TQ_REMOVE(&(xp->members), next)))
+			asn1p_expr_free(expr);
+
 		free(xp);
 	}
 }

--- a/libasn1parser/asn1parser.c
+++ b/libasn1parser/asn1parser.c
@@ -53,8 +53,10 @@ asn1p_parse_buffer(const char *buffer, int size /* = -1 */, enum asn1p_flags fla
 
 	if(ret == 0) {
 		assert(a);
-		if(_asn1p_fix_modules(a, "-"))
+		if(_asn1p_fix_modules(a, "-")) {
+			asn1p_delete(a);
 			return NULL;	/* FIXME: destroy (a) */
+		}
 	} else if(a) {
 		asn1p_delete(a);
 		a = NULL;
@@ -110,8 +112,10 @@ asn1p_parse_file(const char *filename, enum asn1p_flags flags) {
 
 	if(ret == 0) {
 		assert(a);
-		if(_asn1p_fix_modules(a, filename))
+		if(_asn1p_fix_modules(a, filename)) {
+			asn1p_delete(a);
 			return NULL;	/* FIXME: destroy (a) */
+		}
 	} else if(a) {
 		asn1p_delete(a);
 		a = NULL;

--- a/libasn1parser/asn1parser.h
+++ b/libasn1parser/asn1parser.h
@@ -70,5 +70,6 @@ asn1p_t	*asn1p_parse_buffer(const char *buffer, int size /* = -1 */,
 	enum asn1p_flags);
 
 int asn1p_atoi(const char *ptr, asn1c_integer_t *r_value);
+int asn1p_lex_destroy();
 
 #endif	/* ASN1PARSER_H */


### PR DESCRIPTION
Now memory allocated in asn1p_l.c and asn1p_y.c are freed.

Remaining two leaked memory blocks are allocated inside function asn1f_printable_value() and asn1c_make_identifier() hold by static variables. Please refer to [Valgrind log](https://gist.github.com/brchiu/d0ef9f32e373095a9703712aa2b4e9c9)

Below is an excerpt of leaked memory blocks information : 
```
==26140== 25 bytes in 1 blocks are still reachable in loss record 1 of 2
==26140==    at 0x4C2DB2F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==26140==    by 0x12A877: asn1f_printable_value (asn1fix_misc.c:148)
==26140==    by 0x12A252: asn1f_printable_reference (asn1fix_misc.c:12)
==26140==    by 0x12D969: asn1f_lookup_symbol_impl (asn1fix_retrieve.c:292)
==26140==    by 0x12DC9E: asn1f_lookup_symbol (asn1fix_retrieve.c:372)
==26140==    by 0x134ABE: asn1f_class_access (asn1fix_class.c:23)
==26140==    by 0x12D439: asn1f_lookup_symbol_impl (asn1fix_retrieve.c:196)
==26140==    by 0x12DC9E: asn1f_lookup_symbol (asn1fix_retrieve.c:372)
==26140==    by 0x12DF64: asn1f_find_terminal_thing (asn1fix_retrieve.c:433)
==26140==    by 0x12DCC8: asn1f_find_terminal_type (asn1fix_retrieve.c:377)
==26140==    by 0x12F4F1: asn1constraint_pullup (asn1fix_constraint.c:72)
==26140==    by 0x1299B9: asn1f_check_constraints (asn1fix.c:447)
==26140== 
==26140== 66 bytes in 1 blocks are still reachable in loss record 2 of 2
==26140==    at 0x4C2DB2F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==26140==    by 0x14DB08: asn1c_make_identifier (asn1c_misc.c:103)
==26140==    by 0x13C561: asn1c_lang_C_type_common_INTEGER (asn1c_C.c:141)
==26140==    by 0x1393E9: asn1c_compile_expr (asn1compiler.c:107)
==26140==    by 0x139032: asn1_compile (asn1compiler.c:45)
==26140==    by 0x115065: main (asn1c.c:331)
==26140== 
==26140== LEAK SUMMARY:
==26140==    definitely lost: 0 bytes in 0 blocks
==26140==    indirectly lost: 0 bytes in 0 blocks
==26140==      possibly lost: 0 bytes in 0 blocks
==26140==    still reachable: 91 bytes in 2 blocks
==26140==         suppressed: 0 bytes in 0 blocks
==26140== 
==26140== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
==26140== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```