### PR TITLE
Fix encoding of small variable-length strings

### DIFF
--- a/skeletons/OCTET_STRING.c
+++ b/skeletons/OCTET_STRING.c
@@ -1753,7 +1753,8 @@ OCTET_STRING_decode_aper(const asn_codec_ctx_t *opt_codec_ctx,
 	/* X.691, #16.7: long fixed length encoding (up to 64K octets) */
 	if(csiz->effective_bits == 0) {
 		int ret;
-		if (st->size > 2) { /* X.691 #16 NOTE 1 */
+		/* X.691 #16 NOTE 1 */
+		if (csiz->lower_bound != csiz->upper_bound || csiz->upper_bound > 2) {
 			if (aper_get_align(pd) < 0)
 				RETURN(RC_FAIL);
 		}
@@ -1802,7 +1803,8 @@ OCTET_STRING_decode_aper(const asn_codec_ctx_t *opt_codec_ctx,
 			(long)csiz->effective_bits, (long)raw_len,
 			repeat ? "repeat" : "once", td->name);
 
-		if (raw_len > 2) { /* X.691 #16 NOTE 1 */
+		/* X.691 #16 NOTE 1 */
+		if (csiz->lower_bound != csiz->upper_bound || csiz->upper_bound > 2) {
 			if (aper_get_align(pd) < 0)
 				RETURN(RC_FAIL);
 		}
@@ -1956,7 +1958,8 @@ OCTET_STRING_encode_aper(const asn_TYPE_descriptor_t *td,
 		        ret = aper_put_length(po, csiz->upper_bound - csiz->lower_bound + 1, sizeinunits - csiz->lower_bound);
 		        if(ret) ASN__ENCODE_FAILED;
 		}
-		if (st->size > 2) { /* X.691 #16 NOTE 1 */
+		/* X.691 #16 NOTE 1 */
+		if (csiz->lower_bound != csiz->upper_bound || csiz->upper_bound > 2) {
 			if (aper_put_align(po) < 0)
 				ASN__ENCODE_FAILED;
 		}


### PR DESCRIPTION
Only fixed-length strings can be encoded without padding.

> Octet strings of fixed length less than or equal to two octets are not octet-aligned.

(from X.691 sec. 16)

See https://github.com/mouse07410/asn1c/issues/40.