### PR TITLE
Double quote is treated as an invalid character in strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ stamp-h*
 /tests/tests-asn1c-smoke/*.asn
 /tests/tests-asn1c-smoke/*.txt
 /tests/tests-asn1c-smoke/converter-example
+/tests/tests-asn1c-smoke/test-*
 
 # /tests/
 /tests/tests-c-compiler/test-*
@@ -96,6 +97,7 @@ doc/docsrc/*.xdv
 /libasn1parser/asn1p_l.c
 /libasn1parser/asn1p_y.c
 /libasn1parser/asn1p_y.h
+/libasn1parser/lex.yyasn1p_l.c
 
 #code coverage
 *.gcno

--- a/libasn1parser/asn1p_l.l
+++ b/libasn1parser/asn1p_l.l
@@ -539,7 +539,7 @@ WITH			return TOK_WITH;
 
 [(){},;:|!.&@\[\]^]	return yytext[0];
 
-[^A-Za-z0-9:=,{}<.@()[]'\"|&^*;!-] {
+[^A-Za-z0-9:=,{}<.@()[]'\\"|&^*;!-] {
 		if(TYPE_LIFETIME(1994, 0))
 			fprintf(stderr, "ERROR: ");
 		fprintf(stderr,


### PR DESCRIPTION
I discovered this while parsing the OMA LPPe specification which has this definition:
`OMA-LPPe-Uri ::= VisibleString (FROM ( "a".."z" | "A".."Z" | "0".."9" | ":" | "/" | "?" | "#" | "[" | "]" | "@" | "!" | "$" | "&" | "'" | "(" | ")" | "*" | "+" | "," | ";" | "=" | "-" | "." | "_" | "~" | "%"  ))`

Which resulted in this error:
```
ERROR: Symbol '"' at line 487 is prohibited by ASN.1:1994 and ASN.1:1997
ASN.1 grammar parse error near OMA-TS-LPPe-V1_0-20200630-D.asn1:487 (token ""'""): syntax error, unexpected $end
Cannot parse "OMA-TS-LPPe-V1_0-20200630-D.asn1"
```

I traced the first error to https://github.com/mouse07410/asn1c/blob/vlm_master/libasn1parser/asn1p_l.l#L542

The regex on that line is attempting to match any character not valid in the ASN.1 source file. However in regex `\` is a special character, even in inside a character class as explained by https://github.com/westes/flex/blob/master/doc/flex.texi#L888-L894

Properly escaping the `\` with `\\` fixes the issue and I no longer get the incorrect error message.

This PR also adds some more `.gitignore` files that git was finding after compiling asn1c.