### PR TITLE
Small cosmetic fix in check-parsing.sh to keep 'asn1c' in normalized output

### DIFF
--- a/tests/tests-asn1c-compiler/check-parsing.sh
+++ b/tests/tests-asn1c-compiler/check-parsing.sh
@@ -33,9 +33,9 @@ for ref in ${top_srcdir}/tests/tests-asn1c-compiler/*.asn1.+*; do
 	oldversion=${template}.old
 	newversion=${template}.new
 	PROCESSING="$ref (from $src)"
-	LC_ALL=C sed -e 's/^found in .*/found in .../' -e 's/asn1c-[^ ]* ([^)]*)//g' -e 's/asn1c-[^ ]* from [^ ]*//g' -e 's/asn1c-[^ >]*//g' < "$ref" > "$oldversion"
+	LC_ALL=C sed -e 's/^found in .*/found in .../' -e 's/asn1c-[^ ]* ([^)]*)//g' -e 's/asn1c-[^ >]*//g' < "$ref" > "$oldversion"
 	ec=0
-	(${top_builddir}/asn1c/asn1c -S ${top_srcdir}/skeletons -no-gen-OER -no-gen-UPER -no-gen-APER -no-gen-JER $flags "$src" | LC_ALL=C sed -e 's/^found in .*/found in .../' -e 's/asn1c-[^ ]* ([^)]*)//g' -e 's/asn1c-[^ ]* from [^ ]*//g' -e 's/asn1c-[^ >]*//g' > "$newversion") || ec=$?
+	(${top_builddir}/asn1c/asn1c -S ${top_srcdir}/skeletons -no-gen-OER -no-gen-UPER -no-gen-APER -no-gen-JER $flags "$src" | LC_ALL=C sed -e 's/^found in .*/found in .../' -e 's/asn1c-[^ ]* ([^)]*)//g' -e 's/asn1c-[^ >]*//g' > "$newversion") || ec=$?
 	if [ $? = 0 ]; then
 		diff $diffArgs "$oldversion" "$newversion" || ec=$?
 	fi

--- a/tests/tests-asn1c-compiler/check-parsing.sh
+++ b/tests/tests-asn1c-compiler/check-parsing.sh
@@ -33,9 +33,9 @@ for ref in ${top_srcdir}/tests/tests-asn1c-compiler/*.asn1.+*; do
 	oldversion=${template}.old
 	newversion=${template}.new
 	PROCESSING="$ref (from $src)"
-	LC_ALL=C sed -e 's/^found in .*/found in .../' -e 's/asn1c-[^ ]* ([^)]*)//g' -e 's/asn1c-[^ >]*//g' < "$ref" > "$oldversion"
+	LC_ALL=C sed -e 's/^found in .*/found in .../' -e 's/asn1c-[^ ]* ([^)]*)/asn1c/g' -e 's/asn1c-[^ >]*/asn1c/g' < "$ref" > "$oldversion"
 	ec=0
-	(${top_builddir}/asn1c/asn1c -S ${top_srcdir}/skeletons -no-gen-OER -no-gen-UPER -no-gen-APER -no-gen-JER $flags "$src" | LC_ALL=C sed -e 's/^found in .*/found in .../' -e 's/asn1c-[^ ]* ([^)]*)//g' -e 's/asn1c-[^ >]*//g' > "$newversion") || ec=$?
+	(${top_builddir}/asn1c/asn1c -S ${top_srcdir}/skeletons -no-gen-OER -no-gen-UPER -no-gen-APER -no-gen-JER $flags "$src" | LC_ALL=C sed -e 's/^found in .*/found in .../' -e 's/asn1c-[^ ]* ([^)]*)/asn1c/g' -e 's/asn1c-[^ >]*/asn1c/g' > "$newversion") || ec=$?
 	if [ $? = 0 ]; then
 		diff $diffArgs "$oldversion" "$newversion" || ec=$?
 	fi


### PR DESCRIPTION
Improve `sed` chain in check-parsing.sh to keep 'asn1c' in normalized output.

This cleans dirt left behind while reviewing copilot's changes from my phone, in the rush to fix the long time awaited PR #131 