### PR TITLE
fix issue #126: decoding extensible CHOICE error

### DIFF
--- a/skeletons/constr_CHOICE_aper.c
+++ b/skeletons/constr_CHOICE_aper.c
@@ -53,8 +53,8 @@ CHOICE_decode_aper(const asn_codec_ctx_t *opt_codec_ctx,
         if(specs->ext_start == -1)
             ASN__DECODE_FAILED;
 
-        if (ct && ct->upper_bound >= ct->lower_bound) {
-            value = aper_get_nsnnwn(pd, ct->upper_bound - ct->lower_bound + 1);
+        if(specs && specs->tag2el_count > specs->ext_start) {
+            value = aper_get_nsnnwn(pd, specs->tag2el_count - specs->ext_start); /* extension elements range */
             if(value < 0) ASN__DECODE_STARVED;
             value += specs->ext_start;
             if((unsigned)value >= td->elements_count)


### PR DESCRIPTION
The constraints ``ct`` was not effective for extensible CHOICE, so if ``ct && ct->flags & APC_EXTENSIBLE`` was true, ``ct`` was set to ``0``. 
```
if(ct && ct->flags & APC_EXTENSIBLE) {
    value = per_get_few_bits(pd, 1);
    if(value < 0) ASN__DECODE_STARVED;
    if(value) ct = 0;  /* Not restricted */
}
```
Using normal CHOICE constraint in decoding extensible CHOICE was weird.
We should change the normal CHOICE constraint to extensible CHOICE constraint when decoding extensible CHOICE,
the extensible CHOICE constraint was ``lb=0,ub=specs->tag2el_count - specs->ext_start - 1``. So the conditional structure
should be if ``specs && specs->tag2el_count > specs->ext_start``, then decoding the CHOICE which range
was ``specs->tag2el_count - specs->ext_start``, and add ``specs->ext_start`` to ``value`` in the last.