### PR TITLE
ci: improve ci action run-time

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -18,8 +18,8 @@ jobs:
     - name: configure
       run: ./configure
     - name: make
-      run: make
+      run: make -j
     - name: make check
-      run: make check
+      run: make -j check
     - name: make distcheck
-      run: make distcheck
+      run: make -j distcheck


### PR DESCRIPTION
Improve ci action run-time by using the `make`'s capability of running multiple jobs at once. 
This change decreases the ci action run-time from 1h 24m to 37m.