### PR TITLE
Enforce constraints check for UINT

### DIFF
--- a/skeletons/INTEGER_uper.c
+++ b/skeletons/INTEGER_uper.c
@@ -67,7 +67,7 @@ INTEGER_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
                     uvalue, ct->lower_bound);
                 uvalue += ct->lower_bound;
                 if (uvalue > (uintmax_t)ct->upper_bound)
-                    ASN_DECODE_FAILED;
+                    ASN__DECODE_FAILED;
                 if(asn_umax2INTEGER(st, uvalue))
                     ASN__DECODE_FAILED;
             } else {

--- a/skeletons/INTEGER_uper.c
+++ b/skeletons/INTEGER_uper.c
@@ -66,6 +66,8 @@ INTEGER_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
                 ASN_DEBUG("Got value %"ASN_PRIuMAX" + low %"ASN_PRIdMAX"",
                     uvalue, ct->lower_bound);
                 uvalue += ct->lower_bound;
+                if (uvalue > (uintmax_t)ct->upper_bound)
+                  ASN_DECODE_FAILED;
                 if(asn_umax2INTEGER(st, uvalue))
                     ASN__DECODE_FAILED;
             } else {

--- a/skeletons/INTEGER_uper.c
+++ b/skeletons/INTEGER_uper.c
@@ -67,7 +67,7 @@ INTEGER_decode_uper(const asn_codec_ctx_t *opt_codec_ctx,
                     uvalue, ct->lower_bound);
                 uvalue += ct->lower_bound;
                 if (uvalue > (uintmax_t)ct->upper_bound)
-                  ASN_DECODE_FAILED;
+                    ASN_DECODE_FAILED;
                 if(asn_umax2INTEGER(st, uvalue))
                     ASN__DECODE_FAILED;
             } else {


### PR DESCRIPTION
Update INTEGER_uper.c to add upper bound check during decoding. Thank you, @zhouxt1