### PR TITLE
aper: Fix regression reusing allocated sptr decoding CHOICE

### DIFF
--- a/skeletons/constr_CHOICE_aper.c
+++ b/skeletons/constr_CHOICE_aper.c
@@ -17,7 +17,7 @@ CHOICE_decode_aper(const asn_codec_ctx_t *opt_codec_ctx,
     asn_TYPE_member_t *elm = NULL;  /* CHOICE's element */
     void *memb_ptr = NULL;
     void **memb_ptr2 = NULL;
-    void *st = *sptr = NULL;
+    void *st = *sptr;
     int value = 0;
 
     if(ASN__STACK_OVERFLOW_CHECK(opt_codec_ctx))


### PR DESCRIPTION
Recent commit abd1faa6cf396ab1a4cddbe637f80316aa2cdef0 broke passing
already existing output decoded structre as sptr. As a result, a new
sptr was always allocated, and the old one leaked.

Fixes: abd1faa6cf396ab1a4cddbe637f80316aa2cdef0