### PR TITLE
jer: Fix NULL

### DIFF
--- a/skeletons/NULL_jer.c
+++ b/skeletons/NULL_jer.c
@@ -17,29 +17,29 @@ NULL_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
     (void)sptr;
     (void)ilevel;
     (void)flags;
-    (void)cb;
-    (void)app_key;
 
-    /* XMLNullValue is empty */
-    er.encoded = 0;
+    ASN__CALLBACK("null", 4);
     ASN__ENCODED_OK(er);
+
+cb_failed:
+    ASN__ENCODE_FAILED;
 }
 
 
 static enum jer_pbd_rval
 NULL__jer_body_decode(const asn_TYPE_descriptor_t *td, void *sptr,
                       const void *chunk_buf, size_t chunk_size) {
+
     (void)td;
     (void)sptr;
-    (void)chunk_buf;  /* Going to be empty according to the rules below. */
 
-    /*
-     * There must be no content in self-terminating <NULL/> tag.
-     */
-    if(chunk_size)
-        return JPBD_BROKEN_ENCODING;
-    else
+    const char *p = (const char *)chunk_buf;
+
+    if(chunk_size && p[0] == 'n' /* 'null' */) {
         return JPBD_BODY_CONSUMED;
+    } else {
+        return JPBD_BROKEN_ENCODING;
+    }
 }
 
 asn_dec_rval_t


### PR DESCRIPTION
Adds the `null` JSON token for `NULL` type, as per X.697 section 26 (2021).