### PR TITLE
oer: OPEN TYPE encoding fix

### DIFF
--- a/skeletons/OPEN_TYPE.h
+++ b/skeletons/OPEN_TYPE.h
@@ -77,7 +77,10 @@ asn_dec_rval_t OPEN_TYPE_oer_get(
     asn_TYPE_member_t *element, const void *ptr,
     size_t size);
 #define OPEN_TYPE_decode_oer NULL
-#define OPEN_TYPE_encode_oer CHOICE_encode_oer
+asn_enc_rval_t OPEN_TYPE_encode_oer(
+    const asn_TYPE_descriptor_t *type_descriptor,
+    const asn_oer_constraints_t *constraints, const void *struct_ptr,
+    asn_app_consume_bytes_f *consume_bytes_cb, void *app_key);
 #endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
 
 #if !defined(ASN_DISABLE_UPER_SUPPORT)

--- a/skeletons/OPEN_TYPE_oer.c
+++ b/skeletons/OPEN_TYPE_oer.c
@@ -89,3 +89,50 @@ OPEN_TYPE_oer_get(const asn_codec_ctx_t *opt_codec_ctx,
     }
     return rv;
 }
+
+asn_enc_rval_t
+OPEN_TYPE_encode_oer(const asn_TYPE_descriptor_t *td,
+                  const asn_oer_constraints_t *constraints, const void *sptr,
+                  asn_app_consume_bytes_f *cb, void *app_key) {
+    asn_TYPE_member_t *elm; 
+    unsigned present;
+    const void *memb_ptr;
+    ssize_t encoded;
+    asn_enc_rval_t er = {0, 0, 0};
+
+    (void)constraints;
+
+    if(!sptr) ASN__ENCODE_FAILED;
+
+    present = CHOICE_variant_get_presence(td, sptr);
+    if(present == 0 || present > td->elements_count) {
+        ASN__ENCODE_FAILED;
+    } else {
+        present--;
+    }
+
+    ASN_DEBUG("Encoding %s OPEN TYPE element %d", td->name, present);
+
+    elm = &td->elements[present];
+    if(elm->flags & ATF_POINTER) {
+        memb_ptr =
+            *(const void *const *)((const char *)sptr + elm->memb_offset);
+        if(memb_ptr == 0) {
+            /* Mandatory element absent */
+            ASN__ENCODE_FAILED;
+        }
+    } else {
+        memb_ptr = (const void *)((const char *)sptr + elm->memb_offset);
+    }
+
+    if((encoded = oer_open_type_put(elm->type,
+                          elm->encoding_constraints.oer_constraints,
+                          memb_ptr, cb, app_key)) < 0) {
+        ASN__ENCODE_FAILED;
+    }
+
+    er.encoded = encoded;
+    ASN__ENCODED_OK(er);
+
+    return er;
+}


### PR DESCRIPTION
Fixes the encoding of a OER OPEN TYPE to use its own encoder function instead of the CHOICE encoder.
Basically replaces the encoding of the tag (of the CHOICE) for the length of the encoded contained (open) type.
The decoder logic was unchanged.

Related with issues vlm/asn1c#326, #44. 
Relevant comments: https://github.com/mouse07410/asn1c/issues/44#issuecomment-477600095, https://github.com/mouse07410/asn1c/issues/44#issuecomment-477834559.

X.696 30. (2021)