### PR TITLE
Remove JER whitespace

### DIFF
--- a/skeletons/BIT_STRING_jer.c
+++ b/skeletons/BIT_STRING_jer.c
@@ -20,7 +20,6 @@ BIT_STRING_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr,
     char *p = scratch;
     char *scend = scratch + (sizeof(scratch) - 10);
     const BIT_STRING_t *st = (const BIT_STRING_t *)sptr;
-    int xcan = 0;
     uint8_t *buf;
     uint8_t *end;
 
@@ -37,19 +36,15 @@ BIT_STRING_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr,
      */
     for(; buf < end; buf++) {
         int v = *buf;
-        int nline = xcan?0:(((buf - st->buf) % 8) == 0);
-        if(p >= scend || nline) {
+        if(p >= scend) {
             ASN__CALLBACK(scratch, p - scratch);
             p = scratch;
-            if(nline) ASN__TEXT_INDENT(1, ilevel);
         }
         memcpy(p + 0, _bit_pattern[v >> 4], 4);
         memcpy(p + 4, _bit_pattern[v & 0x0f], 4);
         p += 8;
     }
 
-    if(!xcan && ((buf - st->buf) % 8) == 0)
-        ASN__TEXT_INDENT(1, ilevel);
     ASN__CALLBACK(scratch, p - scratch);
     p = scratch;
 
@@ -61,8 +56,6 @@ BIT_STRING_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr,
             *p++ = (v & (1 << i)) ? 0x31 : 0x30;
         ASN__CALLBACK(scratch, p - scratch);
     }
-
-    if(!xcan) ASN__TEXT_INDENT(1, ilevel - 1);
 
     ASN__ENCODED_OK(er);
 cb_failed:

--- a/skeletons/OCTET_STRING_jer.c
+++ b/skeletons/OCTET_STRING_jer.c
@@ -31,20 +31,17 @@ OCTET_STRING_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr,
     buf = st->buf;
     end = buf + st->size;
     for(i = 0; buf < end; buf++, i++) {
-      if(!(i % 16) && (i || st->size > 16)) {
-        ASN__CALLBACK(scratch, p-scratch);
-        p = scratch;
-        ASN__TEXT_INDENT(1, ilevel);
-      }
-      *p++ = h2c[(*buf >> 4) & 0x0F];
-      *p++ = h2c[*buf & 0x0F];
-      *p++ = 0x20;
+        if(!(i % 16) && (i || st->size > 16)) {
+            ASN__CALLBACK(scratch, p-scratch);
+            p = scratch;
+        }
+        *p++ = h2c[(*buf >> 4) & 0x0F];
+        *p++ = h2c[*buf & 0x0F];
+        *p++ = 0x20;
     }
     if(p - scratch) {
-      p--;  /* Remove the tail space */
-      ASN__CALLBACK3("\"", 1, scratch, p-scratch, "\"", 1);  /* Dump the rest */
-      if(st->size > 16)
-        ASN__TEXT_INDENT(1, ilevel-1);
+        p--;  /* Remove the tail space */
+        ASN__CALLBACK3("\"", 1, scratch, p-scratch, "\"", 1);  /* Dump the rest */
     }
 
     ASN__ENCODED_OK(er);
@@ -107,8 +104,8 @@ static const struct OCTET_STRING__jer_escape_table_s {
 
 asn_enc_rval_t
 OCTET_STRING_encode_jer_utf8(const asn_TYPE_descriptor_t *td, const void *sptr,
-                             int ilevel, enum jer_encoder_flags_e flags,
-                             asn_app_consume_bytes_f *cb, void *app_key) {
+        int ilevel, enum jer_encoder_flags_e flags,
+        asn_app_consume_bytes_f *cb, void *app_key) {
     const OCTET_STRING_t *st = (const OCTET_STRING_t *)sptr;
     asn_enc_rval_t er = { 0, 0, 0 };
     uint8_t *buf, *end;
@@ -131,10 +128,10 @@ OCTET_STRING_encode_jer_utf8(const asn_TYPE_descriptor_t *td, const void *sptr,
          * Escape certain characters: X.680/11.15
          */
         if(ch < sizeof(OCTET_STRING__jer_escape_table)
-            / sizeof(OCTET_STRING__jer_escape_table[0])
-        && (s_len = OCTET_STRING__jer_escape_table[ch].size)) {
+                / sizeof(OCTET_STRING__jer_escape_table[0])
+                && (s_len = OCTET_STRING__jer_escape_table[ch].size)) {
             if(((buf - ss) && cb(ss, buf - ss, app_key) < 0)
-            || cb(OCTET_STRING__jer_escape_table[ch].string, s_len, app_key) < 0)
+                    || cb(OCTET_STRING__jer_escape_table[ch].string, s_len, app_key) < 0)
                 ASN__ENCODE_FAILED;
             encoded_len += (buf - ss) + s_len;
             ss = buf + 1;

--- a/skeletons/constr_CHOICE_jer.c
+++ b/skeletons/constr_CHOICE_jer.c
@@ -62,7 +62,7 @@ CHOICE_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
 
         er.encoded = 0;
 
-        ASN__CALLBACK3("{\n\"", 3, mname, mlen, "\": ", 2);
+        ASN__CALLBACK3("{\"", 2, mname, mlen, "\":", 2);
 
         tmper = elm->type->op->jer_encoder(elm->type, memb_ptr,
                                            ilevel + 1, flags, cb, app_key);
@@ -70,7 +70,6 @@ CHOICE_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
         er.encoded += tmper.encoded;
 
         ASN__CALLBACK("}", 1);
-        //        ASN__CALLBACK3("</", 2, mname, mlen, ">", 1);
     }
 
     ASN__ENCODED_OK(er);

--- a/skeletons/constr_SEQUENCE_OF_jer.c
+++ b/skeletons/constr_SEQUENCE_OF_jer.c
@@ -19,7 +19,6 @@ SEQUENCE_OF_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr,
                             ? 0
                             : ((*elm->name) ? elm->name : elm->type->xml_tag);
     size_t mlen = mname ? strlen(mname) : 0;
-    int xcan = 0;
     int i;
 
     if(!sptr) ASN__ENCODE_FAILED;
@@ -33,7 +32,6 @@ SEQUENCE_OF_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr,
         if(!memb_ptr) continue;
 
         if(mname) {
-            if(!xcan) ASN__TEXT_INDENT(1, ilevel);
             ASN__CALLBACK3("{\"", 2, mname, mlen, "\":", 2);
         }
 
@@ -44,7 +42,6 @@ SEQUENCE_OF_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr,
         if(tmper.encoded == 0 && specs->as_XMLValueList) {
             const char *name = elm->type->xml_tag;
             size_t len = strlen(name);
-            if(!xcan) ASN__TEXT_INDENT(1, ilevel + 1);
             ASN__CALLBACK3("\"", 1, name, len, "\"", 1);
         }
 
@@ -56,7 +53,6 @@ SEQUENCE_OF_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr,
         }
     }
 
-    if(!xcan) ASN__TEXT_INDENT(1, ilevel - 1);
     ASN__CALLBACK("]", 1);
 
     ASN__ENCODED_OK(er);

--- a/skeletons/constr_SEQUENCE_jer.c
+++ b/skeletons/constr_SEQUENCE_jer.c
@@ -11,7 +11,6 @@ asn_enc_rval_t SEQUENCE_encode_jer(const asn_TYPE_descriptor_t *td, const void *
                     int ilevel, enum jer_encoder_flags_e flags,
                     asn_app_consume_bytes_f *cb, void *app_key) {
     asn_enc_rval_t er = {0,0,0};
-    int xcan = 0;
     asn_TYPE_descriptor_t *tmp_def_val_td = 0;
     void *tmp_def_val = 0;
     size_t edx;
@@ -21,7 +20,7 @@ asn_enc_rval_t SEQUENCE_encode_jer(const asn_TYPE_descriptor_t *td, const void *
     er.encoded = 0;
 
     int bAddComma = 0;
-    ASN__CALLBACK("{\n", 2);
+    ASN__CALLBACK("{", 1);
     for(edx = 0; edx < td->elements_count; edx++) {
         asn_enc_rval_t tmper = {0,0,0};
         asn_TYPE_member_t *elm = &td->elements[edx];
@@ -57,8 +56,7 @@ asn_enc_rval_t SEQUENCE_encode_jer(const asn_TYPE_descriptor_t *td, const void *
           bAddComma = 0;
         }
 
-        if(!xcan) ASN__TEXT_INDENT(1, ilevel);
-        ASN__CALLBACK3("\"", 1, mname, mlen, "\": ", 3);
+        ASN__CALLBACK3("\"", 1, mname, mlen, "\":", 2);
 
         /* Print the member itself */
         tmper = elm->type->op->jer_encoder(elm->type, memb_ptr, ilevel + 1,
@@ -74,8 +72,6 @@ asn_enc_rval_t SEQUENCE_encode_jer(const asn_TYPE_descriptor_t *td, const void *
         }
     }
     ASN__CALLBACK("}", 1);
-
-    if(!xcan) ASN__TEXT_INDENT(1, ilevel - 1);
 
     ASN__ENCODED_OK(er);
 cb_failed:

--- a/skeletons/constr_SET_OF_jer.c
+++ b/skeletons/constr_SET_OF_jer.c
@@ -55,7 +55,6 @@ SET_OF_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
     const char *mname = specs->as_XMLValueList
         ? 0 : ((*elm->name) ? elm->name : elm->type->xml_tag);
     size_t mlen = mname ? strlen(mname) : 0;
-    int xcan = 0;
     jer_tmp_enc_t *encs = 0;
     size_t encs_count = 0;
     void *original_app_key = app_key;
@@ -64,11 +63,6 @@ SET_OF_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
 
     if(!sptr) ASN__ENCODE_FAILED;
 
-    if(xcan) {
-        encs = (jer_tmp_enc_t *)MALLOC(list->count * sizeof(encs[0]));
-        if(!encs) ASN__ENCODE_FAILED;
-        cb = SET_OF_encode_jer_callback;
-    }
 
     er.encoded = 0;
 
@@ -85,12 +79,9 @@ SET_OF_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
         }
 
         if(mname) {
-            if(!xcan) ASN__TEXT_INDENT(1, ilevel);
             ASN__CALLBACK3("\"", 1, mname, mlen, "\"", 1);
         }
 
-        if(!xcan && specs->as_XMLValueList == 1)
-            ASN__TEXT_INDENT(1, ilevel + 1);
         tmper = elm->type->op->jer_encoder(elm->type, memb_ptr,
                                            ilevel + (specs->as_XMLValueList != 2),
                                            flags, cb, app_key);
@@ -107,8 +98,6 @@ SET_OF_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
         /* } */
 
     }
-
-    if(!xcan) ASN__TEXT_INDENT(1, ilevel - 1);
 
     if(encs) {
         jer_tmp_enc_t *enc = encs;

--- a/skeletons/constr_SET_jer.c
+++ b/skeletons/constr_SET_jer.c
@@ -12,7 +12,6 @@ SET_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
                void *app_key) {
     const asn_SET_specifics_t *specs = (const asn_SET_specifics_t *)td->specifics;
     asn_enc_rval_t er;
-    int xcan = 0;
     const asn_TYPE_tag2member_t *t2m = specs->tag2el_cxer;
     size_t t2m_count = specs->tag2el_cxer_count;
     size_t edx;
@@ -48,8 +47,6 @@ SET_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
             memb_ptr = (const void *)((const char *)sptr + elm->memb_offset);
         }
 
-        if(!xcan)
-            ASN__TEXT_INDENT(1, ilevel);
         ASN__CALLBACK3("\"", 1, mname, mlen, "\"", 1);
 
         /* Print the member itself */
@@ -58,11 +55,7 @@ SET_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
                                            cb, app_key);
         if(tmper.encoded == -1) return tmper;
         er.encoded += tmper.encoded;
-
-        //        ASN__CALLBACK3("</", 2, mname, mlen, ">", 1);
     }
-
-    if(!xcan) ASN__TEXT_INDENT(1, ilevel - 1);
 
     ASN__ENCODED_OK(er);
 cb_failed:

--- a/skeletons/jer_encoder.c
+++ b/skeletons/jer_encoder.c
@@ -14,28 +14,27 @@ jer_encode(const asn_TYPE_descriptor_t *td, const void *sptr,
            asn_app_consume_bytes_f *cb,
            void *app_key) {
     asn_enc_rval_t er = {0, 0, 0};
-	asn_enc_rval_t tmper;
-	const char *mname;
-	size_t mlen;
+    asn_enc_rval_t tmper;
+    const char *mname;
+    size_t mlen;
 
-	if(!td || !sptr) goto cb_failed;
+    if(!td || !sptr) goto cb_failed;
 
-	mname = td->xml_tag;
-	mlen = strlen(mname);
+    mname = td->xml_tag;
+    mlen = strlen(mname);
 
-	ASN__CALLBACK3("{\n\"", 3, mname, mlen, "\":", 2);
+    ASN__CALLBACK3("{\"", 2, mname, mlen, "\":", 2);
 
         int xFlag = 0;
-	tmper = td->op->jer_encoder(td, sptr, 1, xFlag, cb, app_key);
-	if(tmper.encoded == -1) return tmper;
-	er.encoded += tmper.encoded;
+    tmper = td->op->jer_encoder(td, sptr, 1, xFlag, cb, app_key);
+    if(tmper.encoded == -1) return tmper;
+    er.encoded += tmper.encoded;
 
         ASN__CALLBACK("}", 1);
-        //	ASN__CALLBACK3("</", 2, mname, mlen, ">\n", xcan);
 
-	ASN__ENCODED_OK(er);
+    ASN__ENCODED_OK(er);
 cb_failed:
-	ASN__ENCODE_FAILED;
+    ASN__ENCODE_FAILED;
 }
 
 /*
@@ -44,26 +43,26 @@ cb_failed:
  */
 static int
 jer__print2fp(const void *buffer, size_t size, void *app_key) {
-	FILE *stream = (FILE *)app_key;
+    FILE *stream = (FILE *)app_key;
 
-	if(fwrite(buffer, 1, size, stream) != size)
-		return -1;
+    if(fwrite(buffer, 1, size, stream) != size)
+        return -1;
 
-	return 0;
+    return 0;
 }
 
 int
 jer_fprint(FILE *stream, const asn_TYPE_descriptor_t *td, const void *sptr) {
-	asn_enc_rval_t er = {0,0,0};
+    asn_enc_rval_t er = {0,0,0};
 
-	if(!stream) stream = stdout;
-	if(!td || !sptr)
-		return -1;
+    if(!stream) stream = stdout;
+    if(!td || !sptr)
+        return -1;
 
-	er = jer_encode(td, sptr, jer__print2fp, stream);
-	if(er.encoded == -1)
-		return -1;
+    er = jer_encode(td, sptr, jer__print2fp, stream);
+    if(er.encoded == -1)
+        return -1;
 
-	return fflush(stream);
+    return fflush(stream);
 }
 


### PR DESCRIPTION
It was wrongly formatted, and I don't think it's helpful to format JSON
until you want to display it anyway.


Old behavior:
```
{
"MessageFrame":{

    "messageId": 32,
    "value": {
"PersonalSafetyMessage":{

            "basicType": "unavailable",
            "secMark": 65535,
            "msgCnt": 105,
            "id": "5D D7 5A 8C",
            "position": {

                "lat": 900000001,
                "long": 1800000001,
                "elevation": -4096}
            ,
            "accuracy": {

                "semiMajor": 255,
                "semiMinor": 255,
                "orientation": 65535}
            ,
            "speed": 8191,
            "heading": 28800,
            "accelSet": {

                "long": 2001,
                "lat": 2001,
                "vert": -127,
                "yaw": 0}
            ,
            "pathHistory": {

                "initialPosition": {

                    "utcTime": {

                        "year": 0,
                        "month": 0,
                        "day": 0,
                        "hour": 31,
                        "minute": 60,
                        "second": 65535,
                        "offset": 0}
                    ,
                    "long": 1800000001,
                    "lat": 900000001,
                    "elevation": -4096,
                    "posAccuracy": {

                        "semiMajor": 255,
                        "semiMinor": 255,
                        "orientation": 65535}
                    }
                ,
                "crumbData": [
                    {"PathHistoryPoint":{

                        "latOffset": -131072,
                        "lonOffset": -131072,
                        "elevationOffset": -2048,
                        "timeOffset": 65535}
                    }
                ]}
            }
        }}
}
```
New behavior
```
{"MessageFrame":{"messageId": 32,"value": {"PersonalSafetyMessage":{"basicType": "unavailable","secMark": 65535,"msgCnt": 7,"id": "5D D7 5A 8C","position": {"lat": 900000001,"long": 1800000001,"elevation": -4096},"accuracy": {"semiMajor": 255,"semiMinor": 255,"orientation": 65535},"speed": 8191,"heading": 28800,"accelSet": {"long": 2001,"lat": 2001,"vert": -127,"yaw": 0},"pathHistory": {"initialPosition": {"utcTime": {"year": 0,"month": 0,"day": 0,"hour": 31,"minute": 60,"second": 65535,"offset": 0},"long": 1800000001,"lat": 900000001,"elevation": -4096,"posAccuracy": {"semiMajor": 255,"semiMinor": 255,"orientation": 65535}},"crumbData": [{"PathHistoryPoint":{"latOffset": -131072,"lonOffset": -131072,"elevationOffset": -2048,"timeOffset": 65535}}]}}}}}
```
