### PR TITLE
SEQUENCE_free, CHOICE_free null pointer check fix

### DIFF
--- a/skeletons/constr_CHOICE.c
+++ b/skeletons/constr_CHOICE.c
@@ -156,12 +156,13 @@ CHOICE_constraint(const asn_TYPE_descriptor_t *td, const void *sptr,
 void
 CHOICE_free(const asn_TYPE_descriptor_t *td, void *ptr,
             enum asn_struct_free_method method) {
-    const asn_CHOICE_specifics_t *specs =
-        (const asn_CHOICE_specifics_t *)td->specifics;
+    const asn_CHOICE_specifics_t *specs;
     unsigned present;
 
 	if(!td || !ptr)
 		return;
+
+    specs = (const asn_CHOICE_specifics_t *)td->specifics;
 
 	ASN_DEBUG("Freeing %s as CHOICE", td->name);
 

--- a/skeletons/constr_SEQUENCE.c
+++ b/skeletons/constr_SEQUENCE.c
@@ -68,12 +68,13 @@ void
 SEQUENCE_free(const asn_TYPE_descriptor_t *td, void *sptr,
               enum asn_struct_free_method method) {
     size_t edx;
-    const asn_SEQUENCE_specifics_t *specs =
-        (const asn_SEQUENCE_specifics_t *)td->specifics;
+    const asn_SEQUENCE_specifics_t *specs; 
     asn_struct_ctx_t *ctx; /* Decoder context */
 
 	if(!td || !sptr)
 		return;
+
+    specs = (const asn_SEQUENCE_specifics_t *)td->specifics;
 
 	ASN_DEBUG("Freeing %s as SEQUENCE", td->name);
 


### PR DESCRIPTION
Moves the null pointer check of the type descriptor in SEQUENCE_free and CHOICE_free before it is accessed.