### PR TITLE
aper decoder can ignore open types that cannot parse and continue with next ones

### DIFF
--- a/skeletons/OPEN_TYPE.h
+++ b/skeletons/OPEN_TYPE.h
@@ -94,6 +94,14 @@ asn_enc_rval_t OPEN_TYPE_encode_aper(
     const asn_TYPE_descriptor_t *type_descriptor,
     const asn_per_constraints_t *constraints, const void *struct_ptr,
     asn_per_outp_t *per_output);
+
+int OPEN_TYPE_aper_is_unknown_type(
+    const asn_TYPE_descriptor_t *td,
+    void *sptr,
+    const asn_TYPE_member_t *elm);
+
+asn_dec_rval_t OPEN_TYPE_aper_unknown_type_discard_bytes(
+    asn_per_data_t *pd);
 #endif  /* !defined(ASN_DISABLE_APER_SUPPORT) */
 
 extern asn_TYPE_operation_t asn_OP_OPEN_TYPE;

--- a/skeletons/constr_SEQUENCE_aper.c
+++ b/skeletons/constr_SEQUENCE_aper.c
@@ -130,6 +130,11 @@ SEQUENCE_decode_aper(const asn_codec_ctx_t *opt_codec_ctx,
         ASN_DEBUG("Decoding member \"%s\" in %s", elm->name, td->name);
 
         if(elm->flags & ATF_OPEN_TYPE) {
+            if (OPEN_TYPE_aper_is_unknown_type(td, st, elm)) {
+                rv = OPEN_TYPE_aper_unknown_type_discard_bytes(pd);
+                FREEMEM(opres);
+                return rv;
+            }
             rv = OPEN_TYPE_aper_get(opt_codec_ctx, td, st, elm, pd);
         } else {
             rv = elm->type->op->aper_decoder(opt_codec_ctx, elm->type,


### PR DESCRIPTION
It can be used on 3gpp 38.413 when decoding messages encoded with a newer (but backwards compatible) schema. You can ignore protocol extensions that you cannot parse. 