### PR TITLE
fix UPER codec for INTEGER_t

### DIFF
--- a/skeletons/INTEGER_uper.c
+++ b/skeletons/INTEGER_uper.c
@@ -66,7 +66,7 @@ INTEGER_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
                 ASN_DEBUG("Got value %lu + low %ld",
                     uvalue, ct->lower_bound);
                 uvalue += ct->lower_bound;
-                if(asn_ulong2INTEGER(st, uvalue))
+                if(asn_umax2INTEGER(st, uvalue))
                     ASN__DECODE_FAILED;
             } else {
                 uintmax_t uvalue = 0;

--- a/skeletons/INTEGER_uper.c
+++ b/skeletons/INTEGER_uper.c
@@ -61,20 +61,20 @@ INTEGER_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
             if(specs && specs->field_unsigned) {
                 uintmax_t uvalue = 0;
                 if(uper_get_constrained_whole_number(pd,
-                &uvalue, ct->range_bits))
-                ASN__DECODE_STARVED;
-            ASN_DEBUG("Got value %lu + low %ld",
-                uvalue, ct->lower_bound);
-            uvalue += ct->lower_bound;
-            if(asn_ulong2INTEGER(st, uvalue))
-                ASN__DECODE_FAILED;
-        } else {
-            uintmax_t uvalue = 0;
-            intmax_t svalue;
-            if(uper_get_constrained_whole_number(pd,
-                &uvalue, ct->range_bits))
-                ASN__DECODE_STARVED;
-            ASN_DEBUG("Got value %lu + low %ld",
+                    &uvalue, ct->range_bits))
+                    ASN__DECODE_STARVED;
+                ASN_DEBUG("Got value %lu + low %ld",
+                    uvalue, ct->lower_bound);
+                uvalue += ct->lower_bound;
+                if(asn_ulong2INTEGER(st, uvalue))
+                    ASN__DECODE_FAILED;
+            } else {
+                uintmax_t uvalue = 0;
+                intmax_t svalue;
+                if(uper_get_constrained_whole_number(pd,
+                    &uvalue, ct->range_bits))
+                    ASN__DECODE_STARVED;
+                ASN_DEBUG("Got value %lu + low %ld",
                 uvalue, ct->lower_bound);
                 if(per_imax_range_unrebase(uvalue, ct->lower_bound,
                                            ct->upper_bound, &svalue)

--- a/skeletons/uper_support.c
+++ b/skeletons/uper_support.c
@@ -148,7 +148,7 @@ int uper_get_constrained_whole_number(asn_per_data_t *pd, uintmax_t *out_value, 
 
 /* X.691-2008/11, #11.5.6 -> #11.3 */
 int
-uper_put_constrained_whole_number_u(asn_per_outp_t *po, unsigned long v,
+uper_put_constrained_whole_number_u(asn_per_outp_t *po, uintmax_t v,
                                     int nbits) {
     if(nbits <= 31) {
         return per_put_few_bits(po, v, nbits);

--- a/skeletons/uper_support.h
+++ b/skeletons/uper_support.h
@@ -46,7 +46,7 @@ int per_long_range_unrebase(unsigned long inp, intmax_t lb, intmax_t ub, long *o
 int per_imax_range_unrebase(uintmax_t inp, intmax_t lb, intmax_t ub, intmax_t *outp);
 
 /* X.691-2008/11, #11.5 */
-int uper_put_constrained_whole_number_u(asn_per_outp_t *po, unsigned long v, int nbits);
+int uper_put_constrained_whole_number_u(asn_per_outp_t *po, uintmax_t v, int nbits);
 
 /*
  * X.691 (08/2015) #11.9 "General rules for encoding a length determinant"


### PR DESCRIPTION
Large integer values (longer than 4 bytes) were encoded incorrectly on 32bit architectures.