### PR TITLE
Incomplete: Various fixes

### DIFF
--- a/skeletons/constr_CHOICE.c
+++ b/skeletons/constr_CHOICE.c
@@ -1164,10 +1164,13 @@ CHOICE_encode_aper(const asn_TYPE_descriptor_t *td,
 		                                   memb_ptr, po);
 	} else {
 		asn_enc_rval_t rval = {0,0,0};
-		int tmp_range_bits = (int) (ct? ct->range_bits : -1);
 		if(specs->ext_start == -1)
 			ASN__ENCODE_FAILED;
-		if(aper_put_nsnnwn(po, tmp_range_bits, present - specs->ext_start))
+		int n = present - specs->ext_start;
+		if(n <= 63) {
+			if(n < 0) ASN__ENCODE_FAILED;
+			if(per_put_few_bits(po, n, 7)) ASN__ENCODE_FAILED;
+		} else
 			ASN__ENCODE_FAILED;
 		if(aper_open_type_put(elm->type, elm->encoding_constraints.per_constraints,
 		                      memb_ptr, po))

--- a/skeletons/constr_SEQUENCE.c
+++ b/skeletons/constr_SEQUENCE.c
@@ -1835,7 +1835,7 @@ SEQUENCE_encode_aper(const asn_TYPE_descriptor_t *td,
 
 		/* Eliminate default values */
 		if(present && elm->default_value_cmp
-		        && elm->default_value_cmp(memb_ptr2) == 0)
+		        && elm->default_value_cmp(*memb_ptr2) == 0)
 			present = 0;
 
 		ASN_DEBUG("Element %s %s %s->%s is %s",
@@ -1881,7 +1881,7 @@ SEQUENCE_encode_aper(const asn_TYPE_descriptor_t *td,
 		}
 
 		/* Eliminate default values */
-		if(elm->default_value_cmp && elm->default_value_cmp(memb_ptr2) == 0)
+		if(elm->default_value_cmp && elm->default_value_cmp(*memb_ptr2) == 0)
 			continue;
 
 		ASN_DEBUG("Encoding %s->%s", td->name, elm->name);

--- a/skeletons/constr_SET_OF.c
+++ b/skeletons/constr_SET_OF.c
@@ -1157,7 +1157,7 @@ SET_OF_encode_aper(const asn_TYPE_descriptor_t *td,
                             ct->effective_bits))
             ASN__ENCODE_FAILED;*/
 
-        if (aper_put_length(po, ct->upper_bound - ct->lower_bound + 1, list->count - ct->lower_bound) < 0) {
+        if (aper_put_length(po, ct->upper_bound - ct->lower_bound + 1, list->count - ct->lower_bound, 0) < 0) {
             ASN__ENCODE_FAILED;
 	}
     }
@@ -1170,11 +1170,12 @@ SET_OF_encode_aper(const asn_TYPE_descriptor_t *td,
 
     for(seq = 0; seq < list->count;) {
         ssize_t may_encode;
+        int need_eom = 0;
         if(ct && ct->effective_bits >= 0) {
             may_encode = list->count;
         } else {
             may_encode =
-                aper_put_length(po, -1, list->count - seq);
+                aper_put_length(po, -1, list->count - seq, &need_eom);
             if(may_encode < 0) ASN__ENCODE_FAILED;
         }
 
@@ -1185,6 +1186,8 @@ SET_OF_encode_aper(const asn_TYPE_descriptor_t *td,
                 break;
             }
 	}
+        if(need_eom && aper_put_length(po, -1, 0, 0))
+            ASN__ENCODE_FAILED; /* End of Message length */
     }
 
     SET_OF__encode_sorted_free(encoded_els, list->count);

--- a/skeletons/per_opentype.c
+++ b/skeletons/per_opentype.c
@@ -487,11 +487,16 @@ aper_open_type_put(const asn_TYPE_descriptor_t *td,
 	if(size <= 0) return -1;
 
 	for(bptr = buf, toGo = size; toGo;) {
-		ssize_t maySave = aper_put_length(po, -1, toGo);
+        int need_eom = 0;
+		ssize_t maySave = aper_put_length(po, -1, toGo, &need_eom);
 		if(maySave < 0) break;
 		if(per_put_many_bits(po, bptr, maySave * 8)) break;
 		bptr = (char *)bptr + maySave;
 		toGo -= maySave;
+        if(need_eom && aper_put_length(po, -1, 0, 0)) {
+            FREEMEM(buf);
+            return -1;
+        }
 	}
 
 	FREEMEM(buf);

--- a/skeletons/per_support.h
+++ b/skeletons/per_support.h
@@ -101,7 +101,8 @@ int uper_put_constrained_whole_number_u(asn_per_outp_t *po, unsigned long v, int
 ssize_t uper_put_length(asn_per_outp_t *po, size_t whole_length,
                         int *opt_need_eom);
 
-ssize_t aper_put_length(asn_per_outp_t *po, int range, size_t length);
+ssize_t aper_put_length(asn_per_outp_t *po, int range, size_t length,
+                        int *opt_need_eom);
 
 /* Align the current bit position to octet bundary */
 int aper_put_align(asn_per_outp_t *po);


### PR DESCRIPTION
* Empty fragment encoding
* Dereference DEFAULT to get the actual value
* Don't write length bits for small fixed-sized sequence-of
* Index encoding in choice extensions
* Only align when range == 256