### PR TITLE
MinGW support

### DIFF
--- a/libasn1common/asn1_buffer.c
+++ b/libasn1common/asn1_buffer.c
@@ -1,4 +1,3 @@
-#define _GNU_SOURCE
 #include <sys/types.h>
 #include <stdlib.h>
 #include <stdarg.h>

--- a/skeletons/INTEGER.c
+++ b/skeletons/INTEGER.c
@@ -7,6 +7,7 @@
 #include <INTEGER.h>
 #include <asn_codecs_prim.h>	/* Encoder and decoder of a primitive type */
 #include <errno.h>
+#include <inttypes.h>
 
 /*
  * INTEGER basic type description.

--- a/skeletons/OBJECT_IDENTIFIER.c
+++ b/skeletons/OBJECT_IDENTIFIER.c
@@ -8,6 +8,7 @@
 #include <OCTET_STRING.h>
 #include <limits.h>	/* for CHAR_BIT */
 #include <errno.h>
+#include <inttypes.h>
 
 /*
  * OBJECT IDENTIFIER basic type description.

--- a/skeletons/asn_system.h
+++ b/skeletons/asn_system.h
@@ -27,12 +27,15 @@
 #include <limits.h>	/* For LONG_MAX */
 #include <stdarg.h>	/* For va_start */
 #include <stddef.h>	/* for offsetof and ptrdiff_t */
+#include <inttypes.h>	/* for PRIdMAX */
 
 #ifdef	_WIN32
 
 #include <malloc.h>
+#ifndef __MINGW32__
 #define	 snprintf	_snprintf
 #define	 vsnprintf	_vsnprintf
+#endif
 
 /* To avoid linking with ws2_32.lib, here's the definition of ntohl() */
 #define sys_ntohl(l)	((((l) << 24)  & 0xff000000)	\


### PR DESCRIPTION
- fixed: format specifiers like `PRIu32` or `PRIdMAX` are defined in standard C header `inttypes.h`

- fixed: `_snprintf` is a function introduced by MicroSoft, which isn't fully compliant with `snprintf` from C99 (it doesn't support `%zu`, for example). `snprintf`/`vsnprintf` are available in MinGW though

- fixed: `_GNU_SOURCE` was added in `fadb26aa`, Aug 23 2017 in attempt to enable declaration of GNU extension `vasprintf`. But later in `a06b1b4d` and `6bdd8c0a` more correct way of handling this function was added - via definition of subsitution if it's absent (e.g. for Solaris); so enforcing `_GNU_SOURCE` isn't necessary anymore, and it breaks MinGW build.