### PR TITLE
rename HAVE_CONFIG_H to HAVE_ASN1C_CONFIG_H

### DIFF
--- a/examples/sample.makefile.regen
+++ b/examples/sample.makefile.regen
@@ -37,7 +37,7 @@ if test ! -f converter-example.mk ; then
 fi
 
 EXTRA_CFLAGS="-DJUNKTEST -D_DEFAULT_SOURCE"
-test -f config.h && EXTRA_CFLAGS="-DHAVE_CONFIG_H ${EXTRA_CFLAGS}"
+test -f config.h && EXTRA_CFLAGS="-DHAVE_ASN1C_CONFIG_H ${EXTRA_CFLAGS}"
 test -n "$TITLE" && EXTRA_CFLAGS="-DASN_CONVERTER_TITLE=\"$TITLE\" ${EXTRA_CFLAGS}"
 
 {

--- a/libasn1common/asn1_common.h
+++ b/libasn1common/asn1_common.h
@@ -23,7 +23,7 @@
  * SUCH DAMAGE.
  *
  */
-#ifdef HAVE_CONFIG_H
+#ifdef HAVE_ASN1C_CONFIG_H
 #include <config.h>
 #endif
 

--- a/libasn1compiler/asn1c_internal.h
+++ b/libasn1compiler/asn1c_internal.h
@@ -1,7 +1,7 @@
 #ifndef	ASN1_COMPILER_INTERNAL_H
 #define	ASN1_COMPILER_INTERNAL_H
 
-#ifdef	HAVE_CONFIG_H
+#ifdef	HAVE_ASN1C_CONFIG_H
 #include <config.h>
 #endif
 

--- a/libasn1fix/asn1fix_internal.h
+++ b/libasn1fix/asn1fix_internal.h
@@ -1,7 +1,7 @@
 #ifndef	ASN1FIX_INTERNAL_H
 #define	ASN1FIX_INTERNAL_H
 
-#ifdef	HAVE_CONFIG_H
+#ifdef	HAVE_ASN1C_CONFIG_H
 #include <config.h>
 #endif
 

--- a/libasn1parser/asn1p_integer.h
+++ b/libasn1parser/asn1p_integer.h
@@ -1,9 +1,9 @@
 #ifndef	ASN1P_INTEGER_H
 #define	ASN1P_INTEGER_H
 
-#ifdef	HAVE_CONFIG_H
+#ifdef	HAVE_ASN1C_CONFIG_H
 #include "config.h"
-#endif	/* HAVE_CONFIG_H */
+#endif	/* HAVE_ASN1C_CONFIG_H */
 
 #include <asn1_buffer.h>
 

--- a/libasn1parser/asn1parser.h
+++ b/libasn1parser/asn1parser.h
@@ -4,9 +4,9 @@
 #ifndef	ASN1PARSER_H
 #define	ASN1PARSER_H
 
-#ifdef	HAVE_CONFIG_H
+#ifdef	HAVE_ASN1C_CONFIG_H
 #include "config.h"
-#endif	/* HAVE_CONFIG_H */
+#endif	/* HAVE_ASN1C_CONFIG_H */
 
 #include "asn1_ref.h"
 #include "asn1_buffer.h"

--- a/skeletons/asn_system.h
+++ b/skeletons/asn_system.h
@@ -8,7 +8,7 @@
 #ifndef	ASN_SYSTEM_H
 #define	ASN_SYSTEM_H
 
-#ifdef	HAVE_CONFIG_H
+#ifdef	HAVE_ASN1C_CONFIG_H
 #include "config.h"
 #endif
 

--- a/skeletons/converter-example.c
+++ b/skeletons/converter-example.c
@@ -7,7 +7,7 @@
  *
  * cc -DPDU=MyCustomType -o myDecoder.o -c converter-example.c
  */
-#ifdef    HAVE_CONFIG_H
+#ifdef    HAVE_ASN1C_CONFIG_H
 #include <config.h>
 #endif
 #define __EXTENSIONS__


### PR DESCRIPTION
other projects like CppUTest also use HAVE_CONFIG_H so this will reduce
conflicts

Closes #201
