### PR TITLE
jer: Remove implicit variables in ASN_DEBUGs

### DIFF
--- a/skeletons/constr_CHOICE_jer.c
+++ b/skeletons/constr_CHOICE_jer.c
@@ -145,7 +145,7 @@ CHOICE_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
                   ch_size>1?((const uint8_t *)buf_ptr)[1]:'?',
                   ch_size>2?((const uint8_t *)buf_ptr)[2]:'?',
                   ch_size>3?((const uint8_t *)buf_ptr)[3]:'?',
-                  json_key, scv);
+                  td->name, scv);
 
         /* Skip the extensions section */
         if(ctx->phase == 4) {
@@ -249,12 +249,12 @@ CHOICE_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
         }
 
         ASN_DEBUG("Unexpected JSON key [%c%c%c%c] in CHOICE [%s]"
-                  " (ph=%d, key=%s)",
+                  " (ph=%d)",
                   ch_size>0?((const uint8_t *)buf_ptr)[0]:'?',
                   ch_size>1?((const uint8_t *)buf_ptr)[1]:'?',
                   ch_size>2?((const uint8_t *)buf_ptr)[2]:'?',
                   ch_size>3?((const uint8_t *)buf_ptr)[3]:'?',
-                  td->name, ctx->phase, json_key);
+                  td->name, ctx->phase);
         break;
     }
 

--- a/skeletons/constr_CHOICE_jer.c
+++ b/skeletons/constr_CHOICE_jer.c
@@ -140,7 +140,7 @@ CHOICE_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
         }
 
         scv = jer_check_sym(buf_ptr, ch_size, NULL);
-        ASN_DEBUG("JER/CHOICE checked [%c%c%c%c] vs [%s], scv=%d",
+        ASN_DEBUG("JER/CHOICE checked [%c%c%c%c] of [%s], scv=%d",
                   ch_size>0?((const uint8_t *)buf_ptr)[0]:'?',
                   ch_size>1?((const uint8_t *)buf_ptr)[1]:'?',
                   ch_size>2?((const uint8_t *)buf_ptr)[2]:'?',
@@ -248,7 +248,7 @@ CHOICE_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
             break;
         }
 
-        ASN_DEBUG("Unexpected JSON key [%c%c%c%c] in CHOICE [%s]"
+        ASN_DEBUG("Unexpected JSON token [%c%c%c%c] in CHOICE [%s]"
                   " (ph=%d)",
                   ch_size>0?((const uint8_t *)buf_ptr)[0]:'?',
                   ch_size>1?((const uint8_t *)buf_ptr)[1]:'?',

--- a/skeletons/constr_CHOICE_jer.c
+++ b/skeletons/constr_CHOICE_jer.c
@@ -140,12 +140,12 @@ CHOICE_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
         }
 
         scv = jer_check_sym(buf_ptr, ch_size, NULL);
-        ASN_DEBUG("JER/CHOICE checked [%c%c%c%c], scv=%d",
+        ASN_DEBUG("JER/CHOICE checked [%c%c%c%c] vs [%s], scv=%d",
                   ch_size>0?((const uint8_t *)buf_ptr)[0]:'?',
                   ch_size>1?((const uint8_t *)buf_ptr)[1]:'?',
                   ch_size>2?((const uint8_t *)buf_ptr)[2]:'?',
                   ch_size>3?((const uint8_t *)buf_ptr)[3]:'?',
-                  scv);
+                  json_key, scv);
 
         /* Skip the extensions section */
         if(ctx->phase == 4) {
@@ -249,12 +249,12 @@ CHOICE_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
         }
 
         ASN_DEBUG("Unexpected JSON key [%c%c%c%c] in CHOICE [%s]"
-                  " (ph=%d)",
+                  " (ph=%d, key=%s)",
                   ch_size>0?((const uint8_t *)buf_ptr)[0]:'?',
                   ch_size>1?((const uint8_t *)buf_ptr)[1]:'?',
                   ch_size>2?((const uint8_t *)buf_ptr)[2]:'?',
                   ch_size>3?((const uint8_t *)buf_ptr)[3]:'?',
-                  td->name, ctx->phase);
+                  td->name, ctx->phase, json_key);
         break;
     }
 

--- a/skeletons/constr_CHOICE_jer.c
+++ b/skeletons/constr_CHOICE_jer.c
@@ -140,12 +140,12 @@ CHOICE_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
         }
 
         scv = jer_check_sym(buf_ptr, ch_size, NULL);
-        ASN_DEBUG("JER/CHOICE checked [%c%c%c%c] vs [%s], scv=%d",
+        ASN_DEBUG("JER/CHOICE checked [%c%c%c%c], scv=%d",
                   ch_size>0?((const uint8_t *)buf_ptr)[0]:'?',
                   ch_size>1?((const uint8_t *)buf_ptr)[1]:'?',
                   ch_size>2?((const uint8_t *)buf_ptr)[2]:'?',
                   ch_size>3?((const uint8_t *)buf_ptr)[3]:'?',
-                  json_key, scv);
+                  scv);
 
         /* Skip the extensions section */
         if(ctx->phase == 4) {
@@ -249,12 +249,12 @@ CHOICE_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
         }
 
         ASN_DEBUG("Unexpected JSON key [%c%c%c%c] in CHOICE [%s]"
-                  " (ph=%d, key=%s)",
+                  " (ph=%d)",
                   ch_size>0?((const uint8_t *)buf_ptr)[0]:'?',
                   ch_size>1?((const uint8_t *)buf_ptr)[1]:'?',
                   ch_size>2?((const uint8_t *)buf_ptr)[2]:'?',
                   ch_size>3?((const uint8_t *)buf_ptr)[3]:'?',
-                  td->name, ctx->phase, json_key);
+                  td->name, ctx->phase);
         break;
     }
 

--- a/skeletons/constr_SEQUENCE_jer.c
+++ b/skeletons/constr_SEQUENCE_jer.c
@@ -145,8 +145,8 @@ SEQUENCE_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
         }
 
         scv = jer_check_sym(ptr, ch_size, NULL);
-        ASN_DEBUG("JER/SEQUENCE: scv = %d, ph=%d [%s]",
-                  scv, ctx->phase, json_key);
+        ASN_DEBUG("JER/SEQUENCE: scv = %d, ph=%d",
+                  scv, ctx->phase);
 
 
         /* Skip the extensions section */

--- a/skeletons/constr_SEQUENCE_jer.c
+++ b/skeletons/constr_SEQUENCE_jer.c
@@ -146,7 +146,7 @@ SEQUENCE_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
 
         scv = jer_check_sym(ptr, ch_size, NULL);
         ASN_DEBUG("JER/SEQUENCE: scv = %d, ph=%d [%s]",
-                  scv, ctx->phase, json_key);
+                  scv, ctx->phase, td->name);
 
 
         /* Skip the extensions section */

--- a/skeletons/constr_SEQUENCE_jer.c
+++ b/skeletons/constr_SEQUENCE_jer.c
@@ -145,8 +145,8 @@ SEQUENCE_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
         }
 
         scv = jer_check_sym(ptr, ch_size, NULL);
-        ASN_DEBUG("JER/SEQUENCE: scv = %d, ph=%d",
-                  scv, ctx->phase);
+        ASN_DEBUG("JER/SEQUENCE: scv = %d, ph=%d [%s]",
+                  scv, ctx->phase, json_key);
 
 
         /* Skip the extensions section */

--- a/skeletons/constr_SET_OF_jer.c
+++ b/skeletons/constr_SET_OF_jer.c
@@ -79,7 +79,8 @@ SET_OF_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
             asn_dec_rval_t tmprval = {RC_OK, 0};
 
             /* Invoke the inner type decoder, m.b. multiple times */
-            ASN_DEBUG("JER/SET OF element [%s]", element->type->xml_tag);
+            ASN_DEBUG("JER/SET OF element [%s]", 
+                    (*element->name) ? element->name : element->type->xml_tag);
             tmprval = element->type->op->jer_decoder(opt_codec_ctx,
                                                      element->type,
                                                      &ctx->ptr,

--- a/skeletons/constr_SET_OF_jer.c
+++ b/skeletons/constr_SET_OF_jer.c
@@ -79,8 +79,7 @@ SET_OF_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
             asn_dec_rval_t tmprval = {RC_OK, 0};
 
             /* Invoke the inner type decoder, m.b. multiple times */
-            ASN_DEBUG("JER/SET OF element [%s]", elm_tag(*element->name) ? 
-                      element->name : element->type->xml_tag);
+            ASN_DEBUG("JER/SET OF element [%s]", element->type->xml_tag);
             tmprval = element->type->op->jer_decoder(opt_codec_ctx,
                                                      element->type,
                                                      &ctx->ptr,
@@ -125,7 +124,7 @@ SET_OF_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
 
         scv = jer_check_sym(buf_ptr, ch_size, NULL);
         ASN_DEBUG("JER/SET OF: scv = %d, ph=%d t=%s",
-                  scv, ctx->phase, json_key);
+                  scv, ctx->phase, td->name);
         switch(scv) {
         case JCK_AEND:
             if(ctx->phase == 0) break;

--- a/skeletons/constr_SET_OF_jer.c
+++ b/skeletons/constr_SET_OF_jer.c
@@ -79,7 +79,8 @@ SET_OF_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
             asn_dec_rval_t tmprval = {RC_OK, 0};
 
             /* Invoke the inner type decoder, m.b. multiple times */
-            ASN_DEBUG("JER/SET OF element [%s]", element->type->xml_tag);
+            ASN_DEBUG("JER/SET OF element [%s]", elm_tag(*element->name) ? 
+                      element->name : element->type->xml_tag);
             tmprval = element->type->op->jer_decoder(opt_codec_ctx,
                                                      element->type,
                                                      &ctx->ptr,
@@ -123,8 +124,8 @@ SET_OF_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
         }
 
         scv = jer_check_sym(buf_ptr, ch_size, NULL);
-        ASN_DEBUG("JER/SET OF: scv = %d, ph=%d",
-                  scv, ctx->phase);
+        ASN_DEBUG("JER/SET OF: scv = %d, ph=%d t=%s",
+                  scv, ctx->phase, json_key);
         switch(scv) {
         case JCK_AEND:
             if(ctx->phase == 0) break;

--- a/skeletons/constr_SET_OF_jer.c
+++ b/skeletons/constr_SET_OF_jer.c
@@ -79,8 +79,7 @@ SET_OF_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
             asn_dec_rval_t tmprval = {RC_OK, 0};
 
             /* Invoke the inner type decoder, m.b. multiple times */
-            ASN_DEBUG("JER/SET OF element [%s]", elm_tag(*element->name) ? 
-                      element->name : element->type->xml_tag);
+            ASN_DEBUG("JER/SET OF element [%s]", element->type->xml_tag);
             tmprval = element->type->op->jer_decoder(opt_codec_ctx,
                                                      element->type,
                                                      &ctx->ptr,
@@ -124,8 +123,8 @@ SET_OF_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
         }
 
         scv = jer_check_sym(buf_ptr, ch_size, NULL);
-        ASN_DEBUG("JER/SET OF: scv = %d, ph=%d t=%s",
-                  scv, ctx->phase, json_key);
+        ASN_DEBUG("JER/SET OF: scv = %d, ph=%d",
+                  scv, ctx->phase);
         switch(scv) {
         case JCK_AEND:
             if(ctx->phase == 0) break;

--- a/skeletons/constr_SET_jer.c
+++ b/skeletons/constr_SET_jer.c
@@ -147,8 +147,8 @@ SET_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
         }
 
         scv = jer_check_sym(ptr, ch_size, NULL);
-        ASN_DEBUG("JER/SET: scv = %d, ph=%d [%s]",
-                  scv, ctx->phase, json_key);
+        ASN_DEBUG("JER/SET: scv = %d, ph=%d",
+                  scv, ctx->phase);
 
 
         /* Skip the extensions section */

--- a/skeletons/constr_SET_jer.c
+++ b/skeletons/constr_SET_jer.c
@@ -147,8 +147,8 @@ SET_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
         }
 
         scv = jer_check_sym(ptr, ch_size, NULL);
-        ASN_DEBUG("JER/SET: scv = %d, ph=%d",
-                  scv, ctx->phase);
+        ASN_DEBUG("JER/SET: scv = %d, ph=%d [%s]",
+                  scv, ctx->phase, json_key);
 
 
         /* Skip the extensions section */

--- a/skeletons/constr_SET_jer.c
+++ b/skeletons/constr_SET_jer.c
@@ -148,7 +148,7 @@ SET_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
 
         scv = jer_check_sym(ptr, ch_size, NULL);
         ASN_DEBUG("JER/SET: scv = %d, ph=%d [%s]",
-                  scv, ctx->phase, json_key);
+                  scv, ctx->phase, td->name);
 
 
         /* Skip the extensions section */


### PR DESCRIPTION
Removes nonexistent variables _hidden_ in ASN_DEBUG macros.