### PR TITLE
Fix: protect dereferencing pointer to asn_per_constraint_t

### DIFF
--- a/skeletons/constr_CHOICE_aper.c
+++ b/skeletons/constr_CHOICE_aper.c
@@ -52,11 +52,14 @@ CHOICE_decode_aper(const asn_codec_ctx_t *opt_codec_ctx,
     } else {
         if(specs->ext_start == -1)
             ASN__DECODE_FAILED;
-        value = aper_get_nsnnwn(pd, ct->upper_bound - ct->lower_bound + 1);
-        if(value < 0) ASN__DECODE_STARVED;
-        value += specs->ext_start;
-        if((unsigned)value >= td->elements_count)
-            ASN__DECODE_FAILED;
+
+        if (ct && ct->upper_bound >= ct->lower_bound) {
+            value = aper_get_nsnnwn(pd, ct->upper_bound - ct->lower_bound + 1);
+            if(value < 0) ASN__DECODE_STARVED;
+            value += specs->ext_start;
+            if((unsigned)value >= td->elements_count)
+                ASN__DECODE_FAILED;
+        }
     }
 
     /* Adjust if canonical order is different from natural order */


### PR DESCRIPTION
I was getting crashes while processing an S1AP (APER encoding) trace, so after some debugging I found you can get into this else block after going through line 42
`        if(value) ct = 0;  /* Not restricted */`
which nullifies `ct`.

So I just added a null-guard before trying to access `ct->{upper, lower}_bound`.
I'm no ASN expert at all, so I'm not sure this fix is not causing problems down the line, but at least with my trace everything seems to be working fine now: I can get to the end  with no crashes and it seems to correctly process the message that was crashing b4...
