### PR TITLE
WITH SUCCESSORS/DESCENDANTS support

### DIFF
--- a/libasn1fix/asn1fix_export.c
+++ b/libasn1fix/asn1fix_export.c
@@ -42,7 +42,7 @@ asn1f_lookup_module_ex(asn1p_t *asn, const char *module_name,
     arg.asn = asn;
     arg.eh = a1f_replace_me_with_proper_interface_arg.eh;
     arg.debug = a1f_replace_me_with_proper_interface_arg.debug;
-    return asn1f_lookup_module(&arg, module_name, oid);
+    return asn1f_lookup_module(&arg, module_name, oid, 0);
 }
 
 asn1p_expr_t *

--- a/libasn1fix/asn1fix_retrieve.c
+++ b/libasn1fix/asn1fix_retrieve.c
@@ -149,8 +149,15 @@ asn1f_lookup_module(arg_t *arg, const char *module_name, const asn1p_oid_t *oid,
 	TQ_FOR(mod, &(arg->asn->modules), mod_next) {
 		if(oid) {
 			if(mod->module_oid) {
-				if(0 == asn1p_oid_compare_opt(oid,
-					mod->module_oid, oid_option)) {
+				int r = asn1p_oid_compare(oid, mod->module_oid);
+				if(oid_option == XPT_WITH_SUCCESSORS) {
+					if(r == oid->arcs_count && r == mod->module_oid->arcs_count) /* positive and last arc */
+	    				r = 0;
+				} else if(oid_option == XPT_WITH_DESCENDANTS) {
+					if(oid->arcs_count == (-1 - r))
+						r = 0;
+				}
+				if(0 == r) {
 					/* Match! Even if name doesn't. */
 					oid = mod->module_oid;
 					ret = mod;

--- a/libasn1fix/asn1fix_retrieve.h
+++ b/libasn1fix/asn1fix_retrieve.h
@@ -31,7 +31,7 @@ asn1p_module_t *asn1f_lookup_in_imports(arg_t *arg, asn1p_module_t *mod, const c
  */
 asn1p_module_t *asn1f_lookup_module(arg_t *arg,
 		const char *module_name,
-		const asn1p_oid_t *module_oid);
+		const asn1p_oid_t *module_oid, int oid_option);
 
 /*
  * Return the reference to a destination of the given reference,

--- a/libasn1parser/asn1p_l.l
+++ b/libasn1parser/asn1p_l.l
@@ -381,7 +381,8 @@ UTF8String		{
 VideotexString		return TOK_VideotexString;
 VisibleString		return TOK_VisibleString;
 WITH			return TOK_WITH;
-
+SUCCESSORS		return TOK_SUCCESSORS;
+DESCENDANTS		return TOK_DESCENDANTS;
 
 <INITIAL,with_syntax>&[A-Z][A-Za-z0-9]*([-][A-Za-z0-9]+)*	{
 		asn1p_lval.tv_str = strdup(yytext);

--- a/libasn1parser/asn1p_oid.c
+++ b/libasn1parser/asn1p_oid.c
@@ -89,26 +89,37 @@ asn1p_oid_compare(const asn1p_oid_t *a, const asn1p_oid_t *b) {
 
 		if(b->arcs_count > i) {
 			if(a->arcs_count <= i)
-				return -1;
+				return -1-i;
 		} else if(a->arcs_count > i) {
 			if(b->arcs_count <= i)
-				return 1;
+				return 1+i;
 		} else if(b->arcs_count <= i && a->arcs_count <= i) {
 			cmp = b->arcs_count - a->arcs_count;
 			if(cmp < 0)
-				return -1;
+				return -1-i;
 			else if(cmp > 0)
-				return 1;
+				return 1+i;
 			return 0;
 		}
 
 		cmp = b->arcs[i].number - a->arcs[i].number;
 		if(cmp < 0)
-			return -1;
+			return -1-i;
 		else if(cmp > 0)
-			return 1;
+			return 1+i;
 	}
+}
 
+int
+asn1p_oid_compare_opt(const asn1p_oid_t *a, const asn1p_oid_t *b, int oid_options) {
+	int r = asn1p_oid_compare(a, b);
+	if(oid_options == OID_WITH_SUCCESSORS) {
+		if(r == b->arcs_count) /* positive and last arc */
+	    	r = 0;
+	} else if(oid_options == OID_WITH_DESCENDANTS) {
+		/* not supported yet */
+	}
+	return r;
 }
 
 

--- a/libasn1parser/asn1p_oid.c
+++ b/libasn1parser/asn1p_oid.c
@@ -114,10 +114,11 @@ int
 asn1p_oid_compare_opt(const asn1p_oid_t *a, const asn1p_oid_t *b, int oid_options) {
 	int r = asn1p_oid_compare(a, b);
 	if(oid_options == OID_WITH_SUCCESSORS) {
-		if(r == b->arcs_count) /* positive and last arc */
+		if(r == a->arcs_count && r == b->arcs_count) /* positive and last arc */
 	    	r = 0;
 	} else if(oid_options == OID_WITH_DESCENDANTS) {
-		/* not supported yet */
+		if(a->arcs_count == (0 - r))
+			r = 0;
 	}
 	return r;
 }

--- a/libasn1parser/asn1p_oid.c
+++ b/libasn1parser/asn1p_oid.c
@@ -109,18 +109,3 @@ asn1p_oid_compare(const asn1p_oid_t *a, const asn1p_oid_t *b) {
 			return 1+i;
 	}
 }
-
-int
-asn1p_oid_compare_opt(const asn1p_oid_t *a, const asn1p_oid_t *b, int oid_options) {
-	int r = asn1p_oid_compare(a, b);
-	if(oid_options == OID_WITH_SUCCESSORS) {
-		if(r == a->arcs_count && r == b->arcs_count) /* positive and last arc */
-	    	r = 0;
-	} else if(oid_options == OID_WITH_DESCENDANTS) {
-		if(a->arcs_count == (0 - r))
-			r = 0;
-	}
-	return r;
-}
-
-

--- a/libasn1parser/asn1p_oid.h
+++ b/libasn1parser/asn1p_oid.h
@@ -63,5 +63,9 @@ void asn1p_oid_free(asn1p_oid_t *);
  */
 int asn1p_oid_compare(const asn1p_oid_t *a, const asn1p_oid_t *b);
 
+#define OID_WITH_SUCCESSORS  1
+#define OID_WITH_DESCENDANTS 2
+int asn1p_oid_compare_opt(const asn1p_oid_t *a, const asn1p_oid_t *b, int oid_option);
+
 
 #endif	/* ASN1_PARSER_OID_H */

--- a/libasn1parser/asn1p_oid.h
+++ b/libasn1parser/asn1p_oid.h
@@ -63,9 +63,4 @@ void asn1p_oid_free(asn1p_oid_t *);
  */
 int asn1p_oid_compare(const asn1p_oid_t *a, const asn1p_oid_t *b);
 
-#define OID_WITH_SUCCESSORS  1
-#define OID_WITH_DESCENDANTS 2
-int asn1p_oid_compare_opt(const asn1p_oid_t *a, const asn1p_oid_t *b, int oid_option);
-
-
 #endif	/* ASN1_PARSER_OID_H */

--- a/libasn1parser/asn1p_xports.h
+++ b/libasn1parser/asn1p_xports.h
@@ -23,7 +23,10 @@ typedef struct asn1p_xports_s {
 		asn1p_value_t *value;	/* DefinedValue */
 	} identifier;
 
-	int option;  /* (0) | WITH SUCCESSORS (1) | WITH DESCENDANTS (2) */
+	enum asn1p_import_option {
+		XPT_WITH_SUCCESSORS = 1,
+		XPT_WITH_DESCENDANTS
+	} option;
 
 	/*
 	 * Number of entities to import.

--- a/libasn1parser/asn1p_xports.h
+++ b/libasn1parser/asn1p_xports.h
@@ -23,6 +23,8 @@ typedef struct asn1p_xports_s {
 		asn1p_value_t *value;	/* DefinedValue */
 	} identifier;
 
+	int option;  /* (0) | WITH SUCCESSORS (1) | WITH DESCENDANTS (2) */
+
 	/*
 	 * Number of entities to import.
 	 */

--- a/libasn1parser/asn1p_y.y
+++ b/libasn1parser/asn1p_y.y
@@ -267,6 +267,8 @@ static asn1p_module_t *currentModule;
 %token			TOK_TwoDots		".."
 %token			TOK_ThreeDots	"..."
 
+%token			TOK_SUCCESSORS
+%token			TOK_DESCENDANTS
 
 /*
  * Types defined herein.
@@ -286,6 +288,8 @@ static asn1p_module_t *currentModule;
 %type	<a_module>		optImportsBundleSet
 %type	<a_module>		ImportsBundleSet
 %type	<a_xports>		ImportsBundle
+%type	<a_xports>		ImportsBundleInt
+%type	<a_int>			ImportSelectionOption
 %type	<a_xports>		ImportsList
 %type	<a_xports>		ExportsDefinition
 %type	<a_xports>		ExportsBody
@@ -711,11 +715,19 @@ AssignedIdentifier:
 	| ObjectIdentifier { $$.oid = $1; };
 	/* | DefinedValue { $$.value = $1; }; // Handled through saved_aid */
 
-ImportsBundle:
+ImportsBundle: 
+    ImportsBundleInt ImportSelectionOption {
+      $$ = $1;
+      $$->option = $2;
+    }
+    | ImportsBundleInt ;
+
+ImportsBundleInt:
 	ImportsList TOK_FROM TypeRefName AssignedIdentifier {
 		$$ = $1;
 		$$->fromModuleName = $3;
 		$$->identifier = $4;
+		$$->option = 0;
 		/* This stupid thing is used for look-back hack. */
 		saved_aid = $$->identifier.oid ? 0 : &($$->identifier);
 		checkmem($$);
@@ -755,6 +767,14 @@ ImportsElement:
 	}
 	;
 
+ImportSelectionOption:
+	TOK_WITH TOK_SUCCESSORS {
+		$$ = OID_WITH_SUCCESSORS;
+	}
+	| TOK_WITH TOK_DESCENDANTS {
+		$$ = OID_WITH_DESCENDANTS;
+	}
+	;
 
 optExports:
 	{ $$ = 0; }

--- a/libasn1parser/asn1p_y.y
+++ b/libasn1parser/asn1p_y.y
@@ -769,10 +769,10 @@ ImportsElement:
 
 ImportSelectionOption:
 	TOK_WITH TOK_SUCCESSORS {
-		$$ = OID_WITH_SUCCESSORS;
+		$$ = XPT_WITH_SUCCESSORS;
 	}
 	| TOK_WITH TOK_DESCENDANTS {
-		$$ = OID_WITH_DESCENDANTS;
+		$$ = XPT_WITH_DESCENDANTS;
 	}
 	;
 

--- a/tests/tests-asn1c-compiler/161-imports-with-successors-OK.asn1
+++ b/tests/tests-asn1c-compiler/161-imports-with-successors-OK.asn1
@@ -1,0 +1,36 @@
+
+-- OK: Everything is fine
+
+-- iso.org.dod.internet.private.enterprise (1.3.6.1.4.1)
+-- .spelio.software.asn1c.test (9363.1.5.1)
+-- .121
+
+ModuleIMPORTS
+	{ iso org(3) dod(6) internet (1) private(4) enterprise(1)
+		spelio(9363) software(1) asn1c(5) test(1) 161 }
+	DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+	IMPORTS ImportedType
+	FROM ImportedModule1 
+	{ iso org(3) dod(6) internet (1) private(4) enterprise(1)
+	  spelio(9363) software(1) asn1c(5) test(1) 161 minor-version-1(1) }
+	WITH SUCCESSORS
+	;
+
+	Type ::= ImportedType
+
+END
+
+
+ImportedModule1
+	{ iso org(3) dod(6) internet (1) private(4) enterprise(1)
+		spelio(9363) software(1) asn1c(5) test(1) 161 minor-version-5(5)}
+	DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+	IMPORTS -- nothing --;
+
+	ImportedType ::= INTEGER
+
+END

--- a/tests/tests-asn1c-compiler/161-imports-with-successors-SE.asn1
+++ b/tests/tests-asn1c-compiler/161-imports-with-successors-SE.asn1
@@ -1,0 +1,36 @@
+
+-- OK: Everything is fine
+
+-- iso.org.dod.internet.private.enterprise (1.3.6.1.4.1)
+-- .spelio.software.asn1c.test (9363.1.5.1)
+-- .121
+
+ModuleIMPORTS
+	{ iso org(3) dod(6) internet (1) private(4) enterprise(1)
+		spelio(9363) software(1) asn1c(5) test(1) 161 }
+	DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+	IMPORTS ImportedType
+	FROM ImportedModule1 
+	{ iso org(3) dod(6) internet (1) private(4) enterprise(1)
+	  spelio(9363) software(1) asn1c(5) test(1) 161 minor-version-3(3) }
+	WITH SUCCESSORS
+	;
+
+	Type ::= ImportedType
+
+END
+
+
+ImportedModule1
+	{ iso org(3) dod(6) internet (1) private(4) enterprise(1)
+		spelio(9363) software(1) asn1c(5) test(1) 161 minor-version-2(2)}
+	DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+	IMPORTS -- nothing --;
+
+	ImportedType ::= INTEGER
+
+END

--- a/tests/tests-asn1c-compiler/162-imports-with-successors-SE.asn1
+++ b/tests/tests-asn1c-compiler/162-imports-with-successors-SE.asn1
@@ -1,0 +1,36 @@
+
+-- OK: Everything is fine
+
+-- iso.org.dod.internet.private.enterprise (1.3.6.1.4.1)
+-- .spelio.software.asn1c.test (9363.1.5.1)
+-- .121
+
+ModuleIMPORTS
+	{ iso org(3) dod(6) internet (1) private(4) enterprise(1)
+		spelio(9363) software(1) asn1c(5) test(1) 161 }
+	DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+	IMPORTS ImportedType
+	FROM ImportedModule1 
+	{ iso org(3) dod(6) internet (1) private(4) enterprise(1)
+	  spelio(9363) software(1) asn1c(5) test(1) 161 minor-version-3(3) }
+	WITH SUCCESSORS
+	;
+
+	Type ::= ImportedType
+
+END
+
+
+ImportedModule1
+	{ iso org(3) dod(6) internet (1) private(4) enterprise(1)
+		spelio(9363) software(1) asn1c(5) test(1) 161 minor-version-3(3) super-minor-version(1)}
+	DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+	IMPORTS -- nothing --;
+
+	ImportedType ::= INTEGER
+
+END

--- a/tests/tests-asn1c-compiler/163-imports-with-descendants-OK.asn1
+++ b/tests/tests-asn1c-compiler/163-imports-with-descendants-OK.asn1
@@ -1,0 +1,36 @@
+
+-- OK: Everything is fine
+
+-- iso.org.dod.internet.private.enterprise (1.3.6.1.4.1)
+-- .spelio.software.asn1c.test (9363.1.5.1)
+-- .121
+
+ModuleIMPORTS
+	{ iso org(3) dod(6) internet (1) private(4) enterprise(1)
+		spelio(9363) software(1) asn1c(5) test(1) 161 }
+	DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+	IMPORTS ImportedType
+	FROM ImportedModule1 
+	{ iso org(3) dod(6) internet (1) private(4) enterprise(1)
+	  spelio(9363) software(1) asn1c(5) test(1) 163 major-version-1(1) }
+	WITH DESCENDANTS
+	;
+
+	Type ::= ImportedType
+
+END
+
+
+ImportedModule1
+	{ iso org(3) dod(6) internet (1) private(4) enterprise(1)
+		spelio(9363) software(1) asn1c(5) test(1) 163 major-version-1(1) super-minor-version(1) super-minor-version(1)}
+	DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+
+	IMPORTS -- nothing --;
+
+	ImportedType ::= INTEGER
+
+END


### PR DESCRIPTION
This is a collection of commits by @DanyaFilatov to enable the support of module imports with the "WITH SUCCESSORS" and "WITH DESCENDANTS" keywords.

Associated standard: X.680 Amendment 1.