### PR TITLE
jer: Formatting enhancements

### DIFF
--- a/skeletons/BIT_STRING_jer.c
+++ b/skeletons/BIT_STRING_jer.c
@@ -52,7 +52,6 @@ BIT_STRING_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr,
     }
     *p++ = '"';
     ASN__CALLBACK(scratch, p - scratch);
-    ASN__TEXT_INDENT(1, ilevel - 1);
 
     ASN__ENCODED_OK(er);
 cb_failed:

--- a/skeletons/constr_CHOICE_jer.c
+++ b/skeletons/constr_CHOICE_jer.c
@@ -270,6 +270,7 @@ CHOICE_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
         (const asn_CHOICE_specifics_t *)td->specifics;
     asn_enc_rval_t er = {0,0,0};
     unsigned present = 0;
+    int xcan = 0;
 
     if(!sptr)
         ASN__ENCODE_FAILED;
@@ -298,13 +299,16 @@ CHOICE_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
 
         er.encoded = 0;
 
-        ASN__CALLBACK3("{\n\"", 3, mname, mlen, "\": ", 2);
+        ASN__CALLBACK("{",1);
+        if(!xcan) ASN__TEXT_INDENT(1, ilevel + 1);
+        ASN__CALLBACK3("\"", 1, mname, mlen, "\": ", 3);
 
         tmper = elm->type->op->jer_encoder(elm->type, memb_ptr,
                                            ilevel + 1, flags, cb, app_key);
         if(tmper.encoded == -1) return tmper;
         er.encoded += tmper.encoded;
 
+        if(!xcan) ASN__TEXT_INDENT(1, ilevel);
         ASN__CALLBACK("}", 1);
     }
 

--- a/skeletons/constr_SEQUENCE_OF_jer.c
+++ b/skeletons/constr_SEQUENCE_OF_jer.c
@@ -28,6 +28,7 @@ SEQUENCE_OF_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr,
         void *memb_ptr = list->array[i];
         if(!memb_ptr) continue;
 
+        if(!xcan) ASN__TEXT_INDENT(1, ilevel + 1);
         tmper = elm->type->op->jer_encoder(elm->type, memb_ptr, ilevel + 1,
                                            flags, cb, app_key);
         if(tmper.encoded == -1) return tmper;
@@ -44,7 +45,7 @@ SEQUENCE_OF_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr,
         }
     }
 
-    if(!xcan) ASN__TEXT_INDENT(1, ilevel - 1);
+    if(!xcan) ASN__TEXT_INDENT(1, ilevel);
     ASN__CALLBACK("]", 1);
 
     ASN__ENCODED_OK(er);

--- a/skeletons/constr_SEQUENCE_jer.c
+++ b/skeletons/constr_SEQUENCE_jer.c
@@ -308,7 +308,7 @@ asn_enc_rval_t SEQUENCE_encode_jer(const asn_TYPE_descriptor_t *td, const void *
     er.encoded = 0;
 
     int bAddComma = 0;
-    ASN__CALLBACK("{\n", 2);
+    ASN__CALLBACK("{", 1);
     for(edx = 0; edx < td->elements_count; edx++) {
         asn_enc_rval_t tmper = {0,0,0};
         asn_TYPE_member_t *elm = &td->elements[edx];
@@ -344,7 +344,7 @@ asn_enc_rval_t SEQUENCE_encode_jer(const asn_TYPE_descriptor_t *td, const void *
           bAddComma = 0;
         }
 
-        if(!xcan) ASN__TEXT_INDENT(1, ilevel);
+        if(!xcan) ASN__TEXT_INDENT(1, ilevel+1);
         ASN__CALLBACK3("\"", 1, mname, mlen, "\": ", 3);
 
         /* Print the member itself */
@@ -360,9 +360,9 @@ asn_enc_rval_t SEQUENCE_encode_jer(const asn_TYPE_descriptor_t *td, const void *
           bAddComma = 1;
         }
     }
+    if(!xcan) ASN__TEXT_INDENT(1, ilevel);
     ASN__CALLBACK("}", 1);
 
-    if(!xcan) ASN__TEXT_INDENT(1, ilevel - 1);
 
     ASN__ENCODED_OK(er);
 cb_failed:

--- a/skeletons/constr_SET_OF_jer.c
+++ b/skeletons/constr_SET_OF_jer.c
@@ -256,8 +256,7 @@ SET_OF_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
             encs_count++;
         }
 
-        if(!xcan && specs->as_XMLValueList == 1)
-            ASN__TEXT_INDENT(1, ilevel + 1);
+        ASN__TEXT_INDENT(1, ilevel + 1);
         tmper = elm->type->op->jer_encoder(elm->type, memb_ptr,
                                            ilevel + (specs->as_XMLValueList != 2),
                                            flags, cb, app_key);
@@ -273,7 +272,7 @@ SET_OF_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
         }
     }
 
-    if(!xcan) ASN__TEXT_INDENT(1, ilevel - 1);
+    if(!xcan) ASN__TEXT_INDENT(1, ilevel);
     ASN__CALLBACK("]", 1);
 
     if(encs) {

--- a/skeletons/jer_encoder.c
+++ b/skeletons/jer_encoder.c
@@ -19,7 +19,7 @@ jer_encode(const asn_TYPE_descriptor_t *td, const void *sptr,
 	if(!td || !sptr) goto cb_failed;
 
     int xFail = 1; /* TODO JER flags */
-	tmper = td->op->jer_encoder(td, sptr, 1, xFail, cb, app_key);
+	tmper = td->op->jer_encoder(td, sptr, 0, xFail, cb, app_key);
 	if(tmper.encoded == -1) return tmper;
 	er.encoded += tmper.encoded;
 


### PR DESCRIPTION
Provides several enhancements to JER encoder output.

Example before:
```json
{

    "int1": 851,
    "intopt1": 12412,
    "seqofch": [{
"int1":61},{
"seqofbs":["0203"
                ,"030405"
                ,"04050607"
                ,"0506070809"

            ]}
    ],
    "bs": "02040608"
    ,
    "os": "020406080A",
    "seqofint": [9509,919,99
    ],
    "ch": {
"seqofreal":[5.505E3,5.15E2,5.5E1
        ]},
    "seqofnull": [null,null,null
    ],
    "bool1": true,
    "null1": null,
    "enumerated1": "rejected",
    "roi": "8.9.10.11",
    "bmps": "",
    "utf": "abnlmz",
    "setofps": ["stringA","another\"string"
    ],
    "setofnull": [
    ],
    "gt": "19821106210629.456",
    "r": 0,
    "seqA": {

        "int1": 0,
        "bool1": true,
        "enumerated1": "tryagain"}
    }
```
Example after:
```json
{
    "int1": 851,
    "intopt1": 12412,
    "seqofch": [
        {
            "int1": 61
        },
        {
            "seqofbs": [
                "0203",
                "030405",
                "04050607",
                "0506070809"
            ]
        }
    ],
    "bs": "02040608",
    "os": "020406080A",
    "seqofint": [
        9509,
        919,
        99
    ],
    "ch": {
        "seqofreal": [
            5.505E3,
            5.15E2,
            5.5E1
        ]
    },
    "seqofnull": [
        null,
        null,
        null
    ],
    "bool1": true,
    "null1": null,
    "enumerated1": "rejected",
    "roi": "8.9.10.11",
    "bmps": "",
    "utf": "abnlmz",
    "setofps": [
        "stringA",
        "another\"string"
    ],
    "setofnull": [
    ],
    "gt": "19821106210629.456",
    "r": 0,
    "seqA": {
        "int1": 0,
        "bool1": true,
        "enumerated1": "tryagain"
    }
}
```