### PR TITLE
PER: fix encoding and decoding of OPENTYPE with size constraints

### DIFF
--- a/skeletons/OPEN_TYPE_aper.c
+++ b/skeletons/OPEN_TYPE_aper.c
@@ -53,7 +53,8 @@ OPEN_TYPE_aper_get(const asn_codec_ctx_t *opt_codec_ctx,
         (char *)*memb_ptr2
         + elm->type->elements[selected.presence_index - 1].memb_offset;
 
-    rv = aper_open_type_get(opt_codec_ctx, selected.type_descriptor, NULL,
+    rv = aper_open_type_get(opt_codec_ctx, selected.type_descriptor,
+                            elm->type->elements[selected.presence_index - 1].encoding_constraints.per_constraints,
                             &inner_value, pd);
     switch(rv.code) {
     case RC_OK:
@@ -110,7 +111,7 @@ OPEN_TYPE_encode_aper(const asn_TYPE_descriptor_t *td,
         memb_ptr = (const char *)sptr + elm->memb_offset;
     }
 
-    if(aper_open_type_put(elm->type, NULL, memb_ptr, po) < 0) {
+    if(aper_open_type_put(elm->type, elm->encoding_constraints.per_constraints, memb_ptr, po) < 0) {
         ASN__ENCODE_FAILED;
     }
 

--- a/skeletons/OPEN_TYPE_uper.c
+++ b/skeletons/OPEN_TYPE_uper.c
@@ -53,7 +53,8 @@ OPEN_TYPE_uper_get(const asn_codec_ctx_t *opt_codec_ctx,
         (char *)*memb_ptr2
         + elm->type->elements[selected.presence_index - 1].memb_offset;
 
-    rv = uper_open_type_get(opt_codec_ctx, selected.type_descriptor, NULL,
+    rv = uper_open_type_get(opt_codec_ctx, selected.type_descriptor,
+                            elm->type->elements[selected.presence_index - 1].encoding_constraints.per_constraints,
                             &inner_value, pd);
     switch(rv.code) {
     case RC_OK:
@@ -110,7 +111,9 @@ OPEN_TYPE_encode_uper(const asn_TYPE_descriptor_t *td,
         memb_ptr = (const char *)sptr + elm->memb_offset;
     }
 
-    if(uper_open_type_put(elm->type, NULL, memb_ptr, po) < 0) {
+    if(uper_open_type_put(elm->type,
+                          elm->encoding_constraints.per_constraints,
+                          memb_ptr, po) < 0) {
         ASN__ENCODE_FAILED;
     }
 


### PR DESCRIPTION
Constraints have to be used. If not the encoding or decoding may be wrong.

For example RRC-Version of 3GPP 38.473 contains an extension with a fixed size constraint (so the size is not encoded).

Note: this pull request does not solve all cases. For example the constraint:

    SIZE(3..1000000)

is not managed properly. (Solved in another pull request almost ready.)