### PR TITLE
GCC warnings fixes

### DIFF
--- a/skeletons/BIT_STRING_uper.c
+++ b/skeletons/BIT_STRING_uper.c
@@ -55,7 +55,7 @@ BIT_STRING_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
         if(!st) RETURN(RC_FAIL);
     }
 
-    ASN_DEBUG("PER Decoding %s size %ld .. %ld bits %d",
+    ASN_DEBUG("PER Decoding %s size %"ASN_PRIdMAX" .. %"ASN_PRIdMAX" bits %d",
         csiz->flags & APC_EXTENSIBLE ? "extensible" : "non-extensible",
         csiz->lower_bound, csiz->upper_bound, csiz->effective_bits);
 
@@ -79,7 +79,7 @@ BIT_STRING_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
     /* X.691, #16.7: long fixed length encoding (up to 64K octets) */
     if(csiz->effective_bits == 0) {
         int ret;
-        ASN_DEBUG("Encoding BIT STRING size %ld", csiz->upper_bound);
+        ASN_DEBUG("Encoding BIT STRING size %"ASN_PRIdMAX"", csiz->upper_bound);
         ret = per_get_many_bits(pd, st->buf, 0, csiz->upper_bound);
         if(ret < 0) RETURN(RC_WMORE);
         consumed_myself += csiz->upper_bound;
@@ -164,7 +164,7 @@ BIT_STRING_encode_uper(const asn_TYPE_descriptor_t *td,
 
     ASN_DEBUG(
         "Encoding %s into %" ASN_PRI_SIZE " bits"
-        " (%ld..%ld, effective %d)%s",
+        " (%"ASN_PRIdMAX"..%"ASN_PRIdMAX", effective %d)%s",
         td->name, size_in_bits, csiz->lower_bound, csiz->upper_bound,
         csiz->effective_bits, ct_extensible ? " EXT" : "");
 
@@ -192,11 +192,11 @@ BIT_STRING_encode_uper(const asn_TYPE_descriptor_t *td,
     if(csiz->effective_bits >= 0 && !inext) {
         int add_trailer = (ssize_t)size_in_bits < csiz->lower_bound;
         ASN_DEBUG(
-            "Encoding %" ASN_PRI_SIZE " bytes (%ld), length (in %d bits) trailer %d; actual "
+            "Encoding %" ASN_PRI_SIZE " bytes (%"ASN_PRIdMAX"), length (in %d bits) trailer %d; actual "
             "value %" ASN_PRI_SSIZE "",
             st->size, size_in_bits - csiz->lower_bound, csiz->effective_bits,
             add_trailer,
-            add_trailer ? 0 : (ssize_t)size_in_bits - csiz->lower_bound);
+            add_trailer ? 0 : (ssize_t)size_in_bits - (ssize_t)csiz->lower_bound);
         ret = per_put_few_bits(
             po, add_trailer ? 0 : (ssize_t)size_in_bits - csiz->lower_bound,
             csiz->effective_bits);

--- a/skeletons/GeneralizedTime.c
+++ b/skeletons/GeneralizedTime.c
@@ -3,7 +3,9 @@
  * Redistribution and modifications are permitted subject to BSD license.
  */
 #define	_POSIX_PTHREAD_SEMANTICS	/* for Sun */
+#ifndef _REENTRANT
 #define	_REENTRANT			/* for Sun */
+#endif
 #define __EXTENSIONS__                  /* for Sun */
 #ifndef _BSD_SOURCE
 #define _BSD_SOURCE     /* for timegm(3) */

--- a/skeletons/INTEGER_aper.c
+++ b/skeletons/INTEGER_aper.c
@@ -87,7 +87,7 @@ INTEGER_decode_aper(const asn_codec_ctx_t *opt_codec_ctx,
                         ? asn_umax2INTEGER(st, (uintmax_t)value)
                         : asn_imax2INTEGER(st, value))
                     ASN__DECODE_FAILED;
-                ASN_DEBUG("Got value %ld + low %lld",
+                ASN_DEBUG("Got value %"ASN_PRIdMAX" + low %"ASN_PRIdMAX"",
                           value, (intmax_t)ct->lower_bound);
             } else {
                 intmax_t value = 0;
@@ -111,7 +111,7 @@ INTEGER_decode_aper(const asn_codec_ctx_t *opt_codec_ctx,
                         ? asn_umax2INTEGER(st, (uintmax_t)value)
                         : asn_imax2INTEGER(st, value))
                     ASN__DECODE_FAILED;
-                ASN_DEBUG("Got value %ld + low %lld",
+                ASN_DEBUG("Got value %"ASN_PRIdMAX" + low %"ASN_PRIdMAX"",
                           value, (intmax_t)ct->lower_bound);
             }
             return rval;
@@ -191,7 +191,7 @@ INTEGER_encode_aper(const asn_TYPE_descriptor_t *td,
                         || uval > (uintmax_t)ct->upper_bound)
                     inext = 1;
             }
-            ASN_DEBUG("Value %lu (%02x/%zu) lb %lld ub %lld %s",
+            ASN_DEBUG("Value %"ASN_PRIdMAX" (%02x/%"ASN_PRI_SIZE") lb %"ASN_PRIdMAX" ub %"ASN_PRIdMAX" %s",
                       uval, st->buf[0], st->size,
                       (intmax_t)ct->lower_bound,
                       (intmax_t)ct->upper_bound,
@@ -208,7 +208,7 @@ INTEGER_encode_aper(const asn_TYPE_descriptor_t *td,
                         || value > ct->upper_bound)
                     inext = 1;
             }
-            ASN_DEBUG("Value %lu (%02x/%zu) lb %lld ub %lld %s",
+            ASN_DEBUG("Value %"ASN_PRIdMAX" (%02x/%"ASN_PRI_SIZE") lb %"ASN_PRIdMAX" ub %"ASN_PRIdMAX" %s",
                       value, st->buf[0], st->size,
                       (intmax_t)ct->lower_bound,
                       (intmax_t)ct->upper_bound,
@@ -228,7 +228,7 @@ INTEGER_encode_aper(const asn_TYPE_descriptor_t *td,
         uintmax_t v;
 
         /* #10.5.6 */
-        ASN_DEBUG("Encoding integer %ld (%lld) with range %d bits",
+        ASN_DEBUG("Encoding integer %"ASN_PRIdMAX" (%"ASN_PRIdMAX") with range %d bits",
                   value, (intmax_t)(value - ct->lower_bound),
                   ct->range_bits);
 
@@ -287,7 +287,7 @@ INTEGER_encode_aper(const asn_TYPE_descriptor_t *td,
     }
 
     if(ct && ct->lower_bound) {
-        ASN_DEBUG("Adjust lower bound to %lld", (intmax_t)ct->lower_bound);
+        ASN_DEBUG("Adjust lower bound to %"ASN_PRIdMAX"", (intmax_t)ct->lower_bound);
         /* TODO: adjust lower bound */
         ASN__ENCODE_FAILED;
     }

--- a/skeletons/INTEGER_uper.c
+++ b/skeletons/INTEGER_uper.c
@@ -63,7 +63,7 @@ INTEGER_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
                 if(uper_get_constrained_whole_number(pd,
                     &uvalue, ct->range_bits))
                     ASN__DECODE_STARVED;
-                ASN_DEBUG("Got value %lu + low %ld",
+                ASN_DEBUG("Got value %"ASN_PRIuMAX" + low %"ASN_PRIdMAX"",
                     uvalue, ct->lower_bound);
                 uvalue += ct->lower_bound;
                 if(asn_umax2INTEGER(st, uvalue))
@@ -74,7 +74,7 @@ INTEGER_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
                 if(uper_get_constrained_whole_number(pd,
                     &uvalue, ct->range_bits))
                     ASN__DECODE_STARVED;
-                ASN_DEBUG("Got value %lu + low %ld",
+                ASN_DEBUG("Got value %"ASN_PRIuMAX" + low %"ASN_PRIdMAX"",
                 uvalue, ct->lower_bound);
                 if(per_imax_range_unrebase(uvalue, ct->lower_bound,
                                            ct->upper_bound, &svalue)
@@ -160,9 +160,9 @@ INTEGER_encode_uper(const asn_TYPE_descriptor_t *td,
                 || value.u > (uintmax_t)ct->upper_bound)
                     inext = 1;
             }
-            ASN_DEBUG("Value %lu (%02x/%" ASN_PRI_SIZE ") lb %lu ub %lu %s",
+            ASN_DEBUG("Value %"ASN_PRIuMAX" (%02x/%" ASN_PRI_SIZE ") lb %"ASN_PRIuMAX" ub %"ASN_PRIuMAX" %s",
                       value.u, st->buf[0], st->size,
-                      ct->lower_bound, ct->upper_bound,
+                      (uintmax_t)ct->lower_bound, (uintmax_t)ct->upper_bound,
                       inext ? "ext" : "fix");
         } else {
             if(asn_INTEGER2imax(st, &value.s))
@@ -176,7 +176,7 @@ INTEGER_encode_uper(const asn_TYPE_descriptor_t *td,
                 || value.s > ct->upper_bound)
                     inext = 1;
             }
-            ASN_DEBUG("Value %ld (%02x/%" ASN_PRI_SIZE ") lb %ld ub %ld %s",
+            ASN_DEBUG("Value %"ASN_PRIdMAX" (%02x/%" ASN_PRI_SIZE ") lb %"ASN_PRIdMAX" ub %"ASN_PRIdMAX" %s",
                       value.s, st->buf[0], st->size,
                       ct->lower_bound, ct->upper_bound,
                       inext ? "ext" : "fix");
@@ -198,8 +198,8 @@ INTEGER_encode_uper(const asn_TYPE_descriptor_t *td,
             if(((uintmax_t)ct->lower_bound > (uintmax_t)(ct->upper_bound)
             || (value.u < (uintmax_t)ct->lower_bound))
             || (value.u > (uintmax_t)ct->upper_bound)) {
-                ASN_DEBUG("Value %lu to-be-encoded is outside the bounds [%lu, %lu]!",
-                          value.u, ct->lower_bound, ct->upper_bound);
+                ASN_DEBUG("Value %"ASN_PRIuMAX" to-be-encoded is outside the bounds [%"ASN_PRIuMAX", %"ASN_PRIuMAX"]!",
+                          value.u, (uintmax_t)ct->lower_bound, (uintmax_t)ct->upper_bound);
                 ASN__ENCODE_FAILED;
             }
             v = value.u - (uintmax_t)ct->lower_bound;
@@ -208,7 +208,7 @@ INTEGER_encode_uper(const asn_TYPE_descriptor_t *td,
                 ASN__ENCODE_FAILED;
             }
         }
-        ASN_DEBUG("Encoding integer %lu with range %d bits",
+        ASN_DEBUG("Encoding integer %"ASN_PRIuMAX" with range %d bits",
                   v, ct->range_bits);
         if(uper_put_constrained_whole_number_u(po, v, ct->range_bits))
             ASN__ENCODE_FAILED;
@@ -216,7 +216,7 @@ INTEGER_encode_uper(const asn_TYPE_descriptor_t *td,
     }
 
     if(ct && ct->lower_bound) {
-        ASN_DEBUG("Adjust lower bound to %ld", ct->lower_bound);
+        ASN_DEBUG("Adjust lower bound to %"ASN_PRIdMAX"", ct->lower_bound);
         /* TODO: adjust lower bound */
         ASN__ENCODE_FAILED;
     }

--- a/skeletons/OCTET_STRING_uper.c
+++ b/skeletons/OCTET_STRING_uper.c
@@ -90,7 +90,7 @@ OCTET_STRING_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
         if(!st) RETURN(RC_FAIL);
     }
 
-    ASN_DEBUG("PER Decoding %s size %ld .. %ld bits %d",
+    ASN_DEBUG("PER Decoding %s size %"ASN_PRIdMAX" .. %"ASN_PRIdMAX" bits %d",
               csiz->flags & APC_EXTENSIBLE ? "extensible" : "non-extensible",
               csiz->lower_bound, csiz->upper_bound, csiz->effective_bits);
 
@@ -120,7 +120,7 @@ OCTET_STRING_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
     if(csiz->effective_bits == 0) {
         int ret;
         if(bpc) {
-            ASN_DEBUG("Encoding OCTET STRING size %ld",
+            ASN_DEBUG("Encoding OCTET STRING size %"ASN_PRIdMAX"",
                       csiz->upper_bound);
             ret = OCTET_STRING_per_get_characters(pd, st->buf,
                                                   csiz->upper_bound,
@@ -130,7 +130,7 @@ OCTET_STRING_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
                                                   pc);
             if(ret > 0) RETURN(RC_FAIL);
         } else {
-            ASN_DEBUG("Encoding BIT STRING size %ld",
+            ASN_DEBUG("Encoding BIT STRING size %"ASN_PRIdMAX"",
                       csiz->upper_bound);
             ret = per_get_many_bits(pd, st->buf, 0,
                                     unit_bits * csiz->upper_bound);
@@ -250,7 +250,7 @@ OCTET_STRING_encode_uper(const asn_TYPE_descriptor_t *td,
     }
 
     ASN_DEBUG("Encoding %s into %" ASN_PRI_SIZE " units of %d bits"
-              " (%ld..%ld, effective %d)%s",
+              " (%"ASN_PRIdMAX"..%"ASN_PRIdMAX", effective %d)%s",
               td->name, size_in_units, unit_bits,
               csiz->lower_bound, csiz->upper_bound,
               csiz->effective_bits, ct_extensible ? " EXT" : "");
@@ -279,7 +279,7 @@ OCTET_STRING_encode_uper(const asn_TYPE_descriptor_t *td,
     }
 
     if(csiz->effective_bits >= 0 && !inext) {
-        ASN_DEBUG("Encoding %" ASN_PRI_SIZE " bytes (%ld), length in %d bits", st->size,
+        ASN_DEBUG("Encoding %" ASN_PRI_SIZE " bytes (%"ASN_PRIdMAX"), length in %d bits", st->size,
                   size_in_units - csiz->lower_bound, csiz->effective_bits);
         ret = per_put_few_bits(po, size_in_units - csiz->lower_bound,
                                csiz->effective_bits);

--- a/skeletons/RELATIVE-OID_xer.c
+++ b/skeletons/RELATIVE-OID_xer.c
@@ -10,7 +10,7 @@ static enum xer_pbd_rval
 RELATIVE_OID__xer_body_decode(const asn_TYPE_descriptor_t *td, void *sptr,
                               const void *chunk_buf, size_t chunk_size) {
     RELATIVE_OID_t *st = (RELATIVE_OID_t *)sptr;
-    const char *chunk_end = (const char *)chunk_buf + chunk_size;
+    const char *chunk_end __attribute__((unused)) = (const char *)chunk_buf + chunk_size;
     const char *endptr;
     asn_oid_arc_t s_arcs[6];
     asn_oid_arc_t *arcs = s_arcs;

--- a/skeletons/UTCTime_print.c
+++ b/skeletons/UTCTime_print.c
@@ -31,7 +31,7 @@ UTCTime_print(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
             return (cb("<bad-value>", 11, app_key) < 0) ? -1 : 0;
 
         ret = snprintf(buf, sizeof(buf),
-                       "%04d-%02d-%02d %02d:%02d:%02d (GMT)",
+                       "%04d-%02d-%02d %02d:%02d:%02d (UTC)",
                        tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
                        tm.tm_hour, tm.tm_min, tm.tm_sec);
         assert(ret > 0 && ret < (int)sizeof(buf));

--- a/skeletons/asn_system.h
+++ b/skeletons/asn_system.h
@@ -78,11 +78,23 @@ typedef	unsigned int	uint32_t;
 #else	/* !defined(__vxworks) */
 
 #include <inttypes.h>	/* C99 specifies this file */
+#ifdef HAVE_ARPA_INET_H
+#include <arpa/inet.h> /* for ntohl() */
+#define	sys_ntohl(foo)	ntohl(foo)
+#else /* !_HAVE_ARPA_INET_H */
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h> /* for ntohl() */
-#endif
 #define	sys_ntohl(foo)	ntohl(foo)
+#else /* !_HAVE_NETINET_IN_H */
+/* Here's the definition of ntohl() */
+#define sys_ntohl(l)   ((((l) << 24)  & 0xff000000)    \
+            | (((l) << 8) & 0xff0000)  \
+            | (((l) >> 8)  & 0xff00)   \
+            | ((l >> 24) & 0xff))
+#endif /* HAVE_NETINET_IN_H */
+#endif /* HAVE_ARPA_INET_H */
 #endif	/* defined(__vxworks) */
+
 
 #endif	/* _WIN32 */
 

--- a/skeletons/constr_CHOICE_jer.c
+++ b/skeletons/constr_CHOICE_jer.c
@@ -83,7 +83,7 @@ CHOICE_decode_jer(const asn_codec_ctx_t *opt_codec_ctx,
             asn_dec_rval_t tmprval;
             void *memb_ptr;    /* Pointer to the member */
             void **memb_ptr2;  /* Pointer to that pointer */
-            unsigned old_present;
+            unsigned old_present __attribute__((unused));
 
             elm = &td->elements[edx];
 

--- a/skeletons/constr_CHOICE_uper.c
+++ b/skeletons/constr_CHOICE_uper.c
@@ -140,7 +140,7 @@ CHOICE_encode_uper(const asn_TYPE_descriptor_t *td,
         || present_enc > ct->upper_bound) {
             if(ct->flags & APC_EXTENSIBLE) {
                 ASN_DEBUG(
-                    "CHOICE member %d (enc %d) is an extension (%ld..%ld)",
+                    "CHOICE member %d (enc %d) is an extension (%"ASN_PRIdMAX"..%"ASN_PRIdMAX")",
                     present, present_enc, ct->lower_bound, ct->upper_bound);
                 if(per_put_few_bits(po, 1, 1))
                     ASN__ENCODE_FAILED;
@@ -151,7 +151,7 @@ CHOICE_encode_uper(const asn_TYPE_descriptor_t *td,
         }
     }
     if(ct && ct->flags & APC_EXTENSIBLE) {
-        ASN_DEBUG("CHOICE member %d (enc %d) is not an extension (%ld..%ld)",
+        ASN_DEBUG("CHOICE member %d (enc %d) is not an extension (%"ASN_PRIdMAX"..%"ASN_PRIdMAX")",
                   present, present_enc, ct->lower_bound, ct->upper_bound);
         if(per_put_few_bits(po, 0, 1))
             ASN__ENCODE_FAILED;

--- a/skeletons/constr_CHOICE_xer.c
+++ b/skeletons/constr_CHOICE_xer.c
@@ -86,7 +86,7 @@ CHOICE_decode_xer(const asn_codec_ctx_t *opt_codec_ctx,
             asn_dec_rval_t tmprval;
             void *memb_ptr;    /* Pointer to the member */
             void **memb_ptr2;  /* Pointer to that pointer */
-            unsigned old_present;
+            unsigned old_present __attribute__((unused));
 
             elm = &td->elements[edx];
 

--- a/skeletons/constr_SEQUENCE_OF_uper.c
+++ b/skeletons/constr_SEQUENCE_OF_uper.c
@@ -33,7 +33,7 @@ SEQUENCE_OF_encode_uper(const asn_TYPE_descriptor_t *td,
     if(ct) {
         int not_in_root =
             (list->count < ct->lower_bound || list->count > ct->upper_bound);
-        ASN_DEBUG("lb %ld ub %ld %s", ct->lower_bound, ct->upper_bound,
+        ASN_DEBUG("lb %"ASN_PRIdMAX" ub %"ASN_PRIdMAX" %s", ct->lower_bound, ct->upper_bound,
                   ct->flags & APC_EXTENSIBLE ? "ext" : "fix");
         if(ct->flags & APC_EXTENSIBLE) {
             /* Declare whether size is in extension root */

--- a/skeletons/constr_SET_OF_uper.c
+++ b/skeletons/constr_SET_OF_uper.c
@@ -47,7 +47,7 @@ SET_OF_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
     if(ct && ct->effective_bits >= 0) {
         /* X.691, #19.5: No length determinant */
         nelems = per_get_few_bits(pd, ct->effective_bits);
-        ASN_DEBUG("Preparing to fetch %ld+%ld elements from %s",
+        ASN_DEBUG("Preparing to fetch %ld+%"ASN_PRIdMAX" elements from %s",
                   (long)nelems, ct->lower_bound, td->name);
         if(nelems < 0)  ASN__DECODE_STARVED;
         nelems += ct->lower_bound;
@@ -130,7 +130,7 @@ SET_OF_encode_uper(const asn_TYPE_descriptor_t *td,
     if(ct) {
         int not_in_root =
             (list->count < ct->lower_bound || list->count > ct->upper_bound);
-        ASN_DEBUG("lb %ld ub %ld %s", ct->lower_bound, ct->upper_bound,
+        ASN_DEBUG("lb %"ASN_PRIdMAX" ub %"ASN_PRIdMAX" %s", ct->lower_bound, ct->upper_bound,
                   ct->flags & APC_EXTENSIBLE ? "ext" : "fix");
         if(ct->flags & APC_EXTENSIBLE) {
             /* Declare whether size is in extension root */


### PR DESCRIPTION
 - fixed format specifiers warnings (including 32bit systems);
 - fixed _REENTRANT redefinition (appears in some cases after asn1 pdus compile);
 - fixed ntohl implicit declaration (appeared at armhf debian bullseye);
 - fixed unused constants warnings appeared with DNDEBUG;
 - changed print format in UTCTime_print.c (questionable but it'd be nice to have different debug prints).