### PR TITLE
jer: Pure hexadecimal JSON OCTET STRINGs

### DIFF
--- a/skeletons/OCTET_STRING_jer.c
+++ b/skeletons/OCTET_STRING_jer.c
@@ -252,10 +252,6 @@ static ssize_t OCTET_STRING__convert_hexadecimal(void *sptr, const void *chunk_b
     for(; p < pend; p++) {
         int ch = *(const unsigned char *)p;
         switch(ch) {
-        case 0x09: case 0x0a: case 0x0c: case 0x0d:
-        case 0x20:
-            /* Ignore whitespace */
-            continue;
         case 0x30: case 0x31: case 0x32: case 0x33: case 0x34:  /*01234*/
         case 0x35: case 0x36: case 0x37: case 0x38: case 0x39:  /*56789*/
             clv = (clv << 4) + (ch - 0x30);

--- a/tests/tests-skeletons/check-OCTET_STRING.c
+++ b/tests/tests-skeletons/check-OCTET_STRING.c
@@ -7,33 +7,58 @@
 #include <BIT_STRING.h>
 
 enum encoding_type { HEX, BINARY, UTF8 };
+enum encoding_rules { XER, JER };
 
-#define check(t, tag, buf, verify)  check_impl(__LINE__, t, tag, buf, verify)
+#define check_xer(t, tag, buf, verify)  check_impl(__LINE__, XER, t, tag,  buf, verify)
+#define check_jer(t, buf, verify)       check_impl(__LINE__, JER, t, NULL, buf, verify)
 
 static void
-check_impl(int lineno, enum encoding_type type, char *tagname, char *xmlbuf, char *verify) {
+check_impl(int lineno, enum encoding_rules rules, enum encoding_type type, char *tagname, char *xmlbuf, char *verify) {
 	size_t xmllen = strlen(xmlbuf);
 	size_t verlen = verify ? strlen(verify) : 0;
 	asn_TYPE_descriptor_t *td = &asn_DEF_OCTET_STRING;
 	OCTET_STRING_t *st = 0;
 	OCTET_STRING_t **stp = &st;
 	asn_dec_rval_t rc;
-	xer_type_decoder_f *decoder = 0;
+    switch(rules) {
+    case XER:
+        ;
+        xer_type_decoder_f *xer_decoder = 0;
 
-	switch(type) {
-	case HEX:
-		decoder = OCTET_STRING_decode_xer_hex;
-		break;
-	case BINARY:
-		td = &asn_DEF_BIT_STRING;
-		decoder = OCTET_STRING_decode_xer_binary;
-		break;
-	case UTF8:
-		decoder = OCTET_STRING_decode_xer_utf8;
-		break;
-	}
+        switch(type) {
+        case HEX:
+            xer_decoder = OCTET_STRING_decode_xer_hex;
+            break;
+        case BINARY:
+            td = &asn_DEF_BIT_STRING;
+            xer_decoder = OCTET_STRING_decode_xer_binary;
+            break;
+        case UTF8:
+            xer_decoder = OCTET_STRING_decode_xer_utf8;
+            break;
+        }
 
-	rc = decoder(0, td, (void **)stp, tagname, xmlbuf, xmllen);
+        rc = xer_decoder(0, td, (void **)stp, tagname, xmlbuf, xmllen);
+        break;
+    case JER:
+        ;
+        jer_type_decoder_f *jer_decoder = 0;
+
+        switch(type) {
+        case HEX:
+            jer_decoder = OCTET_STRING_decode_jer_hex;
+            break;
+        case UTF8:
+            jer_decoder = OCTET_STRING_decode_jer_utf8;
+            break;
+        default:
+            /* Not supported */
+            assert(0);
+        }
+
+        rc = jer_decoder(0, td, NULL, (void **)stp, xmlbuf, xmllen);
+        break;
+    }
 	printf("%03d: [%s] => [%s]:%zu vs [%s]:%zu, code %d\n",
 		lineno, xmlbuf,
 		st ? (const char *)st->buf : "", st ? st->size : 0,
@@ -86,68 +111,80 @@ encode(char *orig, char *encoded) {
 int
 main() {
 
-	check(HEX, 0, "<OCTET_STRING>41424</OCTET_STRING>",
+	check_xer(HEX, 0, "<OCTET_STRING>41424</OCTET_STRING>",
 		"AB@");
 
-	check(HEX, 0, "<!--comment--><OCTET_STRING>\n"
+	check_xer(HEX, 0, "<!--comment--><OCTET_STRING>\n"
 		"<!--comment-->41424</OCTET_STRING>",
 		"AB@");
 
-	check(HEX, 0, "<OCTET_STRING blah blah> 4 1 4 2 4 5 44 </OCTET_STRING>",
+	check_xer(HEX, 0, "<OCTET_STRING blah blah> 4 1 4 2 4 5 44 </OCTET_STRING>",
 		"ABED");
 
 	/* Some hard cases */
-	check(HEX, "z", "<z><!-- < -->40</z>", "@");
-	check(HEX, "z", "<z><!-- <-->40</z>", "@");
-	check(HEX, "z", "<z><!-- -->>40</z>", 0);
-	check(HEX, "z", "<z><!-- <some <sometag>-->40</z>", "@");
-	check(HEX, "z", "<z><!-- <some <sometag-->>40</z>", 0);
+	check_xer(HEX, "z", "<z><!-- < -->40</z>", "@");
+	check_xer(HEX, "z", "<z><!-- <-->40</z>", "@");
+	check_xer(HEX, "z", "<z><!-- -->>40</z>", 0);
+	check_xer(HEX, "z", "<z><!-- <some <sometag>-->40</z>", "@");
+	check_xer(HEX, "z", "<z><!-- <some <sometag-->>40</z>", 0);
 
-	check(HEX, "z", "ignored<z>40</z>stuff", "@");
+	check_xer(HEX, "z", "ignored<z>40</z>stuff", "@");
 
-	check(HEX, "tag", "<tag>4</tag>", "@");
-	check(HEX, "a-z", "<a-z>7 375 73 6c6 9<!--/-->6 b</a-z>", "suslik");
+	check_xer(HEX, "tag", "<tag>4</tag>", "@");
+	check_xer(HEX, "a-z", "<a-z>7 375 73 6c6 9<!--/-->6 b</a-z>", "suslik");
 
 	/* This one has a comment in a not-yet-supported place */ 
 	/* check(HEX, "a-z", "<a-z>73 75 73 6c 6<!--/-->9 6b</a-z>",
 		"suslik"); */
 
-	check(BINARY, "tag", "<tag/>", "");
-	check(BINARY, "tag", "<tag>blah</tag>", 0);
-	check(BINARY, "tag", "<tag>01000001</tag>", "A");
-	check(BINARY, "tag", "<tag>01000<!--blah--> 00 101 00001</tag>", "AB");
+	check_xer(BINARY, "tag", "<tag/>", "");
+	check_xer(BINARY, "tag", "<tag>blah</tag>", 0);
+	check_xer(BINARY, "tag", "<tag>01000001</tag>", "A");
+	check_xer(BINARY, "tag", "<tag>01000<!--blah--> 00 101 00001</tag>", "AB");
 
-	check(UTF8, 0, "<OCTET_STRING>one, two, three</OCTET_STRING>",
+	check_xer(UTF8, 0, "<OCTET_STRING>one, two, three</OCTET_STRING>",
 		"one, two, three");
 
-	check(UTF8, "z", "<z></z>", "");
-	check(UTF8, "z", "<z z z>&lt;&amp;&gt;</z z z>", "<&>");
-	check(UTF8, "z", "<z z z>a&lt;b&amp;c&gt;d</z z z>", "a<b&c>d");
-	check(UTF8, "z", "<z z z>a&lt</z z z>", "a&lt");
-	check(UTF8, "z", "<z z z>a&sdfsdfsdf;b</z z z>", "a&sdfsdfsdf;b");
-	check(UTF8, "z", "<z z z>a&#x20;b</z z z>", "a b");
-	check(UTF8, "z", "<z z z>a&#32;b</z z z>", "a b");
-	check(UTF8, "z", "<z>a&#32323;b</z>", "a\347\271\203b");
-	check(UTF8, "z", "<z>a&#x4fc4;|</z>", "a\xe4\xbf\x84|");
+	check_xer(UTF8, "z", "<z></z>", "");
+	check_xer(UTF8, "z", "<z z z>&lt;&amp;&gt;</z z z>", "<&>");
+	check_xer(UTF8, "z", "<z z z>a&lt;b&amp;c&gt;d</z z z>", "a<b&c>d");
+	check_xer(UTF8, "z", "<z z z>a&lt</z z z>", "a&lt");
+	check_xer(UTF8, "z", "<z z z>a&sdfsdfsdf;b</z z z>", "a&sdfsdfsdf;b");
+	check_xer(UTF8, "z", "<z z z>a&#x20;b</z z z>", "a b");
+	check_xer(UTF8, "z", "<z z z>a&#32;b</z z z>", "a b");
+	check_xer(UTF8, "z", "<z>a&#32323;b</z>", "a\347\271\203b");
+	check_xer(UTF8, "z", "<z>a&#x4fc4;|</z>", "a\xe4\xbf\x84|");
     /* Last unicode point */
-	check(UTF8, "z", "<z>a&#x10ffff;|</z>", "a\xf4\x8f\xbf\xbf|");
-	check(UTF8, "z", "<z>a&#1114111;|</z>", "a\xf4\x8f\xbf\xbf|");
+	check_xer(UTF8, "z", "<z>a&#x10ffff;|</z>", "a\xf4\x8f\xbf\xbf|");
+	check_xer(UTF8, "z", "<z>a&#1114111;|</z>", "a\xf4\x8f\xbf\xbf|");
     /* One past the last unicode point */
-	check(UTF8, "z", "<z>a&#x110000;|</z>", "a&#x110000;|");
-	check(UTF8, "z", "<z>a&#1114112;|</z>", "a&#1114112;|");
-	check(UTF8, "z", "<z>a&#3000000000;b</z>", "a&#3000000000;b");
-	check(UTF8, "z", "<z>a&#5000000000;b</z>", "a&#5000000000;b");
-	check(UTF8, "z", "<z>a&#300</z>", "a&#300");
-	check(UTF8, "z", "<z>a&#-300;</z>", "a&#-300;");
-	check(UTF8, "z", "<z>a<ff/>b</z>", "a\014b");
-	check(UTF8, "z", "<z>a<soh/>b</z>", "a\001b");
-	check(UTF8, "z", "<z>a<bel/></z>", "a\007");
+	check_xer(UTF8, "z", "<z>a&#x110000;|</z>", "a&#x110000;|");
+	check_xer(UTF8, "z", "<z>a&#1114112;|</z>", "a&#1114112;|");
+	check_xer(UTF8, "z", "<z>a&#3000000000;b</z>", "a&#3000000000;b");
+	check_xer(UTF8, "z", "<z>a&#5000000000;b</z>", "a&#5000000000;b");
+	check_xer(UTF8, "z", "<z>a&#300</z>", "a&#300");
+	check_xer(UTF8, "z", "<z>a&#-300;</z>", "a&#-300;");
+	check_xer(UTF8, "z", "<z>a<ff/>b</z>", "a\014b");
+	check_xer(UTF8, "z", "<z>a<soh/>b</z>", "a\001b");
+	check_xer(UTF8, "z", "<z>a<bel/></z>", "a\007");
 
 	encode("", "");
 	encode("a", "a");
 	encode("a\nb", "a\nb");
 	encode("a\bc", "a<bs/>c");
 	encode("ab\01c\ndef\r\n", "ab<soh/>c\ndef\r\n");
+
+	check_jer(HEX, "\"\"", "");
+	check_jer(HEX, "\"", 0);
+	check_jer(HEX, "", 0);
+	check_jer(HEX, "\"6869\"", "hi");
+	check_jer(HEX, "\"68 69\"", 0);
+
+	check_jer(UTF8, "\"\"", "");
+	check_jer(UTF8, "\"", 0);
+	check_jer(UTF8, "", 0);
+	check_jer(UTF8, "\"hi\"", "hi");
+	check_jer(UTF8, "\"h i\"", "h i");
 
 	return 0;
 }


### PR DESCRIPTION
As per X.697 25.3 2021, a JER OCTET STRING must be composed of only hexadecimal characters (inside quotation marks). 
This PR makes the JER decoder reject OCTET STRINGs which have whitespaces/similar characters. Tests for JER OCTET STRINGs are also added.