### PR TITLE
skeletons/OPEN_TYPE: Fix encoding if ASN_DISABLE_JER_SUPPORT defined

### DIFF
--- a/skeletons/OPEN_TYPE.c
+++ b/skeletons/OPEN_TYPE.c
@@ -30,6 +30,8 @@ asn_TYPE_operation_t asn_OP_OPEN_TYPE = {
 #endif  /* !defined(ASN_DISABLE_XER_SUPPORT) */
 #if !defined(ASN_DISABLE_JER_SUPPORT)
     OPEN_TYPE_encode_jer,
+#else
+    0,
 #endif /* !defined(ASN_DISABLE_JER_SUPPORT) */
 #if !defined(ASN_DISABLE_OER_SUPPORT)
     OPEN_TYPE_decode_oer,


### PR DESCRIPTION

Otherwise the fields end up being misplaced and crash during encoding,
as can be seen in gdb:
"aper_decoder = 0x7ffff7687616 <OPEN_TYPE_encode_aper>, aper_encoder = 0x0"