### PR TITLE
aper: CHOICE cast different signedness comparison

### DIFF
--- a/skeletons/constr_CHOICE_aper.c
+++ b/skeletons/constr_CHOICE_aper.c
@@ -55,7 +55,7 @@ CHOICE_decode_aper(const asn_codec_ctx_t *opt_codec_ctx,
         if(specs->ext_start == -1)
             ASN__DECODE_FAILED;
 
-        if(specs && specs->tag2el_count > specs->ext_start) {
+        if(specs && specs->tag2el_count > (unsigned)specs->ext_start) {
             value = aper_get_nsnnwn(pd); /* extension elements range */
             if(value < 0) ASN__DECODE_STARVED;
             value += specs->ext_start;


### PR DESCRIPTION
Casts signed variable to unsigned in CHOICE decoder to silence different signedness comparison warning.
The cast variable if negative can only have a value of `-1`. This is checked on the previous line so the cast is OK.