### PR TITLE
rename ATS_BASIC_JER to ATS_JER

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,19 @@ If you need to _process_ data conforming to the standard(s) specified in the
 column 3, use the API function specified in column 4.
 See the [doc/asn1c-usage.pdf](doc/asn1c-usage.pdf) for details.
 
-Encoding       | API function       | Understood by | API function
--------------- | ------------------ | ------------- | -------------
-BER            | der_encode()       | BER           | ber_decode()
-DER            | der_encode()       | DER, BER      | ber_decode()
-CER            | _not supported_    | CER, BER      | ber_decode()
-BASIC-OER      | oer_encode()       | *-OER         | oer_decode()
-CANONICAL-OER  | oer_encode()       | *-OER         | oer_decode()
-BASIC-UPER     | uper_encode()      | *-UPER        | uper_decode()
-CANONICAL-UPER | uper_encode()      | *-UPER        | uper_decode()
-*-APER         | _not supported_    | *-APER        | _not supported_
-BASIC-XER      | xer_encode(XER_F_BASIC)    | *-XER | xer_decode()
-CANONICAL-XER  | xer_encode(XER_F_CANONICAL)| *-XER | xer_decode()
+Encoding       | API function               | Understood by | API function
+-------------- | -------------------------- | ------------- | -------------
+BER            | der_encode()               | BER           | ber_decode()
+DER            | der_encode()               | DER, BER      | ber_decode()
+CER            | _not supported_            | CER, BER      | ber_decode()
+BASIC-OER      | oer_encode()               | *-OER         | oer_decode()
+CANONICAL-OER  | oer_encode()               | *-OER         | oer_decode()
+BASIC-UPER     | uper_encode()              | *-UPER        | uper_decode()
+CANONICAL-UPER | uper_encode()              | *-UPER        | uper_decode()
+*-APER         | _not supported_            | *-APER        | _not supported_
+BASIC-XER      | xer_encode(XER_F_BASIC)    | *-XER         | xer_decode()
+CANONICAL-XER  | xer_encode(XER_F_CANONICAL)| *-XER         | xer_decode()
+JER            | jer_encode()               | JER           | _not supported_
 
 *) Asterisk means both BASIC and CANONICAL variants.
 </details>

--- a/skeletons/asn_application.c
+++ b/skeletons/asn_application.c
@@ -432,7 +432,7 @@ asn_encode_internal(const asn_codec_ctx_t *opt_codec_ctx,
 #endif  /* !defined(ASN_DISABLE_XER_SUPPORT) */
 
 #if !defined(ASN_DISABLE_JER_SUPPORT)
-    case ATS_BASIC_JER:
+    case ATS_JER:
         if(td->op->jer_encoder) {
             er = jer_encode(td, sptr, callback, callback_key);
             if(er.encoded == -1) {

--- a/skeletons/asn_application.h
+++ b/skeletons/asn_application.h
@@ -61,7 +61,7 @@ enum asn_transfer_syntax {
      */
     ATS_BASIC_XER,
     ATS_CANONICAL_XER,
-    ATS_BASIC_JER,
+    ATS_JER,
 };
 
 /*

--- a/skeletons/converter-example.c
+++ b/skeletons/converter-example.c
@@ -123,7 +123,7 @@ ats_simple_name(enum asn_transfer_syntax syntax) {
     case ATS_BASIC_XER:
     case ATS_CANONICAL_XER:
         return "XER";
-    case ATS_BASIC_JER:
+    case ATS_JER:
       return "JER";
     case ATS_UNALIGNED_BASIC_PER:
     case ATS_UNALIGNED_CANONICAL_PER:
@@ -172,7 +172,7 @@ static syntax_selector output_encodings[] = {
      "Output as Aligned PER (Packed Encoding Rules)"},
     {"xer", ATS_BASIC_XER, CODEC_OFFSET(xer_encoder),
      "Output as XER (XML Encoding Rules)"},
-    {"jer", ATS_BASIC_JER, CODEC_OFFSET(jer_encoder),
+    {"jer", ATS_JER, CODEC_OFFSET(jer_encoder),
      "Output as JER (JSON Encoding Rules)"},
     {"text", ATS_NONSTANDARD_PLAINTEXT, CODEC_OFFSET(print_struct),
      "Output as plain semi-structured text"},
@@ -432,7 +432,7 @@ main(int ac, char *av[]) {
         const int is_text_output = osyntax == ATS_NONSTANDARD_PLAINTEXT
                                    || osyntax == ATS_BASIC_XER
                                    || osyntax == ATS_CANONICAL_XER
-                                   || osyntax == ATS_BASIC_JER;
+                                   || osyntax == ATS_JER;
         if(is_text_output) {
             binary_out = stdout;
         } else {

--- a/skeletons/jer_encoder.h
+++ b/skeletons/jer_encoder.h
@@ -13,15 +13,20 @@ extern "C" {
 
 struct asn_TYPE_descriptor_s;	/* Forward declaration */
 
-/* Flags used by the jer_encode() and (*jer_type_encoder_f), defined below */
+/* Flags used by the jer_encode() and (*jer_type_encoder_f), defined below
+ *
+ * This isn't actually used, it might be used in the future to support
+ * both normal JSON and prettified JSON output or removed.
+ * It came from XER
+ */
 enum jer_encoder_flags_e {
 	/* Mode of encoding */
-	JER_F_BASIC	= 0x01,	/* BASIC-JER (pretty-printing) */
+	JER_F	= 0x01,	/* JER (pretty-printing) */
 };
 
 /*
  * The JER encoder of any type. May be invoked by the application.
- * Produces CANONICAL-JER and BASIC-JER depending on the (jer_flags).
+ * Produces JER output.
  */
 asn_enc_rval_t jer_encode(const struct asn_TYPE_descriptor_s *type_descriptor,
                           const void *struct_ptr, /* Structure to be encoded */
@@ -30,7 +35,7 @@ asn_enc_rval_t jer_encode(const struct asn_TYPE_descriptor_s *type_descriptor,
 );
 
 /*
- * The variant of the above function which dumps the BASIC-JER (JER_F_BASIC)
+ * The variant of the above function which dumps the JER
  * output into the chosen file pointer.
  * RETURN VALUES:
  * 	 0: The structure is printed.
@@ -42,9 +47,9 @@ int jer_fprint(FILE *stream, const struct asn_TYPE_descriptor_s *td,
 
 /*
  * A helper function that uses JER encoding/decoding to verify that:
- * - Both structures encode into the same BASIC JER.
+ * - Both structures encode into the same JER.
  * - Both resulting JER byte streams can be decoded back.
- * - Both decoded structures encode into the same BASIC JER (round-trip).
+ * - Both decoded structures encode into the same JER (round-trip).
  * All of this verifies equivalence between structures and a round-trip.
  * ARGUMENTS:
  *  (opt_debug_stream)  - If specified, prints ongoing details.


### PR DESCRIPTION
When JER was added it was based on XER, which has BASIC-XER and CANONICAL-XER.
So originally we had BASIC-JER, which isn't a real thing.

This renames ATS_BASIC_JER to ATS_JER and adds JER in the list of encodings in the readme.

This is a breaking change because you use ATS_BASIC_JER when calling asn_encode, do we have any process to call that out?
