### PR TITLE
Oai on vlm master

### DIFF
--- a/asn1c/asn1c.c
+++ b/asn1c/asn1c.c
@@ -118,6 +118,7 @@ main(int ac, char **av) {
                 asn1_fixer_flags |= A1F_EXTENDED_SizeConstraint;
             } else if(strcmp(optarg, "compound-names") == 0) {
                 asn1_compiler_flags |= A1C_COMPOUND_NAMES;
+                asn1_fixer_flags |= A1F_COMPOUND_NAMES;
             } else if(strcmp(optarg, "indirect-choice") == 0) {
                 asn1_compiler_flags |= A1C_INDIRECT_CHOICE;
             } else if(strncmp(optarg, "known-extern-type=", 18) == 0) {

--- a/libasn1common/asn1_ref.c
+++ b/libasn1common/asn1_ref.c
@@ -147,8 +147,6 @@ int
 asn1p_ref_compare(const asn1p_ref_t *a, const asn1p_ref_t *b) {
     if(a->comp_count != b->comp_count)
         return -1;
-    if(a->module != b->module)
-        return -1;
 
     for(size_t i = 0; i < a->comp_count; i++) {
         if(a->components[i].lex_type != b->components[i].lex_type

--- a/libasn1common/asn1_ref.h
+++ b/libasn1common/asn1_ref.h
@@ -5,6 +5,7 @@
 #define	ASN1_REFERENCE_H
 
 struct asn1p_module_s;
+struct asn1p_expr_s;
 
 typedef struct asn1p_ref_s {
 
@@ -39,6 +40,7 @@ typedef struct asn1p_ref_s {
 	size_t comp_count;	/* Number of the components in the reference name. */
 	size_t comp_size;	/* Number of allocated structures */
 
+	struct asn1p_expr_s *ref_expr;  /* De-referenced expression */
 	struct asn1p_module_s *module;	/* Defined in module */
 	int _lineno;	/* Number of line in the file */
 } asn1p_ref_t;

--- a/libasn1compiler/asn1c_C.c
+++ b/libasn1compiler/asn1c_C.c
@@ -971,6 +971,7 @@ asn1c_lang_C_type_CHOICE(arg_t *arg) {
 	asn1p_expr_t *expr = arg->expr;
 	asn1p_expr_t *v;
 	int saved_target = arg->target->target;
+	int ext_num = 1;
 
 	DEPENDENCIES;
 
@@ -990,7 +991,15 @@ asn1c_lang_C_type_CHOICE(arg_t *arg) {
 				skipComma = 1;
 				continue;
 			}
-            OUT("%s", c_presence_name(arg, v));
+
+			if((v->expr_type == ASN_CONSTR_SEQUENCE) &&
+				(v->marker.flags & EM_OPTIONAL) &&
+				(v->Identifier == NULL)) {
+				char ext_name[20];
+				sprintf(ext_name, "ext%d", ext_num++);
+				v->Identifier = strdup(ext_name);
+			}
+			OUT("%s", c_presence_name(arg, v));
 		}
 		OUT("\n");
 	);

--- a/libasn1compiler/asn1c_C.c
+++ b/libasn1compiler/asn1c_C.c
@@ -1485,7 +1485,7 @@ asn1c_lang_C_type_SIMPLE_TYPE(arg_t *arg) {
                || (expr->expr_type == ASN_BASIC_INTEGER)) {
                 OUT("extern const asn_INTEGER_specifics_t "
                     "asn_SPC_%s_specs_%d;\n",
-                    c_name(arg).base_name, expr->_type_unique_index);
+                    MKID(expr), expr->_type_unique_index);
             } else {
                 asn1p_expr_t *terminal = WITH_MODULE_NAMESPACE(
                     expr->module, expr_ns,

--- a/libasn1compiler/asn1c_C.c
+++ b/libasn1compiler/asn1c_C.c
@@ -2409,7 +2409,7 @@ emit_default_string_value(arg_t *arg, asn1p_value_t *v) {
 		uint8_t *e = v->value.string.size + b;
 		OUT("{ ");
 		for(;b < e; b++)
-			OUT("0x%02x, ", *b);
+			OUT("0x%02X, ", *b);
 		OUT("0 };\n");
 	}
 }
@@ -2422,7 +2422,7 @@ emit_default_bitstring_value(arg_t *arg, asn1p_value_t *v) {
 
 	uint8_t *b = v->value.binary_vector.bits;
 	for (int i = 0; i < (v->value.binary_vector.size_in_bits + 7)/8; i++, b++) {
-		OUT("0x%02x", *b);
+		OUT("0x%02X", *b);
 		if(i < (v->value.binary_vector.size_in_bits + 7)/8 - 1)
 			OUT(", ");
 	}

--- a/libasn1compiler/asn1c_ioc.c
+++ b/libasn1compiler/asn1c_ioc.c
@@ -11,7 +11,7 @@
  * Given the table constraint or component relation constraint
  * ({ObjectSetName}{...}) returns "ObjectSetName" as a reference.
  */
-const asn1p_ref_t *
+asn1p_ref_t *
 asn1c_get_information_object_set_reference_from_constraint(arg_t *arg,
     const asn1p_constraint_t *ct) {
 
@@ -68,14 +68,14 @@ asn1c_get_ioc_table(arg_t *arg) {
     asn1p_expr_t *expr = arg->expr;
 	asn1p_expr_t *memb;
     asn1p_expr_t *objset = 0;
-    const asn1p_ref_t *objset_ref = NULL;
+    asn1p_ref_t *objset_ref = NULL;
     asn1c_ioc_table_and_objset_t safe_ioc_tao = {0, 0, 0};
     asn1c_ioc_table_and_objset_t failed_ioc_tao = { 0, 0, 1 };
 
     TQ_FOR(memb, &(expr->members), next) {
         const asn1p_constraint_t *cr_ct =
             asn1p_get_component_relation_constraint(memb->constraints);
-        const asn1p_ref_t *tmpref =
+        asn1p_ref_t *tmpref =
             asn1c_get_information_object_set_reference_from_constraint(arg,
                                                                        cr_ct);
         if(tmpref) {

--- a/libasn1compiler/asn1c_ioc.h
+++ b/libasn1compiler/asn1c_ioc.h
@@ -15,7 +15,7 @@ asn1c_ioc_table_and_objset_t asn1c_get_ioc_table(arg_t *arg);
 int emit_ioc_table(arg_t *arg, asn1p_expr_t *context,
                     asn1c_ioc_table_and_objset_t);
 
-const asn1p_ref_t *asn1c_get_information_object_set_reference_from_constraint(
+asn1p_ref_t *asn1c_get_information_object_set_reference_from_constraint(
     arg_t *arg, const asn1p_constraint_t *ct);
 
 

--- a/libasn1compiler/asn1c_misc.c
+++ b/libasn1compiler/asn1c_misc.c
@@ -82,7 +82,13 @@ asn1c_make_identifier(enum ami_flags_e flags, asn1p_expr_t *expr, ...) {
 		if(expr->_mark & TM_NAMECLASH) {
 			size += strlen(expr->module->ModuleName) + 2;
 			sptr[sptr_cnt++] = expr->module->ModuleName;
+		} else if (expr->reference && expr->reference->ref_expr &&
+			(expr->reference->ref_expr->_mark & TM_NAMECLASH) &&
+			(strcmp(expr->Identifier, expr->reference->ref_expr->Identifier) == 0)) {
+			size += strlen(expr->reference->ref_expr->module->ModuleName) + 2;
+			sptr[sptr_cnt++] = expr->reference->ref_expr->module->ModuleName;
 		}
+
 		sptr[sptr_cnt++] = expr->Identifier;
 
 		size += strlen(expr->Identifier);

--- a/libasn1compiler/asn1c_save.c
+++ b/libasn1compiler/asn1c_save.c
@@ -1029,14 +1029,29 @@ generate_constant_collection(arg_t *arg) {
 
     TQ_FOR(mod, &(arg->asn->modules), mod_next) {
         TQ_FOR(arg->expr, &(mod->members), next) {
-            if(arg->expr->meta_type != AMT_VALUE)
+            if(arg->expr->expr_type != ASN_BASIC_INTEGER)
                 continue;
 
-            if(arg->expr->expr_type == ASN_BASIC_INTEGER) {
+            if(arg->expr->meta_type == AMT_VALUE) {
                 abuf_printf(buf, "#define %s (%s)\n",
                             asn1c_make_identifier(AMI_USE_PREFIX, arg->expr, 0),
                             asn1p_itoa(arg->expr->value->value.v_integer));
                 empty_file = 0;
+            }
+
+            if(arg->expr->meta_type == AMT_TYPE) {
+                if(arg->expr->constraints) {
+                    if(arg->expr->constraints->el_count == 1 &&
+                       arg->expr->constraints->elements[0]->type == ACT_EL_RANGE) {
+                        abuf_printf(buf, "#define min_val_%s (%s)\n",
+                                    asn1c_make_identifier(AMI_USE_PREFIX, arg->expr, 0),
+                                    asn1p_itoa(arg->expr->constraints->elements[0]->range_start->value.v_integer));
+                        abuf_printf(buf, "#define max_val_%s (%s)\n",
+                                    asn1c_make_identifier(AMI_USE_PREFIX, arg->expr, 0),
+                                    asn1p_itoa(arg->expr->constraints->elements[0]->range_stop->value.v_integer));
+                        empty_file = 0;
+                    } 
+                }
             }
         }
     }

--- a/libasn1fix/asn1fix.c
+++ b/libasn1fix/asn1fix.c
@@ -283,6 +283,26 @@ asn1f_fix_module__phase_2(arg_t *arg) {
 		ret = asn1f_recurse_expr(arg, asn1f_check_constraints);
 		RET2RVAL(ret, rvalue);
 
+		if (expr->ioc_table) {
+			for (size_t rn = 0; rn < expr->ioc_table->rows; rn++) {
+				for (size_t cn = 0; cn < expr->ioc_table->row[rn]->columns; cn++) {
+					if (!expr->ioc_table->row[rn]->column[cn].value) {
+						continue;
+					}
+					arg->expr = expr->ioc_table->row[rn]->column[cn].value;
+					ret = asn1f_recurse_expr(arg, asn1f_fix_dereference_defaults);
+					RET2RVAL(ret, rvalue);
+
+					ret = asn1f_recurse_expr(arg, asn1f_resolve_constraints);
+					RET2RVAL(ret, rvalue);
+
+					ret = asn1f_recurse_expr(arg, asn1f_check_constraints);
+					RET2RVAL(ret, rvalue);
+				}
+			}
+			arg->expr = expr;
+		}
+
 		/*
 		 * Uniquely tag each inner type.
 		 */

--- a/libasn1fix/asn1fix.c
+++ b/libasn1fix/asn1fix.c
@@ -65,6 +65,15 @@ asn1f_process(asn1p_t *asn, enum asn1f_flags flags,
 		}
 	}
 
+	if(flags & A1F_COMPOUND_NAMES) {
+		arg.flags |= A1F_COMPOUND_NAMES;
+		flags &= ~A1F_COMPOUND_NAMES;
+		if(arg.debug) {
+			arg.debug(-1,
+				"Allow the same symbol name defined in two different modules");
+		}
+	}
+
 	a1f_replace_me_with_proper_interface_arg = arg;
 
 	/*
@@ -515,8 +524,9 @@ asn1f_check_duplicate(arg_t *arg) {
 
 			/* resolve clash of Identifier in different modules */
 			int oid_exist = (tmparg.expr->module->module_oid && arg->expr->module->module_oid);
-			if ((!oid_exist && strcmp(tmparg.expr->module->ModuleName, arg->expr->module->ModuleName)) ||
-				(oid_exist && !asn1p_oid_compare(tmparg.expr->module->module_oid, arg->expr->module->module_oid))) {
+			if ((arg->flags & A1F_COMPOUND_NAMES) &&
+				((!oid_exist && strcmp(tmparg.expr->module->ModuleName, arg->expr->module->ModuleName)) ||
+				 (oid_exist && asn1p_oid_compare(tmparg.expr->module->module_oid, arg->expr->module->module_oid)))) {
 
 				tmparg.expr->_mark |= TM_NAMECLASH;
 				arg->expr->_mark |= TM_NAMECLASH;

--- a/libasn1fix/asn1fix.h
+++ b/libasn1fix/asn1fix.h
@@ -14,6 +14,7 @@ enum asn1f_flags {
 	A1F_NOFLAGS,
 	A1F_DEBUG			= 0x01,	/* Print debugging output */
 	A1F_EXTENDED_SizeConstraint	= 0x02,	/* Enable constraint gen code */
+	A1F_COMPOUND_NAMES		= 0x04  /* A1C_COMPOUND_NAMES  */
 };
 
 /*

--- a/libasn1fix/asn1fix_export.c
+++ b/libasn1fix/asn1fix_export.c
@@ -47,7 +47,7 @@ asn1f_lookup_module_ex(asn1p_t *asn, const char *module_name,
 
 asn1p_expr_t *
 asn1f_lookup_symbol_ex(asn1p_t *asn, asn1_namespace_t *ns, asn1p_expr_t *expr,
-                       const asn1p_ref_t *ref) {
+                       asn1p_ref_t *ref) {
     arg_t arg;
 
     memset(&arg, 0, sizeof(arg));

--- a/libasn1fix/asn1fix_export.h
+++ b/libasn1fix/asn1fix_export.h
@@ -30,7 +30,7 @@ asn1p_expr_t *asn1f_lookup_symbol_ex(
 		asn1p_t *asn,
 		struct asn1_namespace_s *ns,
 		asn1p_expr_t *expr,
-		const asn1p_ref_t *ref);
+		asn1p_ref_t *ref);
 
 /*
  *  Exportable version of an asn1f_class_access().

--- a/libasn1fix/asn1fix_param.c
+++ b/libasn1fix/asn1fix_param.c
@@ -58,7 +58,7 @@ asn1f_parameterization_fork(arg_t *arg, asn1p_expr_t *expr, asn1p_expr_t *rhs_ps
 	if(!exc) return NULL;
 	if(rarg.resolved_name) {
 		free(exc->Identifier);
-		exc->Identifier = strdup(rarg.resolved_name);
+		exc->Identifier = rarg.resolved_name;
 		exc->_lineno = 0;
 	}
 	rpc = asn1p_expr_clone(rhs_pspecs, 0);
@@ -147,12 +147,13 @@ resolve_expr(asn1p_expr_t *expr_to_resolve, void *resolver_arg) {
 			? strdup(expr_to_resolve->Identifier) : 0;
 		if(expr->meta_type == AMT_TYPEREF) {
 			asn1p_ref_t *ref = expr->reference;
-			rarg->resolved_name = ref->components[ref->comp_count - 1].name;
+			rarg->resolved_name = calloc(1, strlen(rarg->original_expr->Identifier) + strlen(ref->components[ref->comp_count - 1].name) + 2);
+			sprintf(rarg->resolved_name, "%s_%s", rarg->original_expr->Identifier, ref->components[ref->comp_count - 1].name);
 		} else if(expr->meta_type == AMT_VALUESET) {
 			asn1p_constraint_t *ct = expr->constraints;
 			if(ct->type == ACT_EL_TYPE) {
 				asn1p_ref_t *ref = ct->containedSubtype->value.v_type->reference;
-				rarg->resolved_name = ref->components[ref->comp_count - 1].name;
+				rarg->resolved_name = strdup(ref->components[ref->comp_count - 1].name);
 			}
 		}
 		return nex;

--- a/libasn1fix/asn1fix_retrieve.c
+++ b/libasn1fix/asn1fix_retrieve.c
@@ -441,8 +441,10 @@ asn1f_lookup_symbol_impl(arg_t *arg, asn1p_expr_t *rhs_pspecs, const asn1p_ref_t
 
 asn1p_expr_t *
 asn1f_lookup_symbol(arg_t *arg, asn1p_expr_t *rhs_pspecs,
-                    const asn1p_ref_t *ref) {
-    return asn1f_lookup_symbol_impl(arg, rhs_pspecs, ref, 0);
+                    asn1p_ref_t *ref) {
+    asn1p_expr_t *expr = asn1f_lookup_symbol_impl(arg, rhs_pspecs, ref, 0);
+    if (ref) ref->ref_expr = expr;
+    return expr;
 }
 
 asn1p_expr_t *

--- a/libasn1fix/asn1fix_retrieve.h
+++ b/libasn1fix/asn1fix_retrieve.h
@@ -38,7 +38,7 @@ asn1p_module_t *asn1f_lookup_module(arg_t *arg,
  * symbol lookup. Not a recursive function.
  */
 asn1p_expr_t *asn1f_lookup_symbol(arg_t *arg, asn1p_expr_t *rhs_pspecs,
-                                  const asn1p_ref_t *ref);
+                                  asn1p_ref_t *ref);
 
 /*
  * Recursively find the original type for the given expression.

--- a/libasn1parser/asn1p_y.y
+++ b/libasn1parser/asn1p_y.y
@@ -1075,6 +1075,13 @@ AlternativeTypeLists:
 		$$ = $1;
 		asn1p_expr_add($$, $3);
 	}
+	| AlternativeTypeLists ',' TOK_VBracketLeft AlternativeTypeLists TOK_VBracketRight {
+		$$ = $1;
+		$4->meta_type = AMT_TYPE;
+		$4->expr_type = ASN_CONSTR_SEQUENCE;
+		$4->marker.flags |= EM_OPTIONAL;
+		asn1p_expr_add($$, $4);
+	}
 	;
 
 AlternativeType:

--- a/tests/tests-asn1c-compiler/141-component-relation-OK.asn1.+-P
+++ b/tests/tests-asn1c-compiler/141-component-relation-OK.asn1.+-P
@@ -740,6 +740,8 @@ asn_TYPE_descriptor_t asn_DEF_EXTERNAL = {
 extern "C" {
 #endif
 
+#define min_val_ConstrainedInteger (0)
+#define max_val_ConstrainedInteger (32767)
 #define primMessage (1)
 #define cplxMessage (2)
 

--- a/tests/tests-asn1c-compiler/147-inherit-per-constraints-OK.asn1.-Pgen-OER
+++ b/tests/tests-asn1c-compiler/147-inherit-per-constraints-OK.asn1.-Pgen-OER
@@ -1,0 +1,303 @@
+
+/*** <<< INCLUDES [Short] >>> ***/
+
+#include <NativeInteger.h>
+
+/*** <<< TYPE-DECLS [Short] >>> ***/
+
+typedef long	 Short_t;
+
+/*** <<< FUNC-DECLS [Short] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_Short;
+asn_struct_free_f Short_free;
+asn_struct_print_f Short_print;
+asn_constr_check_f Short_constraint;
+ber_type_decoder_f Short_decode_ber;
+der_type_encoder_f Short_encode_der;
+xer_type_decoder_f Short_decode_xer;
+xer_type_encoder_f Short_encode_xer;
+oer_type_decoder_f Short_decode_oer;
+oer_type_encoder_f Short_encode_oer;
+
+/*** <<< CODE [Short] >>> ***/
+
+int
+Short_constraint(const asn_TYPE_descriptor_t *td, const void *sptr,
+			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
+	long value;
+	
+	if(!sptr) {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: value not given (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+	
+	value = *(const long *)sptr;
+	
+	if((value >= 0 && value <= 65535)) {
+		/* Constraint check succeeded */
+		return 0;
+	} else {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: constraint failed (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+}
+
+/*
+ * This type is implemented using NativeInteger,
+ * so here we adjust the DEF accordingly.
+ */
+
+/*** <<< CTDEFS [Short] >>> ***/
+
+static asn_oer_constraints_t asn_OER_type_Short_constr_1 CC_NOTUSED = {
+	{ 2, 1 }	/* (0..65535) */,
+	-1};
+
+/*** <<< STAT-DEFS [Short] >>> ***/
+
+static const ber_tlv_tag_t asn_DEF_Short_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (2 << 2))
+};
+asn_TYPE_descriptor_t asn_DEF_Short = {
+	"Short",
+	"Short",
+	&asn_OP_NativeInteger,
+	asn_DEF_Short_tags_1,
+	sizeof(asn_DEF_Short_tags_1)
+		/sizeof(asn_DEF_Short_tags_1[0]), /* 1 */
+	asn_DEF_Short_tags_1,	/* Same as above */
+	sizeof(asn_DEF_Short_tags_1)
+		/sizeof(asn_DEF_Short_tags_1[0]), /* 1 */
+	{ &asn_OER_type_Short_constr_1, 0, Short_constraint },
+	0, 0,	/* No members */
+	0	/* No specifics */
+};
+
+
+/*** <<< INCLUDES [Alias] >>> ***/
+
+#include "Short.h"
+
+/*** <<< TYPE-DECLS [Alias] >>> ***/
+
+typedef Short_t	 Alias_t;
+
+/*** <<< FUNC-DECLS [Alias] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_Alias;
+asn_struct_free_f Alias_free;
+asn_struct_print_f Alias_print;
+asn_constr_check_f Alias_constraint;
+ber_type_decoder_f Alias_decode_ber;
+der_type_encoder_f Alias_encode_der;
+xer_type_decoder_f Alias_decode_xer;
+xer_type_encoder_f Alias_encode_xer;
+oer_type_decoder_f Alias_decode_oer;
+oer_type_encoder_f Alias_encode_oer;
+
+/*** <<< CODE [Alias] >>> ***/
+
+int
+Alias_constraint(const asn_TYPE_descriptor_t *td, const void *sptr,
+			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
+	long value;
+	
+	if(!sptr) {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: value not given (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+	
+	value = *(const long *)sptr;
+	
+	if((value >= 0 && value <= 65535)) {
+		/* Constraint check succeeded */
+		return 0;
+	} else {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: constraint failed (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+}
+
+/*
+ * This type is implemented using Short,
+ * so here we adjust the DEF accordingly.
+ */
+
+/*** <<< CTDEFS [Alias] >>> ***/
+
+static asn_oer_constraints_t asn_OER_type_Alias_constr_1 CC_NOTUSED = {
+	{ 2, 1 }	/* (0..65535) */,
+	-1};
+
+/*** <<< STAT-DEFS [Alias] >>> ***/
+
+static const ber_tlv_tag_t asn_DEF_Alias_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (2 << 2))
+};
+asn_TYPE_descriptor_t asn_DEF_Alias = {
+	"Alias",
+	"Alias",
+	&asn_OP_NativeInteger,
+	asn_DEF_Alias_tags_1,
+	sizeof(asn_DEF_Alias_tags_1)
+		/sizeof(asn_DEF_Alias_tags_1[0]), /* 1 */
+	asn_DEF_Alias_tags_1,	/* Same as above */
+	sizeof(asn_DEF_Alias_tags_1)
+		/sizeof(asn_DEF_Alias_tags_1[0]), /* 1 */
+	{ &asn_OER_type_Alias_constr_1, 0, Alias_constraint },
+	0, 0,	/* No members */
+	0	/* No specifics */
+};
+
+
+/*** <<< INCLUDES [Soo] >>> ***/
+
+#include <NativeInteger.h>
+#include "Short.h"
+#include "Alias.h"
+#include <constr_SEQUENCE.h>
+
+/*** <<< TYPE-DECLS [Soo] >>> ***/
+
+typedef struct Soo {
+	long	 foo;
+	Short_t	 bar;
+	Alias_t	 baz;
+	
+	/* Context for parsing across buffer boundaries */
+	asn_struct_ctx_t _asn_ctx;
+} Soo_t;
+
+/*** <<< FUNC-DECLS [Soo] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_Soo;
+
+/*** <<< CODE [Soo] >>> ***/
+
+static int
+memb_foo_constraint_1(const asn_TYPE_descriptor_t *td, const void *sptr,
+			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
+	long value;
+	
+	if(!sptr) {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: value not given (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+	
+	value = *(const long *)sptr;
+	
+	if((value >= 0 && value <= 65535)) {
+		/* Constraint check succeeded */
+		return 0;
+	} else {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: constraint failed (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+}
+
+
+/*** <<< CTDEFS [Soo] >>> ***/
+
+static asn_oer_constraints_t asn_OER_memb_foo_constr_2 CC_NOTUSED = {
+	{ 2, 1 }	/* (0..65535) */,
+	-1};
+
+/*** <<< STAT-DEFS [Soo] >>> ***/
+
+static asn_TYPE_member_t asn_MBR_Soo_1[] = {
+	{ ATF_NOFLAGS, 0, offsetof(struct Soo, foo),
+		.tag = (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)),
+		.tag_mode = 0,
+		.type = &asn_DEF_NativeInteger,
+		.type_selector = 0,
+		{ .oer_constraints = &asn_OER_memb_foo_constr_2, .per_constraints = 0, .general_constraints =  memb_foo_constraint_1 },
+		0, 0, /* No default value */
+		.name = "foo"
+		},
+	{ ATF_NOFLAGS, 0, offsetof(struct Soo, bar),
+		.tag = (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)),
+		.tag_mode = 0,
+		.type = &asn_DEF_Short,
+		.type_selector = 0,
+		{ .oer_constraints = 0, .per_constraints = 0, .general_constraints = 0 },
+		0, 0, /* No default value */
+		.name = "bar"
+		},
+	{ ATF_NOFLAGS, 0, offsetof(struct Soo, baz),
+		.tag = (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)),
+		.tag_mode = 0,
+		.type = &asn_DEF_Alias,
+		.type_selector = 0,
+		{ .oer_constraints = 0, .per_constraints = 0, .general_constraints = 0 },
+		0, 0, /* No default value */
+		.name = "baz"
+		},
+};
+static const ber_tlv_tag_t asn_DEF_Soo_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (16 << 2))
+};
+static const asn_TYPE_tag2member_t asn_MAP_Soo_tag2el_1[] = {
+    { (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)), 0, 0, 2 }, /* foo */
+    { (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)), 1, -1, 1 }, /* bar */
+    { (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)), 2, -2, 0 } /* baz */
+};
+static asn_SEQUENCE_specifics_t asn_SPC_Soo_specs_1 = {
+	sizeof(struct Soo),
+	offsetof(struct Soo, _asn_ctx),
+	.tag2el = asn_MAP_Soo_tag2el_1,
+	.tag2el_count = 3,	/* Count of tags in the map */
+	0, 0, 0,	/* Optional elements (not needed) */
+	-1,	/* First extension addition */
+};
+asn_TYPE_descriptor_t asn_DEF_Soo = {
+	"Soo",
+	"Soo",
+	&asn_OP_SEQUENCE,
+	asn_DEF_Soo_tags_1,
+	sizeof(asn_DEF_Soo_tags_1)
+		/sizeof(asn_DEF_Soo_tags_1[0]), /* 1 */
+	asn_DEF_Soo_tags_1,	/* Same as above */
+	sizeof(asn_DEF_Soo_tags_1)
+		/sizeof(asn_DEF_Soo_tags_1[0]), /* 1 */
+	{ 0, 0, SEQUENCE_constraint },
+	asn_MBR_Soo_1,
+	3,	/* Elements count */
+	&asn_SPC_Soo_specs_1	/* Additional specs */
+};
+
+
+/*** <<< asn_constant.h >>> ***/
+
+/*
+ * Generated by asn1c-0.9.29 (http://lionet.info/asn1c)
+ */
+
+#ifndef _ASN_CONSTANT_H
+#define _ASN_CONSTANT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define min_val_Short (0)
+#define max_val_Short (65535)
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ASN_CONSTANT_H */

--- a/tests/tests-asn1c-compiler/147-inherit-per-constraints-OK.asn1.-Pgen-PER
+++ b/tests/tests-asn1c-compiler/147-inherit-per-constraints-OK.asn1.-Pgen-PER
@@ -1,0 +1,315 @@
+
+/*** <<< INCLUDES [Short] >>> ***/
+
+#include <NativeInteger.h>
+
+/*** <<< TYPE-DECLS [Short] >>> ***/
+
+typedef long	 Short_t;
+
+/*** <<< FUNC-DECLS [Short] >>> ***/
+
+extern asn_per_constraints_t asn_PER_type_Short_constr_1;
+extern asn_TYPE_descriptor_t asn_DEF_Short;
+asn_struct_free_f Short_free;
+asn_struct_print_f Short_print;
+asn_constr_check_f Short_constraint;
+ber_type_decoder_f Short_decode_ber;
+der_type_encoder_f Short_encode_der;
+xer_type_decoder_f Short_decode_xer;
+xer_type_encoder_f Short_encode_xer;
+per_type_decoder_f Short_decode_uper;
+per_type_encoder_f Short_encode_uper;
+per_type_decoder_f Short_decode_aper;
+per_type_encoder_f Short_encode_aper;
+
+/*** <<< CODE [Short] >>> ***/
+
+int
+Short_constraint(const asn_TYPE_descriptor_t *td, const void *sptr,
+			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
+	long value;
+	
+	if(!sptr) {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: value not given (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+	
+	value = *(const long *)sptr;
+	
+	if((value >= 0 && value <= 65535)) {
+		/* Constraint check succeeded */
+		return 0;
+	} else {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: constraint failed (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+}
+
+/*
+ * This type is implemented using NativeInteger,
+ * so here we adjust the DEF accordingly.
+ */
+
+/*** <<< CTDEFS [Short] >>> ***/
+
+asn_per_constraints_t asn_PER_type_Short_constr_1 CC_NOTUSED = {
+	{ APC_CONSTRAINED,	 16,  16,  0,  65535 }	/* (0..65535) */,
+	{ APC_UNCONSTRAINED,	-1, -1,  0,  0 },
+	0, 0	/* No PER value map */
+};
+
+/*** <<< STAT-DEFS [Short] >>> ***/
+
+static const ber_tlv_tag_t asn_DEF_Short_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (2 << 2))
+};
+asn_TYPE_descriptor_t asn_DEF_Short = {
+	"Short",
+	"Short",
+	&asn_OP_NativeInteger,
+	asn_DEF_Short_tags_1,
+	sizeof(asn_DEF_Short_tags_1)
+		/sizeof(asn_DEF_Short_tags_1[0]), /* 1 */
+	asn_DEF_Short_tags_1,	/* Same as above */
+	sizeof(asn_DEF_Short_tags_1)
+		/sizeof(asn_DEF_Short_tags_1[0]), /* 1 */
+	{ 0, &asn_PER_type_Short_constr_1, Short_constraint },
+	0, 0,	/* No members */
+	0	/* No specifics */
+};
+
+
+/*** <<< INCLUDES [Alias] >>> ***/
+
+#include "Short.h"
+
+/*** <<< TYPE-DECLS [Alias] >>> ***/
+
+typedef Short_t	 Alias_t;
+
+/*** <<< FUNC-DECLS [Alias] >>> ***/
+
+extern asn_per_constraints_t asn_PER_type_Alias_constr_1;
+extern asn_TYPE_descriptor_t asn_DEF_Alias;
+asn_struct_free_f Alias_free;
+asn_struct_print_f Alias_print;
+asn_constr_check_f Alias_constraint;
+ber_type_decoder_f Alias_decode_ber;
+der_type_encoder_f Alias_encode_der;
+xer_type_decoder_f Alias_decode_xer;
+xer_type_encoder_f Alias_encode_xer;
+per_type_decoder_f Alias_decode_uper;
+per_type_encoder_f Alias_encode_uper;
+per_type_decoder_f Alias_decode_aper;
+per_type_encoder_f Alias_encode_aper;
+
+/*** <<< CODE [Alias] >>> ***/
+
+int
+Alias_constraint(const asn_TYPE_descriptor_t *td, const void *sptr,
+			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
+	long value;
+	
+	if(!sptr) {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: value not given (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+	
+	value = *(const long *)sptr;
+	
+	if((value >= 0 && value <= 65535)) {
+		/* Constraint check succeeded */
+		return 0;
+	} else {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: constraint failed (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+}
+
+/*
+ * This type is implemented using Short,
+ * so here we adjust the DEF accordingly.
+ */
+
+/*** <<< CTDEFS [Alias] >>> ***/
+
+asn_per_constraints_t asn_PER_type_Alias_constr_1 CC_NOTUSED = {
+	{ APC_CONSTRAINED,	 16,  16,  0,  65535 }	/* (0..65535) */,
+	{ APC_UNCONSTRAINED,	-1, -1,  0,  0 },
+	0, 0	/* No PER value map */
+};
+
+/*** <<< STAT-DEFS [Alias] >>> ***/
+
+static const ber_tlv_tag_t asn_DEF_Alias_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (2 << 2))
+};
+asn_TYPE_descriptor_t asn_DEF_Alias = {
+	"Alias",
+	"Alias",
+	&asn_OP_NativeInteger,
+	asn_DEF_Alias_tags_1,
+	sizeof(asn_DEF_Alias_tags_1)
+		/sizeof(asn_DEF_Alias_tags_1[0]), /* 1 */
+	asn_DEF_Alias_tags_1,	/* Same as above */
+	sizeof(asn_DEF_Alias_tags_1)
+		/sizeof(asn_DEF_Alias_tags_1[0]), /* 1 */
+	{ 0, &asn_PER_type_Alias_constr_1, Alias_constraint },
+	0, 0,	/* No members */
+	0	/* No specifics */
+};
+
+
+/*** <<< INCLUDES [Soo] >>> ***/
+
+#include <NativeInteger.h>
+#include "Short.h"
+#include "Alias.h"
+#include <constr_SEQUENCE.h>
+
+/*** <<< TYPE-DECLS [Soo] >>> ***/
+
+typedef struct Soo {
+	long	 foo;
+	Short_t	 bar;
+	Alias_t	 baz;
+	
+	/* Context for parsing across buffer boundaries */
+	asn_struct_ctx_t _asn_ctx;
+} Soo_t;
+
+/*** <<< FUNC-DECLS [Soo] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_Soo;
+
+/*** <<< CODE [Soo] >>> ***/
+
+static int
+memb_foo_constraint_1(const asn_TYPE_descriptor_t *td, const void *sptr,
+			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
+	long value;
+	
+	if(!sptr) {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: value not given (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+	
+	value = *(const long *)sptr;
+	
+	if((value >= 0 && value <= 65535)) {
+		/* Constraint check succeeded */
+		return 0;
+	} else {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: constraint failed (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+}
+
+
+/*** <<< CTDEFS [Soo] >>> ***/
+
+static asn_per_constraints_t asn_PER_memb_foo_constr_2 CC_NOTUSED = {
+	{ APC_CONSTRAINED,	 16,  16,  0,  65535 }	/* (0..65535) */,
+	{ APC_UNCONSTRAINED,	-1, -1,  0,  0 },
+	0, 0	/* No PER value map */
+};
+
+/*** <<< STAT-DEFS [Soo] >>> ***/
+
+static asn_TYPE_member_t asn_MBR_Soo_1[] = {
+	{ ATF_NOFLAGS, 0, offsetof(struct Soo, foo),
+		.tag = (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)),
+		.tag_mode = 0,
+		.type = &asn_DEF_NativeInteger,
+		.type_selector = 0,
+		{ .oer_constraints = 0, .per_constraints = &asn_PER_memb_foo_constr_2, .general_constraints =  memb_foo_constraint_1 },
+		0, 0, /* No default value */
+		.name = "foo"
+		},
+	{ ATF_NOFLAGS, 0, offsetof(struct Soo, bar),
+		.tag = (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)),
+		.tag_mode = 0,
+		.type = &asn_DEF_Short,
+		.type_selector = 0,
+		{ .oer_constraints = 0, .per_constraints = 0, .general_constraints = 0 },
+		0, 0, /* No default value */
+		.name = "bar"
+		},
+	{ ATF_NOFLAGS, 0, offsetof(struct Soo, baz),
+		.tag = (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)),
+		.tag_mode = 0,
+		.type = &asn_DEF_Alias,
+		.type_selector = 0,
+		{ .oer_constraints = 0, .per_constraints = 0, .general_constraints = 0 },
+		0, 0, /* No default value */
+		.name = "baz"
+		},
+};
+static const ber_tlv_tag_t asn_DEF_Soo_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (16 << 2))
+};
+static const asn_TYPE_tag2member_t asn_MAP_Soo_tag2el_1[] = {
+    { (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)), 0, 0, 2 }, /* foo */
+    { (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)), 1, -1, 1 }, /* bar */
+    { (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)), 2, -2, 0 } /* baz */
+};
+static asn_SEQUENCE_specifics_t asn_SPC_Soo_specs_1 = {
+	sizeof(struct Soo),
+	offsetof(struct Soo, _asn_ctx),
+	.tag2el = asn_MAP_Soo_tag2el_1,
+	.tag2el_count = 3,	/* Count of tags in the map */
+	0, 0, 0,	/* Optional elements (not needed) */
+	-1,	/* First extension addition */
+};
+asn_TYPE_descriptor_t asn_DEF_Soo = {
+	"Soo",
+	"Soo",
+	&asn_OP_SEQUENCE,
+	asn_DEF_Soo_tags_1,
+	sizeof(asn_DEF_Soo_tags_1)
+		/sizeof(asn_DEF_Soo_tags_1[0]), /* 1 */
+	asn_DEF_Soo_tags_1,	/* Same as above */
+	sizeof(asn_DEF_Soo_tags_1)
+		/sizeof(asn_DEF_Soo_tags_1[0]), /* 1 */
+	{ 0, 0, SEQUENCE_constraint },
+	asn_MBR_Soo_1,
+	3,	/* Elements count */
+	&asn_SPC_Soo_specs_1	/* Additional specs */
+};
+
+
+/*** <<< asn_constant.h >>> ***/
+
+/*
+ * Generated by asn1c-0.9.29 (http://lionet.info/asn1c)
+ */
+
+#ifndef _ASN_CONSTANT_H
+#define _ASN_CONSTANT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define min_val_Short (0)
+#define max_val_Short (65535)
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ASN_CONSTANT_H */

--- a/tests/tests-asn1c-compiler/155-parameterization-more-than-two-level-OK.asn1.+-P_-gen-UPER_-gen-APER
+++ b/tests/tests-asn1c-compiler/155-parameterization-more-than-two-level-OK.asn1.+-P_-gen-UPER_-gen-APER
@@ -1272,6 +1272,8 @@ asn_TYPE_descriptor_t asn_DEF_EXTERNAL = {
 extern "C" {
 #endif
 
+#define min_val_PacketId (0)
+#define max_val_PacketId (65535)
 #define max_items (256)
 
 

--- a/tests/tests-asn1c-compiler/32-sequence-of-OK.asn1.-P
+++ b/tests/tests-asn1c-compiler/32-sequence-of-OK.asn1.-P
@@ -1,0 +1,452 @@
+
+/*** <<< INCLUDES [Programming] >>> ***/
+
+#include <asn_SEQUENCE_OF.h>
+#include <constr_SEQUENCE_OF.h>
+
+/*** <<< FWD-DECLS [Programming] >>> ***/
+
+struct Fault;
+
+/*** <<< TYPE-DECLS [Programming] >>> ***/
+
+typedef struct Programming {
+	A_SEQUENCE_OF(struct Fault) list;
+	
+	/* Context for parsing across buffer boundaries */
+	asn_struct_ctx_t _asn_ctx;
+} Programming_t;
+
+/*** <<< FUNC-DECLS [Programming] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_Programming;
+
+/*** <<< POST-INCLUDE [Programming] >>> ***/
+
+#include "Fault.h"
+
+/*** <<< STAT-DEFS [Programming] >>> ***/
+
+static asn_TYPE_member_t asn_MBR_Programming_1[] = {
+	{ ATF_POINTER, 0, 0,
+		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
+		.tag_mode = -1,	/* IMPLICIT tag at current level */
+		.type = &asn_DEF_Fault,
+		.type_selector = 0,
+		{ .oer_constraints = 0, .per_constraints = 0, .general_constraints = 0 },
+		0, 0, /* No default value */
+		.name = ""
+		},
+};
+static const ber_tlv_tag_t asn_DEF_Programming_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (16 << 2))
+};
+static asn_SET_OF_specifics_t asn_SPC_Programming_specs_1 = {
+	sizeof(struct Programming),
+	offsetof(struct Programming, _asn_ctx),
+	0,	/* XER encoding is XMLDelimitedItemList */
+};
+asn_TYPE_descriptor_t asn_DEF_Programming = {
+	"Programming",
+	"Programming",
+	&asn_OP_SEQUENCE_OF,
+	asn_DEF_Programming_tags_1,
+	sizeof(asn_DEF_Programming_tags_1)
+		/sizeof(asn_DEF_Programming_tags_1[0]), /* 1 */
+	asn_DEF_Programming_tags_1,	/* Same as above */
+	sizeof(asn_DEF_Programming_tags_1)
+		/sizeof(asn_DEF_Programming_tags_1[0]), /* 1 */
+	{ 0, 0, SEQUENCE_OF_constraint },
+	asn_MBR_Programming_1,
+	1,	/* Single element */
+	&asn_SPC_Programming_specs_1	/* Additional specs */
+};
+
+
+/*** <<< INCLUDES [Fault] >>> ***/
+
+#include <asn_SET_OF.h>
+#include <constr_SET_OF.h>
+
+/*** <<< FWD-DECLS [Fault] >>> ***/
+
+struct Error;
+
+/*** <<< TYPE-DECLS [Fault] >>> ***/
+
+typedef struct Fault {
+	A_SET_OF(struct Error) list;
+	
+	/* Context for parsing across buffer boundaries */
+	asn_struct_ctx_t _asn_ctx;
+} Fault_t;
+
+/*** <<< FUNC-DECLS [Fault] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_Fault;
+extern asn_SET_OF_specifics_t asn_SPC_Fault_specs_1;
+extern asn_TYPE_member_t asn_MBR_Fault_1[1];
+
+/*** <<< POST-INCLUDE [Fault] >>> ***/
+
+#include "Error.h"
+
+/*** <<< STAT-DEFS [Fault] >>> ***/
+
+asn_TYPE_member_t asn_MBR_Fault_1[] = {
+	{ ATF_POINTER, 0, 0,
+		.tag = (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
+		.tag_mode = 0,
+		.type = &asn_DEF_Error,
+		.type_selector = 0,
+		{ .oer_constraints = 0, .per_constraints = 0, .general_constraints = 0 },
+		0, 0, /* No default value */
+		.name = ""
+		},
+};
+static const ber_tlv_tag_t asn_DEF_Fault_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (17 << 2))
+};
+asn_SET_OF_specifics_t asn_SPC_Fault_specs_1 = {
+	sizeof(struct Fault),
+	offsetof(struct Fault, _asn_ctx),
+	0,	/* XER encoding is XMLDelimitedItemList */
+};
+asn_TYPE_descriptor_t asn_DEF_Fault = {
+	"Fault",
+	"Fault",
+	&asn_OP_SET_OF,
+	asn_DEF_Fault_tags_1,
+	sizeof(asn_DEF_Fault_tags_1)
+		/sizeof(asn_DEF_Fault_tags_1[0]), /* 1 */
+	asn_DEF_Fault_tags_1,	/* Same as above */
+	sizeof(asn_DEF_Fault_tags_1)
+		/sizeof(asn_DEF_Fault_tags_1[0]), /* 1 */
+	{ 0, 0, SET_OF_constraint },
+	asn_MBR_Fault_1,
+	1,	/* Single element */
+	&asn_SPC_Fault_specs_1	/* Additional specs */
+};
+
+
+/*** <<< INCLUDES [Error] >>> ***/
+
+#include <constr_SEQUENCE.h>
+
+/*** <<< TYPE-DECLS [Error] >>> ***/
+
+typedef struct Error {
+	/*
+	 * This type is extensible,
+	 * possible extensions are below.
+	 */
+	
+	/* Context for parsing across buffer boundaries */
+	asn_struct_ctx_t _asn_ctx;
+} Error_t;
+
+/*** <<< FUNC-DECLS [Error] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_Error;
+extern asn_SEQUENCE_specifics_t asn_SPC_Error_specs_1;
+
+/*** <<< STAT-DEFS [Error] >>> ***/
+
+static const ber_tlv_tag_t asn_DEF_Error_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (16 << 2))
+};
+asn_SEQUENCE_specifics_t asn_SPC_Error_specs_1 = {
+	sizeof(struct Error),
+	offsetof(struct Error, _asn_ctx),
+	0,	/* No top level tags */
+	0,	/* No tags in the map */
+	0, 0, 0,	/* Optional elements (not needed) */
+	0,	/* First extension addition */
+};
+asn_TYPE_descriptor_t asn_DEF_Error = {
+	"Error",
+	"Error",
+	&asn_OP_SEQUENCE,
+	asn_DEF_Error_tags_1,
+	sizeof(asn_DEF_Error_tags_1)
+		/sizeof(asn_DEF_Error_tags_1[0]), /* 1 */
+	asn_DEF_Error_tags_1,	/* Same as above */
+	sizeof(asn_DEF_Error_tags_1)
+		/sizeof(asn_DEF_Error_tags_1[0]), /* 1 */
+	{ 0, 0, SEQUENCE_constraint },
+	0, 0,	/* No members */
+	&asn_SPC_Error_specs_1	/* Additional specs */
+};
+
+
+/*** <<< INCLUDES [SeqWithMandatory] >>> ***/
+
+#include <UTF8String.h>
+#include <asn_SEQUENCE_OF.h>
+#include <constr_SEQUENCE_OF.h>
+#include <constr_SEQUENCE.h>
+
+/*** <<< FWD-DECLS [SeqWithMandatory] >>> ***/
+
+struct Error;
+
+/*** <<< TYPE-DECLS [SeqWithMandatory] >>> ***/
+
+typedef struct SeqWithMandatory {
+	UTF8String_t	 someString;
+	struct seqOfMan {
+		A_SEQUENCE_OF(struct Error) list;
+		
+		/* Context for parsing across buffer boundaries */
+		asn_struct_ctx_t _asn_ctx;
+	} seqOfMan;
+	
+	/* Context for parsing across buffer boundaries */
+	asn_struct_ctx_t _asn_ctx;
+} SeqWithMandatory_t;
+
+/*** <<< FUNC-DECLS [SeqWithMandatory] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_SeqWithMandatory;
+
+/*** <<< POST-INCLUDE [SeqWithMandatory] >>> ***/
+
+#include "Error.h"
+
+/*** <<< STAT-DEFS [SeqWithMandatory] >>> ***/
+
+static asn_TYPE_member_t asn_MBR_seqOfMan_3[] = {
+	{ ATF_POINTER, 0, 0,
+		.tag = (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
+		.tag_mode = 0,
+		.type = &asn_DEF_Error,
+		.type_selector = 0,
+		{ .oer_constraints = 0, .per_constraints = 0, .general_constraints = 0 },
+		0, 0, /* No default value */
+		.name = ""
+		},
+};
+static const ber_tlv_tag_t asn_DEF_seqOfMan_tags_3[] = {
+	(ASN_TAG_CLASS_CONTEXT | (0 << 2)),
+	(ASN_TAG_CLASS_UNIVERSAL | (16 << 2))
+};
+static asn_SET_OF_specifics_t asn_SPC_seqOfMan_specs_3 = {
+	sizeof(struct seqOfMan),
+	offsetof(struct seqOfMan, _asn_ctx),
+	0,	/* XER encoding is XMLDelimitedItemList */
+};
+static /* Use -fall-defs-global to expose */
+asn_TYPE_descriptor_t asn_DEF_seqOfMan_3 = {
+	"seqOfMan",
+	"seqOfMan",
+	&asn_OP_SEQUENCE_OF,
+	asn_DEF_seqOfMan_tags_3,
+	sizeof(asn_DEF_seqOfMan_tags_3)
+		/sizeof(asn_DEF_seqOfMan_tags_3[0]), /* 2 */
+	asn_DEF_seqOfMan_tags_3,	/* Same as above */
+	sizeof(asn_DEF_seqOfMan_tags_3)
+		/sizeof(asn_DEF_seqOfMan_tags_3[0]), /* 2 */
+	{ 0, 0, SEQUENCE_OF_constraint },
+	asn_MBR_seqOfMan_3,
+	1,	/* Single element */
+	&asn_SPC_seqOfMan_specs_3	/* Additional specs */
+};
+
+static asn_TYPE_member_t asn_MBR_SeqWithMandatory_1[] = {
+	{ ATF_NOFLAGS, 0, offsetof(struct SeqWithMandatory, someString),
+		.tag = (ASN_TAG_CLASS_UNIVERSAL | (12 << 2)),
+		.tag_mode = 0,
+		.type = &asn_DEF_UTF8String,
+		.type_selector = 0,
+		{ .oer_constraints = 0, .per_constraints = 0, .general_constraints = 0 },
+		0, 0, /* No default value */
+		.name = "someString"
+		},
+	{ ATF_NOFLAGS, 0, offsetof(struct SeqWithMandatory, seqOfMan),
+		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
+		.tag_mode = 0,
+		.type = &asn_DEF_seqOfMan_3,
+		.type_selector = 0,
+		{ .oer_constraints = 0, .per_constraints = 0, .general_constraints = 0 },
+		0, 0, /* No default value */
+		.name = "seqOfMan"
+		},
+};
+static const ber_tlv_tag_t asn_DEF_SeqWithMandatory_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (16 << 2))
+};
+static const asn_TYPE_tag2member_t asn_MAP_SeqWithMandatory_tag2el_1[] = {
+    { (ASN_TAG_CLASS_UNIVERSAL | (12 << 2)), 0, 0, 0 }, /* someString */
+    { (ASN_TAG_CLASS_CONTEXT | (0 << 2)), 1, 0, 0 } /* seqOfMan */
+};
+static asn_SEQUENCE_specifics_t asn_SPC_SeqWithMandatory_specs_1 = {
+	sizeof(struct SeqWithMandatory),
+	offsetof(struct SeqWithMandatory, _asn_ctx),
+	.tag2el = asn_MAP_SeqWithMandatory_tag2el_1,
+	.tag2el_count = 2,	/* Count of tags in the map */
+	0, 0, 0,	/* Optional elements (not needed) */
+	-1,	/* First extension addition */
+};
+asn_TYPE_descriptor_t asn_DEF_SeqWithMandatory = {
+	"SeqWithMandatory",
+	"SeqWithMandatory",
+	&asn_OP_SEQUENCE,
+	asn_DEF_SeqWithMandatory_tags_1,
+	sizeof(asn_DEF_SeqWithMandatory_tags_1)
+		/sizeof(asn_DEF_SeqWithMandatory_tags_1[0]), /* 1 */
+	asn_DEF_SeqWithMandatory_tags_1,	/* Same as above */
+	sizeof(asn_DEF_SeqWithMandatory_tags_1)
+		/sizeof(asn_DEF_SeqWithMandatory_tags_1[0]), /* 1 */
+	{ 0, 0, SEQUENCE_constraint },
+	asn_MBR_SeqWithMandatory_1,
+	2,	/* Elements count */
+	&asn_SPC_SeqWithMandatory_specs_1	/* Additional specs */
+};
+
+
+/*** <<< INCLUDES [SeqWithOptional] >>> ***/
+
+#include <UTF8String.h>
+#include <asn_SEQUENCE_OF.h>
+#include <constr_SEQUENCE_OF.h>
+#include <constr_SEQUENCE.h>
+
+/*** <<< FWD-DECLS [SeqWithOptional] >>> ***/
+
+struct Error;
+
+/*** <<< TYPE-DECLS [SeqWithOptional] >>> ***/
+
+typedef struct SeqWithOptional {
+	UTF8String_t	 someString;
+	struct seqOfOpt {
+		A_SEQUENCE_OF(struct Error) list;
+		
+		/* Context for parsing across buffer boundaries */
+		asn_struct_ctx_t _asn_ctx;
+	} *seqOfOpt;
+	
+	/* Context for parsing across buffer boundaries */
+	asn_struct_ctx_t _asn_ctx;
+} SeqWithOptional_t;
+
+/*** <<< FUNC-DECLS [SeqWithOptional] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_SeqWithOptional;
+
+/*** <<< POST-INCLUDE [SeqWithOptional] >>> ***/
+
+#include "Error.h"
+
+/*** <<< STAT-DEFS [SeqWithOptional] >>> ***/
+
+static asn_TYPE_member_t asn_MBR_seqOfOpt_3[] = {
+	{ ATF_POINTER, 0, 0,
+		.tag = (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
+		.tag_mode = 0,
+		.type = &asn_DEF_Error,
+		.type_selector = 0,
+		{ .oer_constraints = 0, .per_constraints = 0, .general_constraints = 0 },
+		0, 0, /* No default value */
+		.name = ""
+		},
+};
+static const ber_tlv_tag_t asn_DEF_seqOfOpt_tags_3[] = {
+	(ASN_TAG_CLASS_CONTEXT | (0 << 2)),
+	(ASN_TAG_CLASS_UNIVERSAL | (16 << 2))
+};
+static asn_SET_OF_specifics_t asn_SPC_seqOfOpt_specs_3 = {
+	sizeof(struct seqOfOpt),
+	offsetof(struct seqOfOpt, _asn_ctx),
+	0,	/* XER encoding is XMLDelimitedItemList */
+};
+static /* Use -fall-defs-global to expose */
+asn_TYPE_descriptor_t asn_DEF_seqOfOpt_3 = {
+	"seqOfOpt",
+	"seqOfOpt",
+	&asn_OP_SEQUENCE_OF,
+	asn_DEF_seqOfOpt_tags_3,
+	sizeof(asn_DEF_seqOfOpt_tags_3)
+		/sizeof(asn_DEF_seqOfOpt_tags_3[0]), /* 2 */
+	asn_DEF_seqOfOpt_tags_3,	/* Same as above */
+	sizeof(asn_DEF_seqOfOpt_tags_3)
+		/sizeof(asn_DEF_seqOfOpt_tags_3[0]), /* 2 */
+	{ 0, 0, SEQUENCE_OF_constraint },
+	asn_MBR_seqOfOpt_3,
+	1,	/* Single element */
+	&asn_SPC_seqOfOpt_specs_3	/* Additional specs */
+};
+
+static asn_TYPE_member_t asn_MBR_SeqWithOptional_1[] = {
+	{ ATF_NOFLAGS, 0, offsetof(struct SeqWithOptional, someString),
+		.tag = (ASN_TAG_CLASS_UNIVERSAL | (12 << 2)),
+		.tag_mode = 0,
+		.type = &asn_DEF_UTF8String,
+		.type_selector = 0,
+		{ .oer_constraints = 0, .per_constraints = 0, .general_constraints = 0 },
+		0, 0, /* No default value */
+		.name = "someString"
+		},
+	{ ATF_POINTER, 1, offsetof(struct SeqWithOptional, seqOfOpt),
+		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
+		.tag_mode = 0,
+		.type = &asn_DEF_seqOfOpt_3,
+		.type_selector = 0,
+		{ .oer_constraints = 0, .per_constraints = 0, .general_constraints = 0 },
+		0, 0, /* No default value */
+		.name = "seqOfOpt"
+		},
+};
+static const ber_tlv_tag_t asn_DEF_SeqWithOptional_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (16 << 2))
+};
+static const asn_TYPE_tag2member_t asn_MAP_SeqWithOptional_tag2el_1[] = {
+    { (ASN_TAG_CLASS_UNIVERSAL | (12 << 2)), 0, 0, 0 }, /* someString */
+    { (ASN_TAG_CLASS_CONTEXT | (0 << 2)), 1, 0, 0 } /* seqOfOpt */
+};
+static asn_SEQUENCE_specifics_t asn_SPC_SeqWithOptional_specs_1 = {
+	sizeof(struct SeqWithOptional),
+	offsetof(struct SeqWithOptional, _asn_ctx),
+	.tag2el = asn_MAP_SeqWithOptional_tag2el_1,
+	.tag2el_count = 2,	/* Count of tags in the map */
+	0, 0, 0,	/* Optional elements (not needed) */
+	-1,	/* First extension addition */
+};
+asn_TYPE_descriptor_t asn_DEF_SeqWithOptional = {
+	"SeqWithOptional",
+	"SeqWithOptional",
+	&asn_OP_SEQUENCE,
+	asn_DEF_SeqWithOptional_tags_1,
+	sizeof(asn_DEF_SeqWithOptional_tags_1)
+		/sizeof(asn_DEF_SeqWithOptional_tags_1[0]), /* 1 */
+	asn_DEF_SeqWithOptional_tags_1,	/* Same as above */
+	sizeof(asn_DEF_SeqWithOptional_tags_1)
+		/sizeof(asn_DEF_SeqWithOptional_tags_1[0]), /* 1 */
+	{ 0, 0, SEQUENCE_constraint },
+	asn_MBR_SeqWithOptional_1,
+	2,	/* Elements count */
+	&asn_SPC_SeqWithOptional_specs_1	/* Additional specs */
+};
+
+
+/*** <<< asn_constant.h >>> ***/
+
+/*
+ * Generated by asn1c-0.9.29 (http://lionet.info/asn1c)
+ */
+
+#ifndef _ASN_CONSTANT_H
+#define _ASN_CONSTANT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define maxSize (10)
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ASN_CONSTANT_H */


### PR DESCRIPTION
A rebase of changes from https://gitlab.eurecom.fr/oai/asn1c/-/tree/velichkov_s1ap_plus_option_group onto vlm_master abd1faa6cf396ab1a4cddbe637f80316aa2cdef0. I hand checked that changes were applied. Caveat: in the skeletons directory some changes were not applied due to refactor that split files in the skeletons directory. There is a non-trivial diff set from the skeletons directory, but not knowing the implications of the changes I kept the code from vlm_master. It appears that this rebase and velichkov's branch have the same behavior in functional tests of the open air interface project which depends on asn1c.