### PR TITLE
jer: OBJECT IDENTIFIER missing quotes

### DIFF
--- a/skeletons/OBJECT_IDENTIFIER_jer.c
+++ b/skeletons/OBJECT_IDENTIFIER_jer.c
@@ -6,11 +6,14 @@
 #include <asn_internal.h>
 #include <OBJECT_IDENTIFIER.h>
 
+#define CQUOTE 0x22
+
 static enum jer_pbd_rval
 OBJECT_IDENTIFIER__jer_body_decode(const asn_TYPE_descriptor_t *td, void *sptr,
                                    const void *chunk_buf, size_t chunk_size) {
     OBJECT_IDENTIFIER_t *st = (OBJECT_IDENTIFIER_t *)sptr;
     const char *chunk_end = (const char *)chunk_buf + chunk_size;
+    const char *p = (const char *)chunk_buf;
     const char *endptr;
     asn_oid_arc_t s_arcs[10];
     asn_oid_arc_t *arcs = s_arcs;
@@ -18,6 +21,23 @@ OBJECT_IDENTIFIER__jer_body_decode(const asn_TYPE_descriptor_t *td, void *sptr,
     ssize_t ret;
 
     (void)td;
+
+    /* Strip quotes */
+    for (; p < chunk_end; ++p) {
+        if (*p == CQUOTE) {
+            ++p;
+            break;
+        }
+    }
+    --chunk_end;
+    for (; chunk_end >= p; --chunk_end) {
+        if (*chunk_end == CQUOTE) 
+            break;
+    }
+    if (chunk_end - p < 0) 
+        return JPBD_BROKEN_ENCODING;
+    chunk_size = chunk_end - p;
+    chunk_buf = p;
 
     num_arcs = OBJECT_IDENTIFIER_parse_arcs(
         (const char *)chunk_buf, chunk_size, arcs,
@@ -65,6 +85,7 @@ OBJECT_IDENTIFIER_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr,
                              asn_app_consume_bytes_f *cb, void *app_key) {
     const OBJECT_IDENTIFIER_t *st = (const OBJECT_IDENTIFIER_t *)sptr;
     asn_enc_rval_t er = {0,0,0};
+    ssize_t oid_encoded = 0;
 
     (void)ilevel;
     (void)flags;
@@ -73,8 +94,14 @@ OBJECT_IDENTIFIER_encode_jer(const asn_TYPE_descriptor_t *td, const void *sptr,
         ASN__ENCODE_FAILED;
     }
 
-    er.encoded = OBJECT_IDENTIFIER__dump_body(st, cb, app_key);
-    if(er.encoded < 0) ASN__ENCODE_FAILED;
+    ASN__CALLBACK("\"", 1);
+    oid_encoded = OBJECT_IDENTIFIER__dump_body(st, cb, app_key);
+    if(oid_encoded < 0) goto cb_failed;
+    er.encoded += oid_encoded;
+    ASN__CALLBACK("\"", 1);
 
     ASN__ENCODED_OK(er);
+
+cb_failed:
+    ASN__ENCODE_FAILED;
 }


### PR DESCRIPTION
Adds missing quotation marks to OBJECT IDENTIFIER JER encoder/decoder.


X.697 32. (2021)