### PR TITLE
JER BIT STRING quoted hex

### DIFF
--- a/skeletons/BIT_STRING_jer.c
+++ b/skeletons/BIT_STRING_jer.c
@@ -6,11 +6,6 @@
 #include <asn_internal.h>
 #include <BIT_STRING.h>
 
-static const char *_bit_pattern[16] = {
-    "0000", "0001", "0010", "0011", "0100", "0101", "0110", "0111",
-    "1000", "1001", "1010", "1011", "1100", "1101", "1110", "1111"
-};
-
 asn_enc_rval_t
 BIT_STRING_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr,
                       int ilevel, enum jer_encoder_flags_e flags,
@@ -18,9 +13,9 @@ BIT_STRING_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr,
     asn_enc_rval_t er = {0, 0, 0};
     char scratch[128];
     char *p = scratch;
-    char *scend = scratch + (sizeof(scratch) - 10);
+    char *scend = scratch + (sizeof(scratch) - 4);
     const BIT_STRING_t *st = (const BIT_STRING_t *)sptr;
-    int xcan = 0;
+    int xcan = 1;
     uint8_t *buf;
     uint8_t *end;
 
@@ -35,6 +30,7 @@ BIT_STRING_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr,
     /*
      * Binary dump
      */
+    *p++ = '"';
     for(; buf < end; buf++) {
         int v = *buf;
         int nline = xcan?0:(((buf - st->buf) % 8) == 0);
@@ -43,9 +39,7 @@ BIT_STRING_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr,
             p = scratch;
             if(nline) ASN__TEXT_INDENT(1, ilevel);
         }
-        memcpy(p + 0, _bit_pattern[v >> 4], 4);
-        memcpy(p + 4, _bit_pattern[v & 0x0f], 4);
-        p += 8;
+        p += sprintf(p, "%02x", v);
     }
 
     if(!xcan && ((buf - st->buf) % 8) == 0)
@@ -54,15 +48,15 @@ BIT_STRING_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr,
     p = scratch;
 
     if(buf == end) {
-        int v = *buf;
+        uint8_t v = *buf;
         int ubits = st->bits_unused;
-        int i;
-        for(i = 7; i >= ubits; i--)
-            *p++ = (v & (1 << i)) ? 0x31 : 0x30;
+        p += sprintf(p, "%02x", v & (0xff << ubits));
         ASN__CALLBACK(scratch, p - scratch);
+        p = scratch;
     }
-
-    if(!xcan) ASN__TEXT_INDENT(1, ilevel - 1);
+    *p++ = '"';
+    ASN__CALLBACK(scratch, p - scratch);
+    ASN__TEXT_INDENT(1, ilevel - 1);
 
     ASN__ENCODED_OK(er);
 cb_failed:


### PR DESCRIPTION
JER BIT STRING currently encodes to:
- an unquoted JSON string;
- and a binary string, instead of a hex string (as per X.697).

This PR fixes both of these issues.

**Current limitation**: this contribution assumes a BIT STRING of fixed size. X.697 provides a variant encoding for BIT STRING of variable size, however, from my understanding, the function in question (`BIT_STRING_encode_jer()`) may not have enough context to know if the BIT STRING element is constrained in size or not.