### PR TITLE
APER: fix non negative normally small whole numbers

### DIFF
--- a/skeletons/NativeEnumerated_aper.c
+++ b/skeletons/NativeEnumerated_aper.c
@@ -64,7 +64,7 @@ NativeEnumerated_decode_aper(const asn_codec_ctx_t *opt_codec_ctx,
          */
 
         /* XXX handle indefinite index length > 64k */
-        value = aper_get_nsnnwn(pd, 65537);
+        value = aper_get_nsnnwn(pd);
         if(value < 0) ASN__DECODE_STARVED;
         value += specs->extension - 1;
         //if(value >= specs->map_count)
@@ -148,9 +148,7 @@ NativeEnumerated_encode_aper(const asn_TYPE_descriptor_t *td,
     ASN_DEBUG("value = %ld, ext = %d, inext = %d, res = %ld",
               value, specs->extension, inext,
               value - (inext ? (specs->extension - 1) : 0));
-    if(aper_put_nsnnwn(po,
-                       ct->upper_bound - ct->lower_bound + 1,
-                       value - (inext ? (specs->extension - 1) : 0)))
+    if(aper_put_nsnnwn(po, value - (inext ? (specs->extension - 1) : 0)))
         ASN__ENCODE_FAILED;
 
     ASN__ENCODED_OK(er);

--- a/skeletons/OCTET_STRING_aper.c
+++ b/skeletons/OCTET_STRING_aper.c
@@ -179,7 +179,6 @@ OCTET_STRING_decode_aper(const asn_codec_ctx_t *opt_codec_ctx,
             raw_len = aper_get_length(pd, csiz->lower_bound, csiz->upper_bound,
                                       csiz->effective_bits, &repeat);
         if(raw_len < 0) RETURN(RC_WMORE);
-        raw_len += csiz->lower_bound;
 
         ASN_DEBUG("Got PER length eb %ld, len %ld, %s (%s)",
                   (long)csiz->effective_bits, (long)raw_len,

--- a/skeletons/aper_support.h
+++ b/skeletons/aper_support.h
@@ -27,7 +27,12 @@ ssize_t aper_get_nslength(asn_per_data_t *pd);
 /*
  * Get the normally small non-negative whole number.
  */
-ssize_t aper_get_nsnnwn(asn_per_data_t *pd, int range);
+ssize_t aper_get_nsnnwn(asn_per_data_t *pd);
+
+/*
+ * Get the constrained whole number.
+ */
+long aper_get_constrained_whole_number(asn_per_data_t *po, long lb, long ub);
 
 /*
  * X.691 (08/2015) #11.9 "General rules for encoding a length determinant"
@@ -54,7 +59,12 @@ int aper_put_nslength(asn_per_outp_t *po, size_t length);
 /*
  * Put the normally small non-negative whole number.
  */
-int aper_put_nsnnwn(asn_per_outp_t *po, int range, int number);
+int aper_put_nsnnwn(asn_per_outp_t *po, int number);
+
+/*
+ * Put the constrained whole number.
+ */
+int aper_put_constrained_whole_number(asn_per_outp_t *po, long lb, long ub, long number);
 
 #ifdef __cplusplus
 }

--- a/skeletons/constr_CHOICE_aper.c
+++ b/skeletons/constr_CHOICE_aper.c
@@ -56,7 +56,7 @@ CHOICE_decode_aper(const asn_codec_ctx_t *opt_codec_ctx,
             ASN__DECODE_FAILED;
 
         if(specs && specs->tag2el_count > specs->ext_start) {
-            value = aper_get_nsnnwn(pd, specs->tag2el_count - specs->ext_start); /* extension elements range */
+            value = aper_get_nsnnwn(pd); /* extension elements range */
             if(value < 0) ASN__DECODE_STARVED;
             value += specs->ext_start;
             if((unsigned)value >= td->elements_count)
@@ -168,7 +168,7 @@ CHOICE_encode_aper(const asn_TYPE_descriptor_t *td,
         asn_enc_rval_t rval = {0,0,0};
         if(specs->ext_start == -1)
             ASN__ENCODE_FAILED;
-        if(aper_put_nsnnwn(po, ct ? ct->range_bits : 0, present - specs->ext_start))
+        if(aper_put_nsnnwn(po, present - specs->ext_start))
             ASN__ENCODE_FAILED;
         if(aper_open_type_put(elm->type, elm->encoding_constraints.per_constraints,
                               memb_ptr, po))

--- a/skeletons/constr_SET_OF_aper.c
+++ b/skeletons/constr_SET_OF_aper.c
@@ -129,13 +129,12 @@ SET_OF_decode_aper(const asn_codec_ctx_t *opt_codec_ctx,
         if(value) ct = 0;  /* Not restricted! */
     }
 
-    if(ct && ct->effective_bits >= 0) {
+    if(ct && ct->upper_bound >= 1 && ct->upper_bound <= 65535
+       && ct->upper_bound == ct->lower_bound) {
         /* X.691, #19.5: No length determinant */
-        nelems = aper_get_nsnnwn(pd, ct->upper_bound - ct->lower_bound + 1);
-        ASN_DEBUG("Preparing to fetch %ld+%lld elements from %s",
-                  (long)nelems, (long long int)ct->lower_bound, td->name);
-        if(nelems < 0)  ASN__DECODE_STARVED;
-        nelems += ct->lower_bound;
+        nelems = ct->upper_bound;
+        ASN_DEBUG("Preparing to fetch %ld elements from %s",
+                  (long)nelems, td->name);
     } else {
         nelems = -1;
     }


### PR DESCRIPTION
aper_put_nsnnwn() and aper_get_nsnnwn() were wrong. All the places where they were used are modified, if needed.

The functions aper_get_constrained_whole_number() and aper_put_constrained_whole_number() are introduced. They don't cover all cases, very big numbers are not supported.