### PR TITLE
jer: GraphicString missing operation definition

### DIFF
--- a/skeletons/GraphicString.c
+++ b/skeletons/GraphicString.c
@@ -39,6 +39,7 @@ asn_TYPE_operation_t asn_OP_GraphicString = {
     OCTET_STRING_encode_jer,  /* Can't expect it to be ASCII/UTF8 */
 #else
     0,
+    0,
 #endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
 #if !defined(ASN_DISABLE_OER_SUPPORT)
     OCTET_STRING_decode_oer,


### PR DESCRIPTION
Adds a missing null element to GraphicString operators if JER support is disabled.