### PR TITLE
Fix issue 24

### DIFF
--- a/libasn1fix/asn1fix_export.c
+++ b/libasn1fix/asn1fix_export.c
@@ -57,6 +57,21 @@ asn1f_find_terminal_type_ex(asn1p_t *asn, asn1p_expr_t *expr) {
 	return asn1f_find_terminal_type(&arg, expr);
 }
 
+asn1p_expr_t *
+asn1f_find_ancestor_type_with_PER_constraint_ex(asn1p_t *asn, asn1p_expr_t *expr) {
+	arg_t arg;
+
+	memset(&arg, 0, sizeof(arg));
+
+	arg.asn = asn;
+	arg.mod = expr->module;
+	arg.expr = expr;
+	arg.eh = a1f_replace_me_with_proper_interface_arg.eh;
+	arg.debug = a1f_replace_me_with_proper_interface_arg.debug;
+
+	return asn1f_find_ancestor_type_with_PER_constraint(&arg, expr);
+}
+
 int
 asn1f_fix_dereference_values_ex(asn1p_t *asn, asn1p_module_t *mod,
         asn1p_expr_t *expr) {

--- a/libasn1fix/asn1fix_export.h
+++ b/libasn1fix/asn1fix_export.h
@@ -38,4 +38,10 @@ asn1p_expr_t *asn1f_find_terminal_type_ex(asn1p_t *asn, asn1p_expr_t *tc);
 int asn1f_fix_dereference_values_ex(asn1p_t *asn, asn1p_module_t *mod,
 	asn1p_expr_t *expr);
 
+/*
+ * Exportable version of asn1f_find_ancestor_type_with_PER_constraint().
+ */
+asn1p_expr_t *asn1f_find_ancestor_type_with_PER_constraint_ex(asn1p_t *asn,
+	asn1p_expr_t *expr);
+
 #endif	/* ASN1FIX_EXPORT_H */

--- a/libasn1fix/asn1fix_retrieve.c
+++ b/libasn1fix/asn1fix_retrieve.c
@@ -3,6 +3,7 @@
 enum ftt_what {
 	FTT_TYPE,	/* Find the type of the given expression */
 	FTT_VALUE,	/* Find the value of the given expression */
+	FTT_CONSTR_TYPE /* Find the type of the given expression having constraint */ 
 };
 
 static asn1p_expr_t *asn1f_find_terminal_thing(arg_t *arg, asn1p_expr_t *expr, enum ftt_what);
@@ -382,6 +383,11 @@ asn1f_find_terminal_value(arg_t *arg, asn1p_expr_t *expr) {
 	return asn1f_find_terminal_thing(arg, expr, FTT_VALUE);
 }
 
+asn1p_expr_t *
+asn1f_find_ancestor_type_with_PER_constraint(arg_t *arg, asn1p_expr_t *expr) {
+	return asn1f_find_terminal_thing(arg, expr, FTT_CONSTR_TYPE);
+}
+
 static asn1p_expr_t *
 asn1f_find_terminal_thing(arg_t *arg, asn1p_expr_t *expr, enum ftt_what what) {
 	asn1p_ref_t *ref = 0;
@@ -389,6 +395,7 @@ asn1f_find_terminal_thing(arg_t *arg, asn1p_expr_t *expr, enum ftt_what what) {
 
 	switch(what) {
 	case FTT_TYPE:
+	case FTT_CONSTR_TYPE:
 		/* Expression may be a terminal type itself */
 		if(expr->expr_type != A1TC_REFERENCE)
 			return expr;
@@ -455,6 +462,10 @@ asn1f_find_terminal_thing(arg_t *arg, asn1p_expr_t *expr, enum ftt_what what) {
 	}
 
 	tc->_type_referenced = 1;
+
+	if((what == FTT_CONSTR_TYPE) && (tc->constraints))
+		return tc;
+
 	tc->_mark |= TM_RECURSION;
 	WITH_MODULE(tc->module,
 		expr = asn1f_find_terminal_thing(arg, tc, what));
@@ -462,6 +473,7 @@ asn1f_find_terminal_thing(arg_t *arg, asn1p_expr_t *expr, enum ftt_what what) {
 
 	return expr;
 }
+
 
 /*
  * Make sure that the specified name is present or otherwise does

--- a/libasn1fix/asn1fix_retrieve.h
+++ b/libasn1fix/asn1fix_retrieve.h
@@ -68,4 +68,11 @@ asn1p_expr_t *asn1f_find_terminal_type(arg_t *arg, asn1p_expr_t *tc);
  */
 asn1p_expr_t *asn1f_find_terminal_value(arg_t *arg, asn1p_expr_t *tc);
 
+/*
+ * Recursively find the original type with constraint for the given
+ * expression.
+ */
+asn1p_expr_t *asn1f_find_ancestor_type_with_PER_constraint(arg_t *arg, asn1p_expr_t *tc);
+
+
 #endif	/* ASN1FIX_RETRIEVE_H */

--- a/tests/126-per-extensions-OK.asn1.-Pgen-PER
+++ b/tests/126-per-extensions-OK.asn1.-Pgen-PER
@@ -244,10 +244,11 @@ typedef struct PDU_2 {
 extern asn_TYPE_descriptor_t asn_DEF_PDU_2;
 extern asn_CHOICE_specifics_t asn_SPC_PDU_2_specs_1;
 extern asn_TYPE_member_t asn_MBR_PDU_2_1[3];
+extern asn_per_constraints_t asn_PER_type_PDU_2_constr_1;
 
 /*** <<< CTDEFS [PDU-2] >>> ***/
 
-static asn_per_constraints_t asn_PER_type_PDU_2_constr_1 GCC_NOTUSED = {
+asn_per_constraints_t asn_PER_type_PDU_2_constr_1 GCC_NOTUSED = {
 	{ APC_CONSTRAINED | APC_EXTENSIBLE,  0,  0,  0l,  0l }	/* (0..0,...) */,
 	{ APC_UNCONSTRAINED,	-1, -1,  0,  0 },
 	0, 0	/* No PER value map */

--- a/tests/50-constraint-OK.asn1.-Pgen-PER
+++ b/tests/50-constraint-OK.asn1.-Pgen-PER
@@ -61,6 +61,7 @@ typedef Int1_t	 Int2_t;
 
 /*** <<< FUNC-DECLS [Int2] >>> ***/
 
+extern asn_per_constraints_t asn_PER_type_Int2_constr_1;
 extern asn_TYPE_descriptor_t asn_DEF_Int2;
 asn_struct_free_f Int2_free;
 asn_struct_print_f Int2_print;
@@ -108,7 +109,7 @@ Int2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 
 /*** <<< CTDEFS [Int2] >>> ***/
 
-static asn_per_constraints_t asn_PER_type_Int2_constr_1 GCC_NOTUSED = {
+asn_per_constraints_t asn_PER_type_Int2_constr_1 GCC_NOTUSED = {
 	{ APC_SEMI_CONSTRAINED,	-1, -1,  0l,  0l }	/* (0..MAX) */,
 	{ APC_UNCONSTRAINED,	-1, -1,  0,  0 },
 	0, 0	/* No PER value map */
@@ -146,6 +147,7 @@ typedef Int2_t	 Int3_t;
 
 /*** <<< FUNC-DECLS [Int3] >>> ***/
 
+extern asn_per_constraints_t asn_PER_type_Int3_constr_1;
 extern asn_TYPE_descriptor_t asn_DEF_Int3;
 asn_struct_free_f Int3_free;
 asn_struct_print_f Int3_print;
@@ -193,7 +195,7 @@ Int3_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 
 /*** <<< CTDEFS [Int3] >>> ***/
 
-static asn_per_constraints_t asn_PER_type_Int3_constr_1 GCC_NOTUSED = {
+asn_per_constraints_t asn_PER_type_Int3_constr_1 GCC_NOTUSED = {
 	{ APC_CONSTRAINED,	 4,  4,  0l,  10l }	/* (0..10) */,
 	{ APC_UNCONSTRAINED,	-1, -1,  0,  0 },
 	0, 0	/* No PER value map */
@@ -231,6 +233,7 @@ typedef Int3_t	 Int4_t;
 
 /*** <<< FUNC-DECLS [Int4] >>> ***/
 
+extern asn_per_constraints_t asn_PER_type_Int4_constr_1;
 extern asn_TYPE_descriptor_t asn_DEF_Int4;
 asn_struct_free_f Int4_free;
 asn_struct_print_f Int4_print;
@@ -278,7 +281,7 @@ Int4_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 
 /*** <<< CTDEFS [Int4] >>> ***/
 
-static asn_per_constraints_t asn_PER_type_Int4_constr_1 GCC_NOTUSED = {
+asn_per_constraints_t asn_PER_type_Int4_constr_1 GCC_NOTUSED = {
 	{ APC_CONSTRAINED | APC_EXTENSIBLE,  4,  4,  1l,  10l }	/* (1..10,...) */,
 	{ APC_UNCONSTRAINED,	-1, -1,  0,  0 },
 	0, 0	/* No PER value map */
@@ -316,6 +319,7 @@ typedef Int4_t	 Int5_t;
 
 /*** <<< FUNC-DECLS [Int5] >>> ***/
 
+extern asn_per_constraints_t asn_PER_type_Int5_constr_1;
 extern asn_TYPE_descriptor_t asn_DEF_Int5;
 asn_struct_free_f Int5_free;
 asn_struct_print_f Int5_print;
@@ -363,7 +367,7 @@ Int5_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 
 /*** <<< CTDEFS [Int5] >>> ***/
 
-static asn_per_constraints_t asn_PER_type_Int5_constr_1 GCC_NOTUSED = {
+asn_per_constraints_t asn_PER_type_Int5_constr_1 GCC_NOTUSED = {
 	{ APC_CONSTRAINED,	 0,  0,  5l,  5l }	/* (5..5) */,
 	{ APC_UNCONSTRAINED,	-1, -1,  0,  0 },
 	0, 0	/* No PER value map */
@@ -538,6 +542,7 @@ typedef Str1_t	 Str2_t;
 
 /*** <<< FUNC-DECLS [Str2] >>> ***/
 
+extern asn_per_constraints_t asn_PER_type_Str2_constr_1;
 extern asn_TYPE_descriptor_t asn_DEF_Str2;
 asn_struct_free_f Str2_free;
 asn_struct_print_f Str2_print;
@@ -603,7 +608,7 @@ Str2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 
 /*** <<< CTDEFS [Str2] >>> ***/
 
-static asn_per_constraints_t asn_PER_type_Str2_constr_1 GCC_NOTUSED = {
+asn_per_constraints_t asn_PER_type_Str2_constr_1 GCC_NOTUSED = {
 	{ APC_CONSTRAINED,	 7,  7,  0l,  127l }	/* (0..127) */,
 	{ APC_CONSTRAINED,	 5,  5,  0l,  30l }	/* (SIZE(0..30)) */,
 	0, 0	/* No PER character map necessary */
@@ -869,6 +874,7 @@ typedef IA5String_t	 PER_Visible_t;
 
 /*** <<< FUNC-DECLS [PER-Visible] >>> ***/
 
+extern asn_per_constraints_t asn_PER_type_PER_Visible_constr_1;
 extern asn_TYPE_descriptor_t asn_DEF_PER_Visible;
 asn_struct_free_f PER_Visible_free;
 asn_struct_print_f PER_Visible_print;
@@ -931,7 +937,7 @@ PER_Visible_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 
 /*** <<< CTDEFS [PER-Visible] >>> ***/
 
-static asn_per_constraints_t asn_PER_type_PER_Visible_constr_1 GCC_NOTUSED = {
+asn_per_constraints_t asn_PER_type_PER_Visible_constr_1 GCC_NOTUSED = {
 	{ APC_CONSTRAINED,	 3,  3,  65l,  70l }	/* (65..70) */,
 	{ APC_SEMI_CONSTRAINED,	-1, -1,  0l,  0l }	/* (SIZE(0..MAX)) */,
 	0, 0	/* No PER character map necessary */
@@ -1891,6 +1897,7 @@ typedef Utf8_1_t	 Utf8_2_t;
 
 /*** <<< FUNC-DECLS [Utf8-2] >>> ***/
 
+extern asn_per_constraints_t asn_PER_type_Utf8_2_constr_1;
 extern asn_TYPE_descriptor_t asn_DEF_Utf8_2;
 asn_struct_free_f Utf8_2_free;
 asn_struct_print_f Utf8_2_print;
@@ -1945,7 +1952,7 @@ Utf8_2_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
 
 /*** <<< CTDEFS [Utf8-2] >>> ***/
 
-static asn_per_constraints_t asn_PER_type_Utf8_2_constr_1 GCC_NOTUSED = {
+asn_per_constraints_t asn_PER_type_Utf8_2_constr_1 GCC_NOTUSED = {
 	{ APC_UNCONSTRAINED,	-1, -1,  0,  0 },
 	{ APC_UNCONSTRAINED,	-1, -1,  0,  0 },
 	0, 0	/* No PER value map */
@@ -2133,7 +2140,7 @@ asn_TYPE_descriptor_t asn_DEF_VisibleIdentifier = {
 	asn_DEF_VisibleIdentifier_tags_1,	/* Same as above */
 	sizeof(asn_DEF_VisibleIdentifier_tags_1)
 		/sizeof(asn_DEF_VisibleIdentifier_tags_1[0]), /* 1 */
-	0,	/* No PER visible constraints */
+	&asn_PER_type_Identifier_constr_1,
 	0, 0,	/* No members */
 	0	/* No specifics */
 };
@@ -2385,7 +2392,7 @@ asn_TYPE_member_t asn_MBR_Sequence_1[] = {
 		.tag_mode = +1,	/* EXPLICIT tag at current level */
 		.type = &asn_DEF_Int4,
 		.memb_constraints = 0,	/* Defer constraints checking to the member type */
-		.per_constraints = 0,	/* No PER visible constraints */
+		.per_constraints = &asn_PER_type_Int4_constr_1,
 		.default_value = 0,
 		.name = "int4"
 		},
@@ -3845,6 +3852,7 @@ typedef VisibleString_t	 Identifier_t;
 
 /*** <<< FUNC-DECLS [Identifier] >>> ***/
 
+extern asn_per_constraints_t asn_PER_type_Identifier_constr_1;
 extern asn_TYPE_descriptor_t asn_DEF_Identifier;
 asn_struct_free_f Identifier_free;
 asn_struct_print_f Identifier_print;
@@ -3939,7 +3947,7 @@ static int asn_PER_MAP_Identifier_1_c2v(unsigned int code) {
 
 /*** <<< CTDEFS [Identifier] >>> ***/
 
-static asn_per_constraints_t asn_PER_type_Identifier_constr_1 GCC_NOTUSED = {
+asn_per_constraints_t asn_PER_type_Identifier_constr_1 GCC_NOTUSED = {
 	{ APC_CONSTRAINED,	 6,  6,  36l,  122l }	/* (36..122) */,
 	{ APC_CONSTRAINED,	 5,  5,  1l,  32l }	/* (SIZE(1..32)) */,
 	asn_PER_MAP_Identifier_1_v2c,	/* Value to PER code map */


### PR DESCRIPTION
My pull [request no. 93](https://github.com/vlm/asn1c/pull/93) "Simplify finding decoder logic" does not
handle inheritance of PER constraint that makes constraint check
is not applied in some types.

For example,

    PLMNidentity ::= TBCD-STRING

    TBCD-STRING ::= OCTET STRING (SIZE (3))

PLMNidentity should have size constraint to limit its length.
Without it, OCTET_STRING_decode_aper() will incorrectly interpret
PLMNidentity's length and fails decoding process.

Applying this commit, PLMNidentity will refer to TBCD-STRING's
constraint.

Thus solve issue 24.