### PR TITLE
jer: INTEGER and ENUMERATED compliant decoding

### DIFF
--- a/skeletons/ENUMERATED.c
+++ b/skeletons/ENUMERATED.c
@@ -35,7 +35,7 @@ asn_TYPE_operation_t asn_OP_ENUMERATED = {
     0,
 #endif  /* !defined(ASN_DISABLE_XER_SUPPORT) */
 #if !defined(ASN_DISABLE_JER_SUPPORT)
-    INTEGER_decode_jer,
+    ENUMERATED_decode_jer,
     INTEGER_encode_jer,
 #else
     0,

--- a/skeletons/ENUMERATED.h
+++ b/skeletons/ENUMERATED.h
@@ -37,7 +37,7 @@ extern asn_TYPE_operation_t asn_OP_ENUMERATED;
 #endif  /* !defined(ASN_DISABLE_XER_SUPPORT) */
 
 #if !defined(ASN_DISABLE_JER_SUPPORT)
-#define ENUMERATED_decode_jer INTEGER_decode_jer
+jer_type_decoder_f ENUMERATED_decode_jer;
 #define ENUMERATED_encode_jer INTEGER_encode_jer
 #endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
 

--- a/skeletons/ENUMERATED_jer.c
+++ b/skeletons/ENUMERATED_jer.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2017 Lev Walkin <vlm@lionet.info>.
+ * All rights reserved.
+ * Redistribution and modifications are permitted subject to BSD license.
+ */
+#include <asn_internal.h>
+#include <ENUMERATED.h>
+#include <INTEGER.h>
+
+struct e2v_key {
+    const char *start;
+    const char *stop;
+    const asn_INTEGER_enum_map_t *vemap;
+    const unsigned int *evmap;
+};
+static int
+ENUMERATED__jer_compar_enum2value(const void *kp, const void *am) {
+    const struct e2v_key *key = (const struct e2v_key *)kp;
+    const asn_INTEGER_enum_map_t *el = (const asn_INTEGER_enum_map_t *)am;
+    const char *ptr, *end, *name;
+
+    /* Remap the element (sort by different criterion) */
+    el = key->vemap + key->evmap[el - key->vemap];
+
+    /* Compare strings */
+    for(ptr = key->start, end = key->stop, name = el->enum_name;
+            ptr < end; ptr++, name++) {
+        if(*ptr != *name || !*name)
+            return *(const unsigned char *)ptr - *(const unsigned char *)name;
+    }
+    return name[0] ? -1 : 0;
+}
+
+static const asn_INTEGER_enum_map_t *
+ENUMERATED_jer_map_enum2value(const asn_INTEGER_specifics_t *specs, const char *lstart,
+                       const char *lstop) {
+    const asn_INTEGER_enum_map_t *el_found;
+    int count = specs ? specs->map_count : 0;
+    struct e2v_key key;
+    const char *lp;
+
+    if(!count) return NULL;
+
+    /* Guaranteed: assert(lstart < lstop); */
+    /* Figure out the tag name */
+    for(lstart++, lp = lstart; lp < lstop; lp++) {
+        switch(*lp) {
+        case 9: case 10: case 11: case 12: case 13: case 32: /* WSP */
+        case 0x22: /* '"' */
+            break;
+        default:
+            continue;
+        }
+        break;
+    }
+    if(lp == lstop) return NULL;  /* No tag found */
+    lstop = lp;
+
+    key.start = lstart;
+    key.stop = lstop;
+    key.vemap = specs->value2enum;
+    key.evmap = specs->enum2value;
+    el_found = (asn_INTEGER_enum_map_t *)bsearch(&key,
+        specs->value2enum, count, sizeof(specs->value2enum[0]),
+        ENUMERATED__jer_compar_enum2value);
+    if(el_found) {
+        /* Remap enum2value into value2enum */
+        el_found = key.vemap + key.evmap[el_found - key.vemap];
+    }
+    return el_found;
+}
+
+static enum jer_pbd_rval
+ENUMERATED__jer_body_decode(const asn_TYPE_descriptor_t *td, void *sptr,
+                         const void *chunk_buf, size_t chunk_size) {
+    INTEGER_t *st = (INTEGER_t *)sptr;
+    intmax_t dec_value;
+    const char *lp;
+    const char *lstart = (const char *)chunk_buf;
+    const char *lstop = lstart + chunk_size;
+    int decoded = 0;
+
+    for (lp = lstart; lp < lstop; ++lp) {
+        if (*lp == 0x22 /* '"' */) { 
+            const asn_INTEGER_enum_map_t *el;
+            el = ENUMERATED_jer_map_enum2value(
+                    (const asn_INTEGER_specifics_t *)
+                    td->specifics, lstart, lstop);
+            if(el) {
+                ASN_DEBUG("Found \"%s\" => %ld",
+                        el->enum_name, el->nat_value);
+                dec_value = el->nat_value;
+                decoded = 1;
+                lp = lstop - 1;
+                continue;
+            }
+            ASN_DEBUG("Unknown identifier for ENUMERATED");
+        } else {
+            continue;
+        }
+    }
+
+    if (!decoded) {
+        return JPBD_BROKEN_ENCODING;;
+    }
+
+    /*
+     * Convert the result of parsing of enumeration into a BER representation.
+     */
+    if(asn_imax2INTEGER(st, dec_value)) {
+        ASN_DEBUG("ENUMERATED decode %s conversion failed", td->name);
+        return JPBD_SYSTEM_FAILURE;
+    }
+
+    return JPBD_BODY_CONSUMED;
+}
+
+asn_dec_rval_t
+ENUMERATED_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
+                   const asn_TYPE_descriptor_t *td, void **sptr,
+                   const char *opt_mname, const void *buf_ptr, size_t size) {
+    return jer_decode_primitive(opt_codec_ctx, td,
+        sptr, sizeof(INTEGER_t), opt_mname,
+        buf_ptr, size, ENUMERATED__jer_body_decode);
+}

--- a/skeletons/INTEGER_jer.c
+++ b/skeletons/INTEGER_jer.c
@@ -31,7 +31,7 @@ INTEGER_jer_st_prealloc(INTEGER_t *st, int min_size) {
     }
 }
 /*
- * Decode the chunk of XML text encoding INTEGER.
+ * Decode the chunk of JSON text encoding INTEGER.
  */
 static enum jer_pbd_rval
 INTEGER__jer_body_decode(const asn_TYPE_descriptor_t *td, void *sptr,

--- a/skeletons/Makefile.am
+++ b/skeletons/Makefile.am
@@ -127,6 +127,7 @@ libasn1cskeletons_la_SOURCES =                  \
     BOOLEAN_xer.c                               \
     BOOLEAN_jer.c                               \
     ENUMERATED_aper.c                           \
+    ENUMERATED_jer.c                            \
     ENUMERATED_oer.c                            \
     ENUMERATED_uper.c                           \
     GeneralizedTime_ber.c                       \

--- a/skeletons/NativeEnumerated.c
+++ b/skeletons/NativeEnumerated.c
@@ -41,7 +41,7 @@ asn_TYPE_operation_t asn_OP_NativeEnumerated = {
     0,
 #endif  /* !defined(ASN_DISABLE_XER_SUPPORT) */
 #if !defined(ASN_DISABLE_JER_SUPPORT)
-    NativeInteger_decode_jer,
+    NativeEnumerated_decode_jer,
     NativeEnumerated_encode_jer,
 #else
     0,

--- a/skeletons/NativeEnumerated.h
+++ b/skeletons/NativeEnumerated.h
@@ -13,6 +13,7 @@
 #define	_NativeEnumerated_H_
 
 #include <NativeInteger.h>
+#include <ENUMERATED.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -42,7 +43,7 @@ xer_type_encoder_f NativeEnumerated_encode_xer;
 #endif  /* !defined(ASN_DISABLE_XER_SUPPORT) */
 
 #if !defined(ASN_DISABLE_JER_SUPPORT)
-#define NativeEnumerated_decode_jer NativeInteger_decode_jer
+jer_type_decoder_f NativeEnumerated_decode_jer;
 jer_type_encoder_f NativeEnumerated_encode_jer;
 #endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
 

--- a/skeletons/NativeEnumerated_jer.c
+++ b/skeletons/NativeEnumerated_jer.c
@@ -6,6 +6,51 @@
 #include <asn_internal.h>
 #include <NativeEnumerated.h>
 
+/*
+ * Decode the chunk of JSON text encoding ENUMERATED.
+ */
+asn_dec_rval_t
+NativeEnumerated_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
+                         const asn_TYPE_descriptor_t *td, void **sptr,
+                         const char *opt_mname, const void *buf_ptr,
+                         size_t size) {
+    const asn_INTEGER_specifics_t *specs =
+        (const asn_INTEGER_specifics_t *)td->specifics;
+    asn_dec_rval_t rval;
+    INTEGER_t st;
+    void *st_ptr = (void *)&st;
+    long *native = (long *)*sptr;
+
+    if(!native) {
+        native = (long *)(*sptr = CALLOC(1, sizeof(*native)));
+        if(!native) ASN__DECODE_FAILED;
+    }
+
+    memset(&st, 0, sizeof(st));
+    rval = ENUMERATED_decode_jer(opt_codec_ctx, td, &st_ptr,
+                              opt_mname, buf_ptr, size);
+    if(rval.code == RC_OK) {
+        long l;
+        if((specs&&specs->field_unsigned)
+            ? asn_INTEGER2ulong(&st, (unsigned long *)&l) /* sic */
+            : asn_INTEGER2long(&st, &l)) {
+            rval.code = RC_FAIL;
+            rval.consumed = 0;
+        } else {
+            *native = l;
+        }
+    } else {
+        /*
+         * Cannot restart from the middle;
+         * there is no place to save state in the native type.
+         * Request a continuation from the very beginning.
+         */
+        rval.consumed = 0;
+    }
+    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_INTEGER, &st);
+    return rval;
+}
+
 asn_enc_rval_t
 NativeEnumerated_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr,
                             int ilevel, enum jer_encoder_flags_e flags,

--- a/skeletons/file-dependencies
+++ b/skeletons/file-dependencies
@@ -17,7 +17,7 @@ IA5String.h IA5String.c OCTET_STRING.h
 INTEGER.h INTEGER.c
 ISO646String.h ISO646String.c OCTET_STRING.h
 NULL.h NULL.c
-NativeEnumerated.h NativeEnumerated.c NativeInteger.h
+NativeEnumerated.h NativeEnumerated.c NativeInteger.h ENUMERATED.h
 NativeInteger.h NativeInteger.c INTEGER.h
 NativeReal.h NativeReal.c REAL.h
 NumericString.h NumericString.c OCTET_STRING.h
@@ -253,6 +253,7 @@ ANY.h ANY_jer.c
 BIT_STRING.h BIT_STRING_jer.c
 BMPString.h BMPString_jer.c
 BOOLEAN.h BOOLEAN_jer.c
+ENUMERATED.h ENUMERATED_jer.c
 GeneralizedTime.h GeneralizedTime_jer.c
 INTEGER.h INTEGER_jer.c
 NULL.h NULL_jer.c


### PR DESCRIPTION
Sets up the JER `INTEGER` decoder, previously based on XER `INTEGER` decoding logic, to only accept `INTEGER` values which follow the X.697 rules, i.e., no leading zeroes, no hexadecimal values, no strings.
Given that this change also affects the `ENUMERATED` type, which should only accept strings according to the standard, associated changes were also added to this PR. 
Since `INTEGER` deals now only with JSON numbers and `ENUMERATED`  deals only with JSON strings, `ENUMERATED` decoding logic was moved to its own file.

Related tests were also added.

X.697 sections 21 and 22 (2021)