### PR TITLE
Multiple Information Object Classes can produce conflicting C variables

### DIFF
--- a/libasn1compiler/asn1c_ioc.c
+++ b/libasn1compiler/asn1c_ioc.c
@@ -171,7 +171,7 @@ parse_unparsed_oid(const char *buf, int len, uint64_t arcs[], int max_arcs) {
  *      parse the textual OID and emit proper bytes+length.
  */
 static int
-emit_ioc_value(arg_t *arg, struct asn1p_ioc_cell_s *cell) {
+emit_ioc_value(arg_t *arg, struct asn1p_ioc_cell_s *cell, asn1p_expr_t *objset) {
 
     if(cell->value && cell->value->meta_type == AMT_VALUE) {
         const char *prim_type = NULL;
@@ -213,8 +213,10 @@ emit_ioc_value(arg_t *arg, struct asn1p_ioc_cell_s *cell) {
             return -1;
         }
         }
-        OUT("static const %s asn_VAL_%d_%s = ", prim_type,
-            cell->value->_type_unique_index, MKID(cell->value));
+        char *objset_name = strdup(MKID(objset));
+        OUT("static const %s asn_VAL_%s_%d_%s = ", prim_type,
+            objset_name, cell->value->_type_unique_index, MKID(cell->value));
+        free(objset_name);
 
         asn1p_expr_t *expr_value = cell->value;
         while(expr_value->value->type == ATV_REFERENCED) {
@@ -310,7 +312,7 @@ emit_ioc_value(arg_t *arg, struct asn1p_ioc_cell_s *cell) {
  *      the non-descriptor placeholder &asn_DEF_SEQUENCE_OF.
  */
 static int
-emit_ioc_cell(arg_t *arg, struct asn1p_ioc_cell_s *cell) {
+emit_ioc_cell(arg_t *arg, struct asn1p_ioc_cell_s *cell, asn1p_expr_t *objset) {
     OUT("{ \"%s\", ", cell->field->Identifier);
 
     if(!cell->value) {
@@ -323,7 +325,9 @@ emit_ioc_cell(arg_t *arg, struct asn1p_ioc_cell_s *cell) {
         if(!vt) return -1;
         GEN_INCLUDE(asn1c_type_name(arg, vt, TNF_INCLUDE));
         OUT("aioc__value, &asn_DEF_%s, ", asn1c_type_name(arg, vt, TNF_SAFE));
-        OUT("&asn_VAL_%d_%s", cell->value->_type_unique_index, MKID(cell->value));
+        char *objset_name = strdup(MKID(objset));
+        OUT("&asn_VAL_%s_%d_%s", objset_name, cell->value->_type_unique_index, MKID(cell->value));
+        free(objset_name);
 
     /* } else if(cell->value->meta_type == AMT_TYPE) { */
     /*     /\* Anonymous / constructed type (e.g., SEQUENCE OF CommTxPDU): */
@@ -396,7 +400,7 @@ emit_ioc_table(arg_t *arg, asn1p_expr_t *context, asn1c_ioc_table_and_objset_t i
     for(size_t rn = 0; rn < ioc_tao.ioct->rows; rn++) {
         asn1p_ioc_row_t *row = ioc_tao.ioct->row[rn];
         for(size_t cn = 0; cn < row->columns; cn++) {
-            if(emit_ioc_value(arg, &row->column[cn])) {
+            if(emit_ioc_value(arg, &row->column[cn], ioc_tao.objset)) {
                 return -1;
             }
         }
@@ -449,7 +453,7 @@ emit_ioc_table(arg_t *arg, asn1p_expr_t *context, asn1c_ioc_table_and_objset_t i
         }
         for(size_t cn = 0; cn < row->columns; cn++) {
             if(rn || cn) OUT(",\n");
-            emit_ioc_cell(arg, &row->column[cn]);
+            emit_ioc_cell(arg, &row->column[cn], ioc_tao.objset);
         }
     }
     OUT("\n");

--- a/tests/tests-asn1c-compiler/139-component-relation-OK.asn1.+-P
+++ b/tests/tests-asn1c-compiler/139-component-relation-OK.asn1.+-P
@@ -47,15 +47,15 @@ extern asn_TYPE_descriptor_t asn_DEF_Frame;
 
 /*** <<< IOC-TABLES [Frame] >>> ***/
 
-static const long asn_VAL_1_basicMessage = 1;
-static const long asn_VAL_2_2 = 2;
+static const long asn_VAL_FrameTypes_1_basicMessage = 1;
+static const long asn_VAL_FrameTypes_2_2 = 2;
 extern asn_TYPE_descriptor_t asn_DEF_PrimitiveMessage;
 extern asn_TYPE_descriptor_t asn_DEF_ComplexMessage;
 
 static const asn_ioc_cell_t asn_IOS_FrameTypes_1_rows[] = {
-	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_1_basicMessage },
+	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_FrameTypes_1_basicMessage },
 	{ "&Type", aioc__type, &asn_DEF_PrimitiveMessage },
-	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_2_2 },
+	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_FrameTypes_2_2 },
 	{ "&Type", aioc__type, &asn_DEF_ComplexMessage }
 };
 static const asn_ioc_set_t asn_IOS_FrameTypes_1[] = {

--- a/tests/tests-asn1c-compiler/140-component-relation-OK.asn1.+-P
+++ b/tests/tests-asn1c-compiler/140-component-relation-OK.asn1.+-P
@@ -47,15 +47,15 @@ extern asn_TYPE_descriptor_t asn_DEF_Frame;
 
 /*** <<< IOC-TABLES [Frame] >>> ***/
 
-static const long asn_VAL_1_basicMessage = 1;
-static const long asn_VAL_2_2 = 2;
+static const long asn_VAL_FrameTypes_1_basicMessage = 1;
+static const long asn_VAL_FrameTypes_2_2 = 2;
 extern asn_TYPE_descriptor_t asn_DEF_PrimitiveMessage;
 extern asn_TYPE_descriptor_t asn_DEF_ComplexMessage;
 
 static const asn_ioc_cell_t asn_IOS_FrameTypes_1_rows[] = {
-	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_1_basicMessage },
+	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_FrameTypes_1_basicMessage },
 	{ "&Type", aioc__type, &asn_DEF_PrimitiveMessage },
-	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_2_2 },
+	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_FrameTypes_2_2 },
 	{ "&Type", aioc__type, &asn_DEF_ComplexMessage }
 };
 static const asn_ioc_set_t asn_IOS_FrameTypes_1[] = {

--- a/tests/tests-asn1c-compiler/141-component-relation-OK.asn1.+-P
+++ b/tests/tests-asn1c-compiler/141-component-relation-OK.asn1.+-P
@@ -48,15 +48,15 @@ extern asn_TYPE_descriptor_t asn_DEF_Frame;
 
 /*** <<< IOC-TABLES [Frame] >>> ***/
 
-static const long asn_VAL_1_primMessage = 1;
-static const long asn_VAL_2_cplxMessage = 2;
+static const long asn_VAL_FrameTypes_1_primMessage = 1;
+static const long asn_VAL_FrameTypes_2_cplxMessage = 2;
 extern asn_TYPE_descriptor_t asn_DEF_PrimitiveMessage;
 extern asn_TYPE_descriptor_t asn_DEF_ComplexMessage;
 
 static const asn_ioc_cell_t asn_IOS_FrameTypes_1_rows[] = {
-	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_1_primMessage },
+	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_FrameTypes_1_primMessage },
 	{ "&Type", aioc__type, &asn_DEF_PrimitiveMessage },
-	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_2_cplxMessage },
+	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_FrameTypes_2_cplxMessage },
 	{ "&Type", aioc__type, &asn_DEF_ComplexMessage }
 };
 static const asn_ioc_set_t asn_IOS_FrameTypes_1[] = {

--- a/tests/tests-asn1c-compiler/144-ios-parameterization-OK.asn1.+-P
+++ b/tests/tests-asn1c-compiler/144-ios-parameterization-OK.asn1.+-P
@@ -128,15 +128,15 @@ extern asn_TYPE_member_t asn_MBR_RegionalExtension_1[2];
 
 /*** <<< IOC-TABLES [SpecializedContent] >>> ***/
 
-static const long asn_VAL_1_1 = 1;
-static const long asn_VAL_2_2 = 2;
+static const long asn_VAL_RegionalExtension_1_1 = 1;
+static const long asn_VAL_RegionalExtension_2_2 = 2;
 static asn_TYPE_descriptor_t asn_DEF_INTEGER_1;
 static asn_TYPE_descriptor_t asn_DEF_BOOLEAN_2;
 
 static const asn_ioc_cell_t asn_IOS_RegionalExtension_1_rows[] = {
-	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_1_1 },
+	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_RegionalExtension_1_1 },
 	{ "&Type", aioc__type, &asn_DEF_INTEGER_1 },
-	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_2_2 },
+	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_RegionalExtension_2_2 },
 	{ "&Type", aioc__type, &asn_DEF_BOOLEAN_2 }
 };
 static const asn_ioc_set_t asn_IOS_RegionalExtension_1[] = {

--- a/tests/tests-asn1c-compiler/146-ios-parameterization-per-OK.asn1.+-P_-gen-UPER_-gen-APER
+++ b/tests/tests-asn1c-compiler/146-ios-parameterization-per-OK.asn1.+-P_-gen-UPER_-gen-APER
@@ -128,15 +128,15 @@ extern asn_TYPE_member_t asn_MBR_RegionalExtension_1[2];
 
 /*** <<< IOC-TABLES [SpecializedContent] >>> ***/
 
-static const long asn_VAL_1_1 = 1;
-static const long asn_VAL_2_2 = 2;
+static const long asn_VAL_RegionalExtension_1_1 = 1;
+static const long asn_VAL_RegionalExtension_2_2 = 2;
 static asn_TYPE_descriptor_t asn_DEF_INTEGER_1;
 static asn_TYPE_descriptor_t asn_DEF_BOOLEAN_2;
 
 static const asn_ioc_cell_t asn_IOS_RegionalExtension_1_rows[] = {
-	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_1_1 },
+	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_RegionalExtension_1_1 },
 	{ "&Type", aioc__type, &asn_DEF_INTEGER_1 },
-	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_2_2 },
+	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_RegionalExtension_2_2 },
 	{ "&Type", aioc__type, &asn_DEF_BOOLEAN_2 }
 };
 static const asn_ioc_set_t asn_IOS_RegionalExtension_1[] = {

--- a/tests/tests-asn1c-compiler/155-parameterization-more-than-two-level-OK.asn1.+-P_-gen-UPER_-gen-APER
+++ b/tests/tests-asn1c-compiler/155-parameterization-more-than-two-level-OK.asn1.+-P_-gen-UPER_-gen-APER
@@ -732,16 +732,16 @@ extern asn_TYPE_member_t asn_MBR_ClassItem_1[3];
 
 /*** <<< IOC-TABLES [Packet] >>> ***/
 
-static const long asn_VAL_1_id_TYPE1 = 1;
-static const long asn_VAL_1_blue = 2;
-static const long asn_VAL_1_crc_ok = 1;
+static const long asn_VAL_ClassItem_1_id_TYPE1 = 1;
+static const long asn_VAL_ClassItem_1_blue = 2;
+static const long asn_VAL_ClassItem_1_crc_ok = 1;
 static asn_TYPE_descriptor_t asn_DEF_OCTET_STRING_1;
 
 static const asn_ioc_cell_t asn_IOS_ClassItem_1_rows[] = {
-	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_1_id_TYPE1 },
-	{ "&color", aioc__value, &asn_DEF_NativeEnumerated, &asn_VAL_1_blue },
+	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_ClassItem_1_id_TYPE1 },
+	{ "&color", aioc__value, &asn_DEF_NativeEnumerated, &asn_VAL_ClassItem_1_blue },
 	{ "&Value", aioc__type, &asn_DEF_OCTET_STRING_1 },
-	{ "&valid", aioc__value, &asn_DEF_NativeEnumerated, &asn_VAL_1_crc_ok }
+	{ "&valid", aioc__value, &asn_DEF_NativeEnumerated, &asn_VAL_ClassItem_1_crc_ok }
 };
 static const asn_ioc_set_t asn_IOS_ClassItem_1[] = {
 	{ 1, 4, asn_IOS_ClassItem_1_rows }

--- a/tests/tests-asn1c-compiler/156-union-ios-OK.asn1.+-P_-gen-UPER_-gen-APER
+++ b/tests/tests-asn1c-compiler/156-union-ios-OK.asn1.+-P_-gen-UPER_-gen-APER
@@ -137,12 +137,12 @@ extern asn_TYPE_member_t asn_MBR_TotalRegionExtension_1[2];
 
 /*** <<< IOC-TABLES [SpecializedContent] >>> ***/
 
-static const long asn_VAL_1_1 = 1;
-static const long asn_VAL_2_2 = 2;
-static const long asn_VAL_3_3 = 3;
-static const long asn_VAL_4_1 = 1;
-static const long asn_VAL_5_2 = 2;
-static const long asn_VAL_6_3 = 3;
+static const long asn_VAL_TotalRegionExtension_1_1 = 1;
+static const long asn_VAL_TotalRegionExtension_2_2 = 2;
+static const long asn_VAL_TotalRegionExtension_3_3 = 3;
+static const long asn_VAL_TotalRegionExtension_4_1 = 1;
+static const long asn_VAL_TotalRegionExtension_5_2 = 2;
+static const long asn_VAL_TotalRegionExtension_6_3 = 3;
 static asn_TYPE_descriptor_t asn_DEF_INTEGER_1;
 static asn_TYPE_descriptor_t asn_DEF_BOOLEAN_2;
 static asn_TYPE_descriptor_t asn_DEF_OCTET_STRING_3;
@@ -151,17 +151,17 @@ static asn_TYPE_descriptor_t asn_DEF_BOOLEAN_5;
 static asn_TYPE_descriptor_t asn_DEF_OCTET_STRING_6;
 
 static const asn_ioc_cell_t asn_IOS_TotalRegionExtension_1_rows[] = {
-	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_1_1 },
+	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_TotalRegionExtension_1_1 },
 	{ "&Type", aioc__type, &asn_DEF_INTEGER_1 },
-	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_2_2 },
+	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_TotalRegionExtension_2_2 },
 	{ "&Type", aioc__type, &asn_DEF_BOOLEAN_2 },
-	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_3_3 },
+	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_TotalRegionExtension_3_3 },
 	{ "&Type", aioc__type, &asn_DEF_OCTET_STRING_3 },
-	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_4_1 },
+	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_TotalRegionExtension_4_1 },
 	{ "&Type", aioc__type, &asn_DEF_INTEGER_4 },
-	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_5_2 },
+	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_TotalRegionExtension_5_2 },
 	{ "&Type", aioc__type, &asn_DEF_BOOLEAN_5 },
-	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_6_3 },
+	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_TotalRegionExtension_6_3 },
 	{ "&Type", aioc__type, &asn_DEF_OCTET_STRING_6 }
 };
 static const asn_ioc_set_t asn_IOS_TotalRegionExtension_1[] = {

--- a/tests/tests-asn1c-compiler/160-multiple-parameterized-instance-OK.asn1.+-P_-gen-UPER_-gen-APER_-fcompound-names
+++ b/tests/tests-asn1c-compiler/160-multiple-parameterized-instance-OK.asn1.+-P_-gen-UPER_-gen-APER_-fcompound-names
@@ -353,12 +353,12 @@ extern asn_TYPE_member_t asn_MBR_RegionalExtension4_7[2];
 
 /*** <<< IOC-TABLES [SpecializedContent] >>> ***/
 
-static const long asn_VAL_1_1 = 1;
-static const long asn_VAL_2_2 = 2;
-static const long asn_VAL_3_3 = 3;
-static const long asn_VAL_4_1 = 1;
-static const long asn_VAL_5_2 = 2;
-static const long asn_VAL_6_3 = 3;
+static const long asn_VAL_TotalRegionExtension_1_1 = 1;
+static const long asn_VAL_TotalRegionExtension_2_2 = 2;
+static const long asn_VAL_TotalRegionExtension_3_3 = 3;
+static const long asn_VAL_TotalRegionExtension_4_1 = 1;
+static const long asn_VAL_TotalRegionExtension_5_2 = 2;
+static const long asn_VAL_TotalRegionExtension_6_3 = 3;
 static asn_TYPE_descriptor_t asn_DEF_INTEGER_1;
 static asn_TYPE_descriptor_t asn_DEF_BOOLEAN_2;
 static asn_TYPE_descriptor_t asn_DEF_OCTET_STRING_3;
@@ -367,45 +367,45 @@ static asn_TYPE_descriptor_t asn_DEF_BOOLEAN_5;
 static asn_TYPE_descriptor_t asn_DEF_OCTET_STRING_6;
 
 static const asn_ioc_cell_t asn_IOS_TotalRegionExtension_1_rows[] = {
-	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_1_1 },
+	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_TotalRegionExtension_1_1 },
 	{ "&Type", aioc__type, &asn_DEF_INTEGER_1 },
-	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_2_2 },
+	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_TotalRegionExtension_2_2 },
 	{ "&Type", aioc__type, &asn_DEF_BOOLEAN_2 },
-	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_3_3 },
+	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_TotalRegionExtension_3_3 },
 	{ "&Type", aioc__type, &asn_DEF_OCTET_STRING_3 },
-	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_4_1 },
+	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_TotalRegionExtension_4_1 },
 	{ "&Type", aioc__type, &asn_DEF_INTEGER_4 },
-	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_5_2 },
+	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_TotalRegionExtension_5_2 },
 	{ "&Type", aioc__type, &asn_DEF_BOOLEAN_5 },
-	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_6_3 },
+	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_TotalRegionExtension_6_3 },
 	{ "&Type", aioc__type, &asn_DEF_OCTET_STRING_6 }
 };
 static const asn_ioc_set_t asn_IOS_TotalRegionExtension_1[] = {
 	{ 6, 2, asn_IOS_TotalRegionExtension_1_rows }
 };
-static const long asn_VAL_7_1 = 1;
-static const long asn_VAL_8_4 = 4;
+static const long asn_VAL_RegionalExtension3_7_1 = 1;
+static const long asn_VAL_RegionalExtension3_8_4 = 4;
 static asn_TYPE_descriptor_t asn_DEF_OCTET_STRING_7;
 static asn_TYPE_descriptor_t asn_DEF_OCTET_STRING_8;
 
 static const asn_ioc_cell_t asn_IOS_RegionalExtension3_1_rows[] = {
-	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_7_1 },
+	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_RegionalExtension3_7_1 },
 	{ "&Type", aioc__type, &asn_DEF_OCTET_STRING_7 },
-	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_8_4 },
+	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_RegionalExtension3_8_4 },
 	{ "&Type", aioc__type, &asn_DEF_OCTET_STRING_8 }
 };
 static const asn_ioc_set_t asn_IOS_RegionalExtension3_1[] = {
 	{ 2, 2, asn_IOS_RegionalExtension3_1_rows }
 };
-static const long asn_VAL_9_5 = 5;
-static const long asn_VAL_10_6 = 6;
+static const long asn_VAL_RegionalExtension4_9_5 = 5;
+static const long asn_VAL_RegionalExtension4_10_6 = 6;
 static asn_TYPE_descriptor_t asn_DEF_INTEGER_9;
 static asn_TYPE_descriptor_t asn_DEF_OCTET_STRING_5__10;
 
 static const asn_ioc_cell_t asn_IOS_RegionalExtension4_1_rows[] = {
-	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_9_5 },
+	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_RegionalExtension4_9_5 },
 	{ "&Type", aioc__type, &asn_DEF_INTEGER_9 },
-	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_10_6 },
+	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_RegionalExtension4_10_6 },
 	{ "&Type", aioc__type, &asn_DEF_OCTET_STRING_5__10 }
 };
 static const asn_ioc_set_t asn_IOS_RegionalExtension4_1[] = {

--- a/tests/tests-asn1c-compiler/98-attribute-class-OK.asn1.+-P
+++ b/tests/tests-asn1c-compiler/98-attribute-class-OK.asn1.+-P
@@ -22,12 +22,12 @@ extern asn_TYPE_descriptor_t asn_DEF_Attribute;
 
 /*** <<< IOC-TABLES [Attribute] >>> ***/
 
-static const RELATIVE_OID_t asn_VAL_1_raf = { (uint8_t[]){ 3, 2, 1}, 3 }; /* {3 2 1} */
-static const RELATIVE_OID_t asn_VAL_2_rcf = { (uint8_t[]){ 3, 2, 2}, 3 }; /* {3 2 2} */
+static const RELATIVE_OID_t asn_VAL_Attributes_1_raf = { (uint8_t[]){ 3, 2, 1}, 3 }; /* {3 2 1} */
+static const RELATIVE_OID_t asn_VAL_Attributes_2_rcf = { (uint8_t[]){ 3, 2, 2}, 3 }; /* {3 2 2} */
 
 static const asn_ioc_cell_t asn_IOS_Attributes_1_rows[] = {
-	{ "&id", aioc__value, &asn_DEF_RELATIVE_OID, &asn_VAL_1_raf },
-	{ "&id", aioc__value, &asn_DEF_RELATIVE_OID, &asn_VAL_2_rcf }
+	{ "&id", aioc__value, &asn_DEF_RELATIVE_OID, &asn_VAL_Attributes_1_raf },
+	{ "&id", aioc__value, &asn_DEF_RELATIVE_OID, &asn_VAL_Attributes_2_rcf }
 };
 static const asn_ioc_set_t asn_IOS_Attributes_1[] = {
 	{ 2, 1, asn_IOS_Attributes_1_rows }


### PR DESCRIPTION
Hi,
If multiple information object classes and sets are used in a single ASN.1 module with the same variable names then in some cases they can produce invalid C code. I've tried to produce a minimal example:

Using the following ASN.1 file:
```asn1
ReproduceCollision DEFINITIONS AUTOMATIC TAGS ::= BEGIN

    Criticality ::= ENUMERATED { reject }

    PROTOCOL-IES ::= CLASS {
        &id          INTEGER UNIQUE,
        &criticality Criticality
    } WITH SYNTAX {
        ID &id CRITICALITY &criticality
    }

    PROTOCOL-IES2 ::= CLASS {
        &id          INTEGER UNIQUE,
        &criticality Criticality
    } WITH SYNTAX {
        ID &id CRITICALITY &criticality
    }

    Container {PROTOCOL-IES : IEsSetParam} ::= SEQUENCE {
        id          PROTOCOL-IES.&id({IEsSetParam}),
        criticality PROTOCOL-IES.&criticality({IEsSetParam}{@id})
    }

    SetA PROTOCOL-IES ::= {
        { ID 1
          CRITICALITY reject
        }
    }

    SetB PROTOCOL-IES2 ::= {
	    { ID 2
	      CRITICALITY reject
	    }
    }

    MessageA ::= SEQUENCE {
        field1 Container {{SetA}}
    }

    MessageB ::= SEQUENCE {
        field1 Container {{SetB}}
    }

END
```

using:
`asn1c -findirect-choice -fcompound-names -fincludes-quoted -fno-include-deps -no-gen-example -S asn1c_source/skeletons reproduce_issue.asn1 -D test_reproduce_output`

This generates the following C code in Container.c:
```c
/*
 * Generated by asn1c-8799fd7f-2025-11-26 (git@github.com:mouse07410/asn1c)
 * From ASN.1 module "ReproduceCollision"
 * 	found in "reproduce_issue.asn1"
 * 	`asn1c -findirect-choice -fcompound-names -fincludes-quoted -fno-include-deps -no-gen-example -S asn1c_source/skeletons -D test_reproduce_output`
 */

#include "Container.h"

static const long asn_VAL_1_1 = 1;
static const long asn_VAL_1_reject = 0;

static const asn_ioc_cell_t asn_IOS_SetA_1_rows[] = {
	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_1_1 },
	{ "&criticality", aioc__value, &asn_DEF_NativeEnumerated, &asn_VAL_1_reject }
};
static const asn_ioc_set_t asn_IOS_SetA_1[] = {
	{ 1, 2, asn_IOS_SetA_1_rows }
};
static const long asn_VAL_1_2 = 2;
static const long asn_VAL_1_reject = 0;

... snip ...

```

The relevant lines being `static const long asn_VAL_1_reject = 0;`, which is repeated twice. If you try to compile this file you will get this error by gcc: 

```bash
│ test_reproduce_output/Container.c:25:19: error: redefinition of ‘asn_VAL_1_reject’                                                                                                                                                         │
│    25 | static const long asn_VAL_1_reject = 0;                                                                                                                                                                                            │
│       |                   ^~~~~~~~~~~~~~~~                                                                                                                                                                                                 │
│ test_reproduce_output/Container.c:11:19: note: previous definition of ‘asn_VAL_1_reject’ with type ‘long int’                                                                                                                              │
│    11 | static const long asn_VAL_1_reject = 0;                                                                                                                                                                                            │
│       |                   ^~~~~~~~~~~~~~~~ 
```

 Granted this is a highly specific example and I am not aware of any ASN.1 specs where this may be a problem. Regardless, this was something I ran into. I have created a PR which merely prepends the name of the information object on the value to avoid the name collision. So  `static const long asn_VAL_1_reject = 0;` becomes  `static const long asn_VAL_SetA_1_reject = 0;` and  `static const long asn_VAL_SetB_1_reject = 0;`. I've also updated relevant test cases.