### PR TITLE
Continuous OCTET STRING JER string

### DIFF
--- a/skeletons/OCTET_STRING_jer.c
+++ b/skeletons/OCTET_STRING_jer.c
@@ -30,22 +30,19 @@ OCTET_STRING_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr,
      */
     buf = st->buf;
     end = buf + st->size;
+    ASN__CALLBACK("\"", 1);
     for(i = 0; buf < end; buf++, i++) {
       if(!(i % 16) && (i || st->size > 16)) {
         ASN__CALLBACK(scratch, p-scratch);
         p = scratch;
-        ASN__TEXT_INDENT(1, ilevel);
       }
       *p++ = h2c[(*buf >> 4) & 0x0F];
       *p++ = h2c[*buf & 0x0F];
-      *p++ = 0x20;
     }
     if(p - scratch) {
-      p--;  /* Remove the tail space */
-      ASN__CALLBACK3("\"", 1, scratch, p-scratch, "\"", 1);  /* Dump the rest */
-      if(st->size > 16)
-        ASN__TEXT_INDENT(1, ilevel-1);
+      ASN__CALLBACK(scratch, p-scratch);  /* Dump the rest */
     }
+    ASN__CALLBACK("\"", 1);
 
     ASN__ENCODED_OK(er);
 cb_failed:


### PR DESCRIPTION
Per X.697 (section 25.3), a JER-encoded OCTET STRING must be a JSON string with continuous hexadecimal digits.
To be a valid JSON string, the output also cannot have line breaks.
This PR fixes both of these issues.

Consider the definition TEST,
```
TEST ::= SEQUENCE {
   i1 INTEGER,
   os OCTET STRING,
   i2 INTEGER
}
```

With `i1=1`, `os={1,2,...,32}`, and `i2=2`, this currently encodes to,
```
{
"TEST":{

    "i1": 1,
    "os":
        00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F
        "02 00 00 00 00 00 00 00 18 19 1A 1B 1C 1D 1E 1F"
    ,
    "i2": 2}
}
```

With this PR the above becomes,
```
{
"TEST":{

    "i1": 1,
    "os": "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F",
    "i2": 2}
}
```
