### PR TITLE
jer: Remove unused arguments and variables

### DIFF
--- a/asn1-tools/unber/libasn1_unber_tool.c
+++ b/asn1-tools/unber/libasn1_unber_tool.c
@@ -827,8 +827,7 @@ xer_decode_general(const asn_codec_ctx_t *opt_codec_ctx, asn_struct_ctx_t *ctx,
 
 asn_dec_rval_t
 jer_decode_general(const asn_codec_ctx_t *opt_codec_ctx, asn_struct_ctx_t *ctx,
-                   void *struct_key, const char *json_key, const void *buf_ptr,
-                   size_t size,
+                   void *struct_key, const void *buf_ptr, size_t size,
                    int (*otd)(void *struct_key, const void *chunk_buf,
                               size_t chunk_size),
                    ssize_t (*br)(void *struct_key, const void *chunk_buf,
@@ -837,7 +836,6 @@ jer_decode_general(const asn_codec_ctx_t *opt_codec_ctx, asn_struct_ctx_t *ctx,
     (void)opt_codec_ctx;
     (void)ctx;
     (void)struct_key;
-    (void)json_key;
     (void)buf_ptr;
     (void)size;
     (void)otd;

--- a/skeletons/BIT_STRING_jer.c
+++ b/skeletons/BIT_STRING_jer.c
@@ -18,6 +18,9 @@ BIT_STRING_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr,
     uint8_t *buf;
     uint8_t *end;
 
+    (void)ilevel;
+    (void)flags;
+
     if(!st || !st->buf)
         ASN__ENCODE_FAILED;
 

--- a/skeletons/BMPString_jer.c
+++ b/skeletons/BMPString_jer.c
@@ -10,11 +10,10 @@
 asn_dec_rval_t
 BMPString_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
                      const asn_TYPE_descriptor_t *td, void **sptr,
-                     const char *opt_mname, const void *buf_ptr, size_t size) {
+                     const void *buf_ptr, size_t size) {
     asn_dec_rval_t rc;
 
-    rc = OCTET_STRING_decode_jer_utf8(opt_codec_ctx, td, sptr, opt_mname,
-        buf_ptr, size);
+    rc = OCTET_STRING_decode_jer_utf8(opt_codec_ctx, td, sptr, buf_ptr, size);
     if(rc.code == RC_OK) {
         /*
          * Now we have a whole string in UTF-8 format.

--- a/skeletons/BOOLEAN_jer.c
+++ b/skeletons/BOOLEAN_jer.c
@@ -18,6 +18,7 @@ BOOLEAN__jer_body_decode(const asn_TYPE_descriptor_t *td, void *sptr,
     const char *p = (const char *)chunk_buf;
 
     (void)td;
+    (void)chunk_size;
 
     if(p[0] == 't' /* 'true' */) {
         *st = 1;
@@ -34,9 +35,9 @@ BOOLEAN__jer_body_decode(const asn_TYPE_descriptor_t *td, void *sptr,
 asn_dec_rval_t
 BOOLEAN_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
                    const asn_TYPE_descriptor_t *td, void **sptr,
-                   const char *opt_mname, const void *buf_ptr, size_t size) {
+                   const void *buf_ptr, size_t size) {
     return jer_decode_primitive(opt_codec_ctx, td,
-                                sptr, sizeof(BOOLEAN_t), opt_mname, buf_ptr, size,
+                                sptr, sizeof(BOOLEAN_t), buf_ptr, size,
                                 BOOLEAN__jer_body_decode);
 }
 

--- a/skeletons/ENUMERATED_jer.c
+++ b/skeletons/ENUMERATED_jer.c
@@ -118,8 +118,8 @@ ENUMERATED__jer_body_decode(const asn_TYPE_descriptor_t *td, void *sptr,
 asn_dec_rval_t
 ENUMERATED_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
                    const asn_TYPE_descriptor_t *td, void **sptr,
-                   const char *opt_mname, const void *buf_ptr, size_t size) {
+                   const void *buf_ptr, size_t size) {
     return jer_decode_primitive(opt_codec_ctx, td,
-        sptr, sizeof(INTEGER_t), opt_mname,
+        sptr, sizeof(INTEGER_t),
         buf_ptr, size, ENUMERATED__jer_body_decode);
 }

--- a/skeletons/INTEGER_jer.c
+++ b/skeletons/INTEGER_jer.c
@@ -182,9 +182,9 @@ INTEGER__jer_body_decode(const asn_TYPE_descriptor_t *td, void *sptr,
 asn_dec_rval_t
 INTEGER_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
                    const asn_TYPE_descriptor_t *td, void **sptr,
-                   const char *opt_mname, const void *buf_ptr, size_t size) {
+                   const void *buf_ptr, size_t size) {
     return jer_decode_primitive(opt_codec_ctx, td,
-        sptr, sizeof(INTEGER_t), opt_mname,
+        sptr, sizeof(INTEGER_t),
         buf_ptr, size, INTEGER__jer_body_decode);
 }
 

--- a/skeletons/NULL_jer.c
+++ b/skeletons/NULL_jer.c
@@ -45,8 +45,8 @@ NULL__jer_body_decode(const asn_TYPE_descriptor_t *td, void *sptr,
 asn_dec_rval_t
 NULL_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
                 const asn_TYPE_descriptor_t *td, void **sptr,
-                const char *opt_mname, const void *buf_ptr, size_t size) {
+                const void *buf_ptr, size_t size) {
     return jer_decode_primitive(opt_codec_ctx, td,
-        sptr, sizeof(NULL_t), opt_mname, buf_ptr, size,
+        sptr, sizeof(NULL_t), buf_ptr, size,
         NULL__jer_body_decode);
 }

--- a/skeletons/NativeEnumerated_jer.c
+++ b/skeletons/NativeEnumerated_jer.c
@@ -12,8 +12,7 @@
 asn_dec_rval_t
 NativeEnumerated_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
                          const asn_TYPE_descriptor_t *td, void **sptr,
-                         const char *opt_mname, const void *buf_ptr,
-                         size_t size) {
+                         const void *buf_ptr, size_t size) {
     const asn_INTEGER_specifics_t *specs =
         (const asn_INTEGER_specifics_t *)td->specifics;
     asn_dec_rval_t rval;
@@ -27,8 +26,7 @@ NativeEnumerated_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
     }
 
     memset(&st, 0, sizeof(st));
-    rval = ENUMERATED_decode_jer(opt_codec_ctx, td, &st_ptr,
-                              opt_mname, buf_ptr, size);
+    rval = ENUMERATED_decode_jer(opt_codec_ctx, td, &st_ptr, buf_ptr, size);
     if(rval.code == RC_OK) {
         long l;
         if((specs&&specs->field_unsigned)

--- a/skeletons/NativeInteger_jer.c
+++ b/skeletons/NativeInteger_jer.c
@@ -12,7 +12,7 @@
 asn_dec_rval_t
 NativeInteger_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
                          const asn_TYPE_descriptor_t *td, void **sptr,
-                         const char *opt_mname, const void *buf_ptr,
+                         const void *buf_ptr,
                          size_t size) {
     const asn_INTEGER_specifics_t *specs =
         (const asn_INTEGER_specifics_t *)td->specifics;
@@ -27,8 +27,7 @@ NativeInteger_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
     }
 
     memset(&st, 0, sizeof(st));
-    rval = INTEGER_decode_jer(opt_codec_ctx, td, &st_ptr,
-                              opt_mname, buf_ptr, size);
+    rval = INTEGER_decode_jer(opt_codec_ctx, td, &st_ptr, buf_ptr, size);
     if(rval.code == RC_OK) {
         long l;
         if((specs&&specs->field_unsigned)

--- a/skeletons/NativeReal_jer.c
+++ b/skeletons/NativeReal_jer.c
@@ -13,13 +13,12 @@
 asn_dec_rval_t
 NativeReal_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
                       const asn_TYPE_descriptor_t *td, void **sptr,
-                      const char *opt_mname, const void *buf_ptr, size_t size) {
+                      const void *buf_ptr, size_t size) {
     asn_dec_rval_t rval;
     REAL_t st = { 0, 0 };
     REAL_t *stp = &st;
 
-    rval = REAL_decode_jer(opt_codec_ctx, td, (void **)&stp, opt_mname,
-                           buf_ptr, size);
+    rval = REAL_decode_jer(opt_codec_ctx, td, (void **)&stp, buf_ptr, size);
     if(rval.code == RC_OK) {
         double d;
         if(asn_REAL2double(&st, &d) || NativeReal__set(td, sptr, d) < 0) {

--- a/skeletons/OBJECT_IDENTIFIER_jer.c
+++ b/skeletons/OBJECT_IDENTIFIER_jer.c
@@ -52,11 +52,11 @@ OBJECT_IDENTIFIER__jer_body_decode(const asn_TYPE_descriptor_t *td, void *sptr,
 asn_dec_rval_t
 OBJECT_IDENTIFIER_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
                              const asn_TYPE_descriptor_t *td, void **sptr,
-                             const char *opt_mname, const void *buf_ptr,
+                             const void *buf_ptr,
                              size_t size) {
     return jer_decode_primitive(opt_codec_ctx, td,
-        sptr, sizeof(OBJECT_IDENTIFIER_t), opt_mname,
-            buf_ptr, size, OBJECT_IDENTIFIER__jer_body_decode);
+        sptr, sizeof(OBJECT_IDENTIFIER_t),
+        buf_ptr, size, OBJECT_IDENTIFIER__jer_body_decode);
 }
 
 asn_enc_rval_t

--- a/skeletons/OCTET_STRING_jer.c
+++ b/skeletons/OCTET_STRING_jer.c
@@ -20,6 +20,9 @@ OCTET_STRING_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr,
     uint8_t *end;
     size_t i;
 
+    (void)ilevel;
+    (void)flags;
+
     if(!st || (!st->buf && st->size))
         ASN__ENCODE_FAILED;
 
@@ -493,7 +496,7 @@ OCTET_STRING__convert_entrefs(void *sptr, const void *chunk_buf,
 static asn_dec_rval_t
 OCTET_STRING__decode_jer(
     const asn_codec_ctx_t *opt_codec_ctx, const asn_TYPE_descriptor_t *td,
-    void **sptr, const char *opt_mname, const void *buf_ptr, size_t size,
+    void **sptr, const void *buf_ptr, size_t size,
     int (*opt_unexpected_tag_decoder)(void *struct_ptr, const void *chunk_buf,
                                       size_t chunk_size),
     ssize_t (*body_receiver)(void *struct_ptr, const void *chunk_buf,
@@ -502,7 +505,6 @@ OCTET_STRING__decode_jer(
     const asn_OCTET_STRING_specifics_t *specs = td->specifics
         ? (const asn_OCTET_STRING_specifics_t *)td->specifics
         : &asn_SPC_OCTET_STRING_specs;
-    const char *xml_tag = opt_mname ? opt_mname : td->xml_tag;
     asn_struct_ctx_t *ctx;  /* Per-structure parser context */
     asn_dec_rval_t rval;  /* Return value from the decoder */
     int st_allocated;
@@ -534,7 +536,7 @@ OCTET_STRING__decode_jer(
     /* Restore parsing context */
     ctx = (asn_struct_ctx_t *)(((char *)*sptr) + specs->ctx_offset);
 
-    return jer_decode_general(opt_codec_ctx, ctx, *sptr, xml_tag,
+    return jer_decode_general(opt_codec_ctx, ctx, *sptr,
                               buf_ptr, size,
                               opt_unexpected_tag_decoder,
                               body_receiver);
@@ -553,9 +555,8 @@ sta_failed:
 asn_dec_rval_t
 OCTET_STRING_decode_jer_hex(const asn_codec_ctx_t *opt_codec_ctx,
                             const asn_TYPE_descriptor_t *td, void **sptr,
-                            const char *opt_mname, const void *buf_ptr,
-                            size_t size) {
-    return OCTET_STRING__decode_jer(opt_codec_ctx, td, sptr, opt_mname,
+                            const void *buf_ptr, size_t size) {
+    return OCTET_STRING__decode_jer(opt_codec_ctx, td, sptr,
                                     buf_ptr, size, 0,
                                     OCTET_STRING__convert_hexadecimal);
 }
@@ -566,9 +567,8 @@ OCTET_STRING_decode_jer_hex(const asn_codec_ctx_t *opt_codec_ctx,
 asn_dec_rval_t
 OCTET_STRING_decode_jer_utf8(const asn_codec_ctx_t *opt_codec_ctx,
                              const asn_TYPE_descriptor_t *td, void **sptr,
-                             const char *opt_mname, const void *buf_ptr,
-                             size_t size) {
-    return OCTET_STRING__decode_jer(opt_codec_ctx, td, sptr, opt_mname,
+                             const void *buf_ptr, size_t size) {
+    return OCTET_STRING__decode_jer(opt_codec_ctx, td, sptr,
                                     buf_ptr, size,
                                     OCTET_STRING__handle_control_chars,
                                     OCTET_STRING__convert_entrefs);

--- a/skeletons/OPEN_TYPE_jer.c
+++ b/skeletons/OPEN_TYPE_jer.c
@@ -103,7 +103,7 @@ OPEN_TYPE_jer_get(const asn_codec_ctx_t *opt_codec_ctx,
         + elm->type->elements[selected.presence_index - 1].memb_offset;
 
     rv = selected.type_descriptor->op->jer_decoder(
-        opt_codec_ctx, selected.type_descriptor, &inner_value, NULL, ptr, size);
+        opt_codec_ctx, selected.type_descriptor, &inner_value, ptr, size);
     ADVANCE(rv.consumed);
     rv.consumed = 0;
     switch(rv.code) {

--- a/skeletons/REAL_jer.c
+++ b/skeletons/REAL_jer.c
@@ -323,9 +323,8 @@ REAL__jer_body_decode(const asn_TYPE_descriptor_t *td, void *sptr,
 asn_dec_rval_t
 REAL_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
                 const asn_TYPE_descriptor_t *td, void **sptr,
-                const char *opt_mname, const void *buf_ptr, size_t size) {
-    return jer_decode_primitive(opt_codec_ctx, td,
-                                sptr, sizeof(REAL_t), opt_mname,
+                const void *buf_ptr, size_t size) {
+    return jer_decode_primitive(opt_codec_ctx, td, sptr, sizeof(REAL_t),
                                 buf_ptr, size, REAL__jer_body_decode);
 }
 

--- a/skeletons/RELATIVE-OID_jer.c
+++ b/skeletons/RELATIVE-OID_jer.c
@@ -72,10 +72,9 @@ RELATIVE_OID__jer_body_decode(const asn_TYPE_descriptor_t *td, void *sptr,
 asn_dec_rval_t
 RELATIVE_OID_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
                         const asn_TYPE_descriptor_t *td, void **sptr,
-                        const char *opt_mname, const void *buf_ptr,
-                        size_t size) {
+                        const void *buf_ptr, size_t size) {
     return jer_decode_primitive(opt_codec_ctx, td,
-                                sptr, sizeof(RELATIVE_OID_t), opt_mname,
+                                sptr, sizeof(RELATIVE_OID_t),
                                 buf_ptr, size, RELATIVE_OID__jer_body_decode);
 }
 

--- a/skeletons/UniversalString_jer.c
+++ b/skeletons/UniversalString_jer.c
@@ -10,12 +10,10 @@
 asn_dec_rval_t
 UniversalString_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
                            const asn_TYPE_descriptor_t *td, void **sptr,
-                           const char *opt_mname, const void *buf_ptr,
-                           size_t size) {
+                           const void *buf_ptr, size_t size) {
     asn_dec_rval_t rc;
 
-    rc = OCTET_STRING_decode_jer_utf8(opt_codec_ctx, td, sptr, opt_mname,
-                                      buf_ptr, size);
+    rc = OCTET_STRING_decode_jer_utf8(opt_codec_ctx, td, sptr, buf_ptr, size);
     if(rc.code == RC_OK) {
         /*
          * Now we have a whole string in UTF-8 format.

--- a/skeletons/asn_codecs_prim.h
+++ b/skeletons/asn_codecs_prim.h
@@ -71,7 +71,7 @@ typedef enum jer_pbd_rval(jer_primitive_body_decoder_f)(
 asn_dec_rval_t jer_decode_primitive(
     const asn_codec_ctx_t *opt_codec_ctx,
     const asn_TYPE_descriptor_t *type_descriptor, void **struct_ptr,
-    size_t struct_size, const char *opt_mname, const void *buf_ptr, size_t size,
+    size_t struct_size, const void *buf_ptr, size_t size,
     jer_primitive_body_decoder_f *prim_body_decoder);
 #endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
 

--- a/skeletons/asn_codecs_prim_jer.c
+++ b/skeletons/asn_codecs_prim_jer.c
@@ -117,10 +117,9 @@ jer_decode__primitive_body(void *key, const void *chunk_buf, size_t chunk_size, 
 asn_dec_rval_t
 jer_decode_primitive(const asn_codec_ctx_t *opt_codec_ctx,
                      const asn_TYPE_descriptor_t *td, void **sptr,
-                     size_t struct_size, const char *opt_mname,
+                     size_t struct_size,
                      const void *buf_ptr, size_t size,
                      jer_primitive_body_decoder_f *prim_body_decoder) {
-    const char *xml_tag = opt_mname ? opt_mname : td->xml_tag;
     asn_struct_ctx_t s_ctx;
     struct jdp_arg_s s_arg;
     asn_dec_rval_t rc;
@@ -141,7 +140,7 @@ jer_decode_primitive(const asn_codec_ctx_t *opt_codec_ctx,
     s_arg.want_more = 0;
 
     rc = jer_decode_general(opt_codec_ctx, &s_ctx, &s_arg,
-                            xml_tag, buf_ptr, size,
+                            buf_ptr, size,
                             jer_decode__unexpected_tag,
                             jer_decode__primitive_body);
     switch(rc.code) {

--- a/skeletons/constr_CHOICE_jer.c
+++ b/skeletons/constr_CHOICE_jer.c
@@ -32,7 +32,7 @@
 asn_dec_rval_t
 CHOICE_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
                   const asn_TYPE_descriptor_t *td, void **struct_ptr,
-                  const char *opt_mname, const void *buf_ptr, size_t size) {
+                  const void *buf_ptr, size_t size) {
     /*
      * Bring closer parts of structure description.
      */
@@ -99,7 +99,6 @@ CHOICE_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
             /* Start/Continue decoding the inner member */
             tmprval = elm->type->op->jer_decoder(opt_codec_ctx,
                                                  elm->type, memb_ptr2,
-                                                 elm->name,
                                                  buf_ptr, size);
             JER_ADVANCE(tmprval.consumed);
             ASN_DEBUG("JER/CHOICE: itdf: [%s] code=%d",

--- a/skeletons/constr_SEQUENCE_jer.c
+++ b/skeletons/constr_SEQUENCE_jer.c
@@ -40,7 +40,7 @@
 asn_dec_rval_t
 SEQUENCE_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
                     const asn_TYPE_descriptor_t *td, void **struct_ptr,
-                    const char *opt_mname, const void *ptr, size_t size) {
+                    const void *ptr, size_t size) {
     /*
      * Bring closer parts of structure description.
      */
@@ -108,7 +108,7 @@ SEQUENCE_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
             } else {
                 /* Invoke the inner type decoder, m.b. multiple times */
                 tmprval = elm->type->op->jer_decoder(opt_codec_ctx,
-                                                     elm->type, memb_ptr2, elm->name,
+                                                     elm->type, memb_ptr2,
                                                      ptr, size);
             }
             JER_ADVANCE(tmprval.consumed);

--- a/skeletons/constr_SET_OF_jer.c
+++ b/skeletons/constr_SET_OF_jer.c
@@ -32,13 +32,12 @@
 asn_dec_rval_t
 SET_OF_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
                   const asn_TYPE_descriptor_t *td, void **struct_ptr,
-                  const char *opt_mname, const void *buf_ptr, size_t size) {
+                  const void *buf_ptr, size_t size) {
     /*
      * Bring closer parts of structure description.
      */
     const asn_SET_OF_specifics_t *specs = (const asn_SET_OF_specifics_t *)td->specifics;
     const asn_TYPE_member_t *element = td->elements;
-    const char *elm_tag;
 
     /*
      * ... and parts of the structure being constructed.
@@ -55,14 +54,6 @@ SET_OF_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
     if(st == 0) {
         st = *struct_ptr = CALLOC(1, specs->struct_size);
         if(st == 0) RETURN(RC_FAIL);
-    }
-
-    /* Which tag is expected for the downstream */
-    if(specs->as_XMLValueList) {
-        elm_tag = (specs->as_XMLValueList == 1) ? 0 : "";
-    } else {
-        elm_tag = (*element->name)
-                ? element->name : element->type->xml_tag;
     }
 
     /*
@@ -88,10 +79,11 @@ SET_OF_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
             asn_dec_rval_t tmprval = {RC_OK, 0};
 
             /* Invoke the inner type decoder, m.b. multiple times */
-            ASN_DEBUG("JER/SET OF element [%s]", elm_tag);
+            ASN_DEBUG("JER/SET OF element [%s]", elm_tag(*element->name) ? 
+                      element->name : element->type->xml_tag);
             tmprval = element->type->op->jer_decoder(opt_codec_ctx,
                                                      element->type,
-                                                     &ctx->ptr, elm_tag,
+                                                     &ctx->ptr,
                                                      buf_ptr, size);
             if(tmprval.code == RC_OK) {
                 asn_anonymous_set_ *list = _A_SET_FROM_VOID(st);

--- a/skeletons/constr_SET_jer.c
+++ b/skeletons/constr_SET_jer.c
@@ -39,7 +39,7 @@
 asn_dec_rval_t
 SET_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
                     const asn_TYPE_descriptor_t *td, void **struct_ptr,
-                    const char *opt_mname, const void *ptr, size_t size) {
+                    const void *ptr, size_t size) {
     /*
      * Bring closer parts of structure description.
      */
@@ -112,7 +112,7 @@ SET_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
 
             /* Invoke the inner type decoder, m.b. multiple times */
             tmprval = elm->type->op->jer_decoder(opt_codec_ctx,
-                                                 elm->type, memb_ptr2, elm->name,
+                                                 elm->type, memb_ptr2,
                                                  ptr, size);
             JER_ADVANCE(tmprval.consumed);
             if(tmprval.code != RC_OK)

--- a/skeletons/jer_decoder.c
+++ b/skeletons/jer_decoder.c
@@ -35,7 +35,7 @@ jer_decode(const asn_codec_ctx_t *opt_codec_ctx,
 	/*
 	 * Invoke type-specific decoder.
 	 */
-	return td->op->jer_decoder(opt_codec_ctx, td, struct_ptr, 0, buffer, size);
+	return td->op->jer_decoder(opt_codec_ctx, td, struct_ptr, buffer, size);
 }
 
 
@@ -210,7 +210,6 @@ asn_dec_rval_t
 jer_decode_general(const asn_codec_ctx_t *opt_codec_ctx,
 	asn_struct_ctx_t *ctx,	/* Type decoder context */
 	void *struct_key,
-	const char *json_key,	/* Expected JSON key */
 	const void *buf_ptr, size_t size,
 	int (*opt_unexpected_key_decoder)
 		(void *struct_key, const void *chunk_buf, size_t chunk_size),
@@ -223,6 +222,7 @@ jer_decode_general(const asn_codec_ctx_t *opt_codec_ctx,
 	ssize_t consumed_myself = 0;
 
 	(void)opt_codec_ctx;
+    (void)opt_unexpected_key_decoder;
 
 	/*
 	 * Phases of jer/JSON processing:

--- a/skeletons/jer_decoder.h
+++ b/skeletons/jer_decoder.h
@@ -31,7 +31,6 @@ asn_dec_rval_t jer_decode(
 typedef asn_dec_rval_t(jer_type_decoder_f)(
     const asn_codec_ctx_t *opt_codec_ctx,
     const struct asn_TYPE_descriptor_s *type_descriptor, void **struct_ptr,
-    const char *opt_mname, /* Member name */
     const void *buf_ptr, size_t size);
 
 /*******************************
@@ -48,7 +47,6 @@ asn_dec_rval_t jer_decode_general(
     const asn_codec_ctx_t *opt_codec_ctx,
     asn_struct_ctx_t *ctx, /* Type decoder context */
     void *struct_key,      /* Treated as opaque pointer */
-    const char *json_key,   /* Expected XML tag name */
     const void *buf_ptr, size_t size,
     int (*opt_unexpected_tag_decoder)(void *struct_key, const void *chunk_buf,
                                       size_t chunk_size),


### PR DESCRIPTION
Cleans up JER-related code to remove unused arguments and variables.