### PR TITLE
jer: Add missing 'fall through' marker comments

### DIFF
--- a/skeletons/constr_CHOICE_jer.c
+++ b/skeletons/constr_CHOICE_jer.c
@@ -186,6 +186,7 @@ CHOICE_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
                 ctx->phase = 1;  /* Processing body phase */
                 continue;
             }
+            /* Fall through */
         case JCK_KEY:
         case JCK_UNKNOWN:
 

--- a/skeletons/constr_SET_OF_jer.c
+++ b/skeletons/constr_SET_OF_jer.c
@@ -145,11 +145,10 @@ SET_OF_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
                 ctx->phase = 3;  /* Phase out */
                 RETURN(RC_OK);
             }
-        case JCK_OEND:
             /* Fall through */
+        case JCK_OEND:
         case JCK_KEY:
         case JCK_COMMA:
-
         case JCK_ASTART:
             if(ctx->phase == 0) {
                 JER_ADVANCE(ch_size);


### PR DESCRIPTION
Adds missing 'fall through' marker comments to silence related [GCC warnings](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wimplicit-fallthrough).