### PR TITLE
Enforce constraints on ENUMERATED types.

### DIFF
--- a/skeletons/Makefile.am
+++ b/skeletons/Makefile.am
@@ -151,6 +151,7 @@ libasn1cskeletons_la_SOURCES =                  \
     NULL_xer.c                                  \
     NULL_jer.c                                  \
     NativeEnumerated_aper.c                     \
+    NativeEnumerated_ber.c                      \
     NativeEnumerated_uper.c                     \
     NativeEnumerated_xer.c                      \
     NativeEnumerated_jer.c                      \
@@ -263,4 +264,3 @@ check_converter_c89_32_example_CFLAGS = $(CFLAGS_M32) -DNO_ASN_PDU
 check_converter_c89_32_example_SOURCES = converter-example.c
 check_converter_c89_32_example_LDADD = libasn1cskeletons_c89_32.la
 endif
-

--- a/skeletons/NativeEnumerated.c
+++ b/skeletons/NativeEnumerated.c
@@ -82,7 +82,7 @@ NativeEnumerated_constraint(const asn_TYPE_descriptor_t *td, const void *sptr,
                       asn_app_constraint_failed_f *ctfailcb, void *app_key) {
     const asn_INTEGER_specifics_t *specs =
         (const asn_INTEGER_specifics_t *)td->specifics;
-    long *native = (long *)sptr;
+    const long *native = (const long *)sptr;
     const asn_INTEGER_enum_map_t *el;
     el = INTEGER_map_value2enum(specs, *native);
     if(el) {

--- a/skeletons/NativeEnumerated.c
+++ b/skeletons/NativeEnumerated.c
@@ -28,14 +28,14 @@ asn_TYPE_operation_t asn_OP_NativeEnumerated = {
     NativeInteger_compare,
     NativeInteger_copy,
 #if !defined(ASN_DISABLE_BER_SUPPORT)
-    NativeInteger_decode_ber,
-    NativeInteger_encode_der,
+    NativeEnumerated_decode_ber,
+    NativeEnumerated_encode_der,
 #else
     0,
     0,
 #endif  /* !defined(ASN_DISABLE_BER_SUPPORT) */
 #if !defined(ASN_DISABLE_XER_SUPPORT)
-    NativeInteger_decode_xer,
+    NativeEnumerated_decode_xer,
     NativeEnumerated_encode_xer,
 #else
     0,
@@ -76,6 +76,23 @@ asn_TYPE_operation_t asn_OP_NativeEnumerated = {
 #endif  /* !defined(ASN_DISABLE_RFILL_SUPPORT) */
     0  /* Use generic outmost tag fetcher */
 };
+
+int
+NativeEnumerated_constraint(const asn_TYPE_descriptor_t *td, const void *sptr,
+                      asn_app_constraint_failed_f *ctfailcb, void *app_key) {
+    const asn_INTEGER_specifics_t *specs =
+        (const asn_INTEGER_specifics_t *)td->specifics;
+    long *native = (long *)sptr;
+    const asn_INTEGER_enum_map_t *el;
+    el = INTEGER_map_value2enum(specs, *native);
+    if(el) {
+        return 0;
+    } else {
+        ASN_DEBUG("No element corresponds to the value %ld", *native);
+        return -1;
+    }
+}
+
 asn_TYPE_descriptor_t asn_DEF_NativeEnumerated = {
     "ENUMERATED",  /* The ASN.1 type is still ENUMERATED */
     "ENUMERATED",
@@ -94,7 +111,7 @@ asn_TYPE_descriptor_t asn_DEF_NativeEnumerated = {
 #if !defined(ASN_DISABLE_JER_SUPPORT)
         0,
 #endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
-        asn_generic_no_constraint
+        NativeEnumerated_constraint
     },
     0, 0,  /* No members */
     0  /* No specifics */

--- a/skeletons/NativeEnumerated.h
+++ b/skeletons/NativeEnumerated.h
@@ -31,15 +31,15 @@ extern asn_TYPE_operation_t asn_OP_NativeEnumerated;
 #define NativeEnumerated_compare NativeInteger_compare
 #define NativeEnumerated_copy    NativeInteger_copy
 
-#define NativeEnumerated_constraint asn_generic_no_constraint
+asn_constr_check_f NativeEnumerated_constraint;
 
 #if !defined(ASN_DISABLE_BER_SUPPORT)
-#define NativeEnumerated_decode_ber NativeInteger_decode_ber
-#define NativeEnumerated_encode_der NativeInteger_encode_der
-#endif  /* !defined(ASN_DISABLE_BER_SUPPORT) */
+ber_type_decoder_f NativeEnumerated_decode_ber;
+der_type_encoder_f NativeEnumerated_encode_der;
+#endif /* !defined(ASN_DISABLE_BER_SUPPORT) */
 
 #if !defined(ASN_DISABLE_XER_SUPPORT)
-#define NativeEnumerated_decode_xer NativeInteger_decode_xer
+xer_type_decoder_f NativeEnumerated_decode_xer;
 xer_type_encoder_f NativeEnumerated_encode_xer;
 #endif  /* !defined(ASN_DISABLE_XER_SUPPORT) */
 

--- a/skeletons/NativeEnumerated_ber.c
+++ b/skeletons/NativeEnumerated_ber.c
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2017 Lev Walkin <vlm@lionet.info>.
+ * All rights reserved.
+ * Redistribution and modifications are permitted subject to BSD license.
+ */
+#include <asn_internal.h>
+#include <NativeInteger.h>
+#include <INTEGER.h>
+
+/*
+ * Decode NativeEnumerated type.
+ */
+asn_dec_rval_t
+NativeEnumerated_decode_ber(const asn_codec_ctx_t *opt_codec_ctx,
+                         const asn_TYPE_descriptor_t *td, void **nint_ptr,
+                         const void *buf_ptr, size_t size, int tag_mode) {
+    const asn_INTEGER_specifics_t *specs =
+        (const asn_INTEGER_specifics_t *)td->specifics;
+    long *native = (long *)*nint_ptr;
+    const asn_INTEGER_enum_map_t *el;
+    asn_dec_rval_t rval;
+    ber_tlv_len_t length;
+
+    /*
+     * If the structure is not there, allocate it.
+     */
+    if(native == NULL) {
+        native = (long *)(*nint_ptr = CALLOC(1, sizeof(*native)));
+        if(native == NULL) {
+            rval.code = RC_FAIL;
+            rval.consumed = 0;
+            return rval;
+        }
+    }
+
+    ASN_DEBUG("Decoding %s as NativeEnumerated (tm=%d)",
+              td->name, tag_mode);
+
+    /*
+     * Check tags.
+     */
+    rval = ber_check_tags(opt_codec_ctx, td, 0, buf_ptr, size,
+                          tag_mode, 0, &length, 0);
+    if(rval.code != RC_OK)
+        return rval;
+
+    ASN_DEBUG("%s length is %d bytes", td->name, (int)length);
+
+    /*
+     * Make sure we have this length.
+     */
+    buf_ptr = ((const char *)buf_ptr) + rval.consumed;
+    size -= rval.consumed;
+    if(length > (ber_tlv_len_t)size) {
+        rval.code = RC_WMORE;
+        rval.consumed = 0;
+        return rval;
+    }
+
+    /*
+     * ASN.1 encoded NativeEnumerated: buf_ptr, length
+     * Fill the native, at the same time checking for overflow.
+     * If overflow occurred, return with RC_FAIL.
+     */
+    {
+        INTEGER_t tmp;
+        union {
+            const void *constbuf;
+            void *nonconstbuf;
+        } unconst_buf;
+        long l;
+
+        unconst_buf.constbuf = buf_ptr;
+        tmp.buf = (uint8_t *)unconst_buf.nonconstbuf;
+        tmp.size = length;
+
+        if((specs&&specs->field_unsigned)
+            ? asn_INTEGER2ulong(&tmp, (unsigned long *)&l) /* sic */
+            : asn_INTEGER2long(&tmp, &l)) {
+            rval.code = RC_FAIL;
+            rval.consumed = 0;
+            return rval;
+        }
+
+        el = INTEGER_map_value2enum(specs, l);
+        if(!el) {
+            ASN_DEBUG("No element corresponds to the value %ld", l);
+            ASN__DECODE_FAILED;
+        }
+
+        *native = el->nat_value;
+    }
+
+    rval.code = RC_OK;
+    rval.consumed += length;
+
+    ASN_DEBUG("Took %ld/%ld bytes to encode %s (%ld)",
+              (long)rval.consumed, (long)length, td->name, (long)*native);
+
+    return rval;
+}
+
+/*
+ * Encode the NativeEnumerated using the standard INTEGER type DER encoder.
+ */
+asn_enc_rval_t
+NativeEnumerated_encode_der(const asn_TYPE_descriptor_t *td, const void *sptr,
+                         int tag_mode, ber_tlv_tag_t tag,
+                         asn_app_consume_bytes_f *cb, void *app_key) {
+    const asn_INTEGER_specifics_t *specs =
+        (const asn_INTEGER_specifics_t *)td->specifics;
+    unsigned long native = *(unsigned long *)sptr; /* Disable sign ext. */
+
+
+    asn_enc_rval_t erval = {0,0,0};
+    INTEGER_t tmp;
+    const asn_INTEGER_enum_map_t *el;
+
+    el = INTEGER_map_value2enum(specs, native);
+    if(!el) {
+        ASN_DEBUG(
+            "No elemenet corresponds to the value %ld", native);
+        ASN__ENCODE_FAILED;
+    }
+
+#ifdef WORDS_BIGENDIAN  /* Opportunistic optimization */
+
+    tmp.buf = (uint8_t *)&native;
+    tmp.size = sizeof(native);
+
+#else  /* Works even if WORDS_BIGENDIAN is not set where should've been */
+    uint8_t buf[sizeof(native)];
+    uint8_t *p;
+
+    /* Prepare a fake INTEGER */
+    for(p = buf + sizeof(buf) - 1; p >= buf; p--, native >>= 8)
+        *p = (uint8_t)native;
+
+    tmp.buf = buf;
+    tmp.size = sizeof(buf);
+#endif  /* WORDS_BIGENDIAN */
+
+    /* Encode fake INTEGER */
+    erval = INTEGER_encode_der(td, &tmp, tag_mode, tag, cb, app_key);
+    if(erval.structure_ptr == &tmp) {
+        erval.structure_ptr = sptr;
+    }
+    return erval;
+}

--- a/skeletons/NativeEnumerated_ber.c
+++ b/skeletons/NativeEnumerated_ber.c
@@ -4,8 +4,8 @@
  * Redistribution and modifications are permitted subject to BSD license.
  */
 #include <asn_internal.h>
-#include <NativeInteger.h>
 #include <INTEGER.h>
+#include <NativeEnumerated.h>
 
 /*
  * Decode NativeEnumerated type.
@@ -109,7 +109,7 @@ NativeEnumerated_encode_der(const asn_TYPE_descriptor_t *td, const void *sptr,
                          asn_app_consume_bytes_f *cb, void *app_key) {
     const asn_INTEGER_specifics_t *specs =
         (const asn_INTEGER_specifics_t *)td->specifics;
-    unsigned long native = *(unsigned long *)sptr; /* Disable sign ext. */
+    unsigned long native = *(const unsigned long *)sptr; /* Disable sign ext. */
 
 
     asn_enc_rval_t erval = {0,0,0};

--- a/skeletons/NativeEnumerated_xer.c
+++ b/skeletons/NativeEnumerated_xer.c
@@ -28,9 +28,54 @@ NativeEnumerated_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr,
         if(er.encoded < 0) ASN__ENCODE_FAILED;
         ASN__ENCODED_OK(er);
     } else {
-        ASN_DEBUG(
-            "ASN.1 forbids dealing with "
-            "unknown value of ENUMERATED type");
+        ASN_DEBUG("No element corresponds to the value %ld", *native);
         ASN__ENCODE_FAILED;
     }
+}
+
+asn_dec_rval_t
+NativeEnumerated_decode_xer(const asn_codec_ctx_t *opt_codec_ctx,
+                         const asn_TYPE_descriptor_t *td, void **sptr,
+                         const char *opt_mname, const void *buf_ptr,
+                         size_t size) {
+    const asn_INTEGER_specifics_t *specs =
+        (const asn_INTEGER_specifics_t *)td->specifics;
+    asn_dec_rval_t rval;
+    INTEGER_t st;
+    void *st_ptr = (void *)&st;
+    long *native = (long *)*sptr;
+    const asn_INTEGER_enum_map_t *el;
+    if(!native) {
+        native = (long *)(*sptr = CALLOC(1, sizeof(*native)));
+        if(!native) ASN__DECODE_FAILED;
+    }
+
+    memset(&st, 0, sizeof(st));
+    rval = INTEGER_decode_xer(opt_codec_ctx, td, &st_ptr, opt_mname, buf_ptr,
+                              size);
+    if(rval.code == RC_OK) {
+        long l;
+        if((specs && specs->field_unsigned)
+               ? asn_INTEGER2ulong(&st, (unsigned long *)&l) /* sic */
+               : asn_INTEGER2long(&st, &l)) {
+            rval.code = RC_FAIL;
+            rval.consumed = 0;
+        } else {
+            el = INTEGER_map_value2enum(specs, l);
+            if(!el) {
+                ASN_DEBUG("No element corresponds to the value %ld", l);
+                ASN__DECODE_FAILED;
+            }
+            *native = el->nat_value;
+        }
+    } else {
+        /*
+         * Cannot restart from the middle;
+         * there is no place to save state in the native type.
+         * Request a continuation from the very beginning.
+         */
+        rval.consumed = 0;
+    }
+    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_INTEGER, &st);
+    return rval;
 }

--- a/skeletons/file-dependencies
+++ b/skeletons/file-dependencies
@@ -70,6 +70,7 @@ GeneralizedTime.h GeneralizedTime_ber.c
 INTEGER.h INTEGER_ber.c
 NULL.h NULL_ber.c
 NativeInteger.h NativeInteger_ber.c
+NativeEnumerated.h NativeEnumerated_ber.c
 NativeReal.h NativeReal_ber.c
 OCTET_STRING.h OCTET_STRING_ber.c
 OPEN_TYPE.h OPEN_TYPE_ber.c


### PR DESCRIPTION
Currently, ENUMERATED types accept any integer value including those outside the named range, but only in **BER/DER/XER**. For example, given the ASN.1 specification:

```asn1
Test DEFINITIONS ::=

BEGIN

Color ::= ENUMERATED {red    (0),
                      blue   (1),
                      yellow (2)}
END
```

This code would correctly encode and decode, **but only in BER/DER/XER**:
```cpp
void constraints_should_prevent_this_ber()
{
	Color_t test = 500; // allowed range is value >= 0, <= 2
	int buf_size = 256;
	uint8_t buf[buf_size];

	asn_enc_rval_t encoding = der_encode_to_buffer(&asn_DEF_Color, &test, (void *)buf, sizeof(buf));

	if (encoding.encoded == -1)
	{
		fprintf(stderr, "der_encode failed: %s: %s\n", encoding.failed_type->name, strerror(errno));
		// exit(1);
	}
	else if (encoding.encoded > buf_size)
	{
		perror("encode failed: buffer too small\n");
		// exit(2);
	}
	else
	{
		printf("der_encode succeeded, %ld bytes\n", encoding.encoded);
		for (int i = 0; i < encoding.encoded; ++i)
		{
			printf("%02x ", buf[i]);
		}
		printf("(%ld bytes)\n", encoding.encoded);
	}

	Color_t *p = (Color_t *)calloc(1, sizeof(Color_t));

	if (!p)
	{
		perror("calloc failed");
		exit(1);
	}

	memset(p, 0, sizeof(Color_t));

	printf("Before Color_t: %ld, %s\n", *p, buf);

	asn_dec_rval_t retval = ber_decode(0, &asn_DEF_Color, (void **)&p, (const void *)buf, encoding.encoded);

	if(retval.code == RC_OK)
	{
		printf("successfully decoded Color_t: %ld\n", *p);
	}
	else
	{
		printf("ber_decode failed, %d\n", retval.code);
	}

	// -------------------------------------------------------------------------------------------------------------------------------------------------
}
```

This PR adds

```cpp
el = INTEGER_map_value2enum(specs, l);
if(!el) {
    ASN_DEBUG("No element corresponds to the value %ld", l);
    ASN__DECODE_FAILED;
}
```

to the type specific decoder for NativeEnumerated types. It also replaces the constraint enforcement function from `asn_no_constraint` to a new function which checks that the value is within the enumeration.

## Implementation Details

Originally, the NativeEnumerated type's operation structure referenced `INTEGER`. This duplicates that function and adds the above code snippet to `NativeEnumerated_decode_ber`, `NativeEnumerated_encode_der`, and `NativeEnumerated_decode_xer`.

## Feedback
Please let me know if this is not adequate and I'll resolve the issues.
