### PR TITLE
Make NativeInteger_rfill.c act more like BIT_STRING_rfill.c

### DIFF
--- a/skeletons/NativeInteger_rfill.c
+++ b/skeletons/NativeInteger_rfill.c
@@ -63,7 +63,9 @@ NativeInteger_random_fill(const asn_TYPE_descriptor_t *td, void **sptr,
                 0, sizeof(variants) / sizeof(variants[0]) - 1)];
         }
 
-        if(!constraints) constraints = &td->encoding_constraints;
+        if(!constraints || !constraints->per_constraints)
+            constraints = &td->encoding_constraints;
+
 #if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
         const asn_per_constraints_t *ct;
 


### PR DESCRIPTION
NativeInteger_rfill.c was sometimes ignoring the PER constrains,
i added a check which was also present in BIT_STRING_rfill.c and it fixed my problem.

I don't know if this was intended, it's my first PR.
Thank you!