### PR TITLE
Fix XER encoding and add complex-threshold CLI parameter

### DIFF
--- a/asn1c/asn1c.c
+++ b/asn1c/asn1c.c
@@ -79,7 +79,7 @@ int is_integer(const char *str, long *out_val) {
 static void usage(const char *av0); /* Print the Usage screen and exit */
 static int importStandardModules(asn1p_t *asn, const char *skeletons_dir);
 
-int complex_threshold = 4;  /* threshold after which complex_level is true (DIRTY HACK */
+int complex_threshold = 4;  /* threshold after which complex_level is true (DIRTY HACK) */
 
 int
 main(int ac, char **av) {

--- a/asn1c/asn1c.c
+++ b/asn1c/asn1c.c
@@ -192,7 +192,7 @@ main(int ac, char **av) {
                 	fprintf(stderr, "-f%s: bad format or value too large\n", optarg);
 	                exit(EX_USAGE);
 	            }
-                complex_threshold = (int) (thresh_val & 0x0ffff);
+                complex_threshold = (int)thresh_val;
             } else {
                 fprintf(stderr, "-f%s: Invalid argument\n", optarg);
                 exit(EX_USAGE);

--- a/asn1c/asn1c.c
+++ b/asn1c/asn1c.c
@@ -58,22 +58,22 @@ Copyright (c) 2022-2026 Mouse <mouse07410@noreply.github.com> and contributors.\
 static
 int is_integer(const char *str, long *out_val) {
     char *endptr;
-    errno = 0; // To distinguish success/failure after call
+    errno = 0; /* To distinguish success/failure after call */
 
-    // 10 is the base (decimal)
+    /* 10 is the base (decimal) */
     long val = strtol(str, &endptr, 10);
 
-    // Check for various possible errors
-    if (str == endptr) return 0; // No digits found at all
-    if (errno == ERANGE && (val == LONG_MAX || val == LONG_MIN)) return 0; // Overflow
-    if (errno != 0 && val == 0) return 0; // Other conversion error
+    /* Check for various possible errors */
+    if (str == endptr) return 0; /* No digits found at all */
+    if (errno == ERANGE && (val == LONG_MAX || val == LONG_MIN)) return 0; /* Overflow */
+    if (errno != 0 && val == 0) return 0; /* Other conversion error */
 
-    // Check for trailing garbage (optional)
-    // If you want to allow "123 ", you'd check if *endptr is whitespace
+    /* Check for trailing garbage (optional) */
+    /* If you want to allow "123 ", you'd check if *endptr is whitespace */
     if (*endptr != '\0') return 0;
 
     if (out_val) *out_val = val;
-    return 1; // Success
+    return 1; /* Success */
 }
 
 static void usage(const char *av0); /* Print the Usage screen and exit */

--- a/asn1c/asn1c.c
+++ b/asn1c/asn1c.c
@@ -55,8 +55,13 @@ Copyright (c) 2022-2026 Mouse <mouse07410@noreply.github.com> and contributors.\
 #include <errno.h>
 #include <limits.h>
 
-static
-int is_integer(const char *str, long *out_val) {
+/*
+ * Parse a string as a decimal integer with validation.
+ * Returns 1 on success, 0 on failure (non-integer, overflow, or trailing garbage).
+ * If out_val is non-NULL, stores the parsed value on success.
+ */
+static int
+is_integer(const char *str, long *out_val) {
     char *endptr;
     errno = 0; /* To distinguish success/failure after call */
 

--- a/asn1c/asn1c.c
+++ b/asn1c/asn1c.c
@@ -186,8 +186,8 @@ main(int ac, char **av) {
                 char *threshold = optarg + 18;
                 long thresh_val;
                 if ((is_integer(threshold, &thresh_val) != 1)
-                	|| (thresh_val > 500) // let's not be stupid here
-                	|| (thresh_val <= 0)  // again, stupidity not appreciated
+                	|| (thresh_val > 500) /* let's not be stupid here */
+                	|| (thresh_val <= 0)  /* again, stupidity not appreciated */
                 	) {
                 	fprintf(stderr, "-f%s: bad format or value too large\n", optarg);
 	                exit(EX_USAGE);

--- a/asn1c/asn1c.c
+++ b/asn1c/asn1c.c
@@ -50,8 +50,36 @@ Copyright (c) 2022-2026 Mouse <mouse07410@noreply.github.com> and contributors.\
 #include <dirent.h>
 #endif
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <limits.h>
+
+static
+int is_integer(const char *str, long *out_val) {
+    char *endptr;
+    errno = 0; // To distinguish success/failure after call
+
+    // 10 is the base (decimal)
+    long val = strtol(str, &endptr, 10);
+
+    // Check for various possible errors
+    if (str == endptr) return 0; // No digits found at all
+    if (errno == ERANGE && (val == LONG_MAX || val == LONG_MIN)) return 0; // Overflow
+    if (errno != 0 && val == 0) return 0; // Other conversion error
+
+    // Check for trailing garbage (optional)
+    // If you want to allow "123 ", you'd check if *endptr is whitespace
+    if (*endptr != '\0') return 0;
+
+    if (out_val) *out_val = val;
+    return 1; // Success
+}
+
 static void usage(const char *av0); /* Print the Usage screen and exit */
 static int importStandardModules(asn1p_t *asn, const char *skeletons_dir);
+
+int complex_threshold = 4;  /* threshold after which complex_level is true (DIRTY HACK */
 
 int
 main(int ac, char **av) {
@@ -154,6 +182,18 @@ main(int ac, char **av) {
             } else if(strncmp(optarg, "prefix=", 7) == 0) {
                 char *prefix = optarg + 7;
                 asn1c_prefix_set(prefix);
+            } else if(strncmp(optarg, "complex-threshold=", 18) == 0) {
+                char *threshold = optarg + 18;
+                long thresh_val;
+                if ((is_integer(threshold, &thresh_val) != 1)
+                	|| (thresh_val > 500) // let's not be stupid here
+                	|| (thresh_val <= 0)  // again, stupidity not appreciated
+                	) {
+                	fprintf(stderr, "-f%s: bad format or value too large\n", optarg);
+	                exit(EX_USAGE);
+	            }
+                complex_threshold = (int) (thresh_val & 0x0ffff);
+                //fprintf(stderr, "DEBUG: complex_threshold = %d\n", complex_threshold);
             } else {
                 fprintf(stderr, "-f%s: Invalid argument\n", optarg);
                 exit(EX_USAGE);
@@ -588,6 +628,7 @@ usage(const char *av0) {
 "\n"
 
 "  -fbless-SIZE          Allow SIZE() constraint for INTEGER etc (non-std.)\n"
+"  -fcomplex-threshold=<value>   Threshold value beyond which to use indirection\n"
 "  -fcompound-names      Disambiguate C's struct NAME's inside top-level types\n"
 "  -findirect-choice     Compile members of CHOICE as indirect pointers\n"
 "  -fincludes-quoted     Generate #includes in \"double\" instead of <angle> quotes\n"

--- a/asn1c/asn1c.c
+++ b/asn1c/asn1c.c
@@ -193,7 +193,6 @@ main(int ac, char **av) {
 	                exit(EX_USAGE);
 	            }
                 complex_threshold = (int) (thresh_val & 0x0ffff);
-                //fprintf(stderr, "DEBUG: complex_threshold = %d\n", complex_threshold);
             } else {
                 fprintf(stderr, "-f%s: Invalid argument\n", optarg);
                 exit(EX_USAGE);

--- a/libasn1compiler/asn1c_C.c
+++ b/libasn1compiler/asn1c_C.c
@@ -4216,6 +4216,7 @@ emit_include_dependencies(arg_t *arg) {
 	return 0;
 }
 
+extern int complex_threshold; // defined in asn1c/asn1c.c - need fixing
 /*
  * Check if it is better to make this type indirectly accessed via
  * a pointer.
@@ -4308,7 +4309,7 @@ expr_break_recursion(arg_t *arg, asn1p_expr_t *expr) {
 			 * This threshold is chosen to avoid breaking existing test expectations
 			 * while still handling deeply nested structures like F1AP's SRSConfig.
 			 */
-			if(complex_members >= 4) {
+			if(complex_members >= complex_threshold) {
 				expr->marker.flags |= EM_INDIRECT;
 				expr->marker.flags |= EM_UNRECURSE;
 				return 1;

--- a/libasn1compiler/asn1c_internal.h
+++ b/libasn1compiler/asn1c_internal.h
@@ -55,6 +55,8 @@ typedef struct arg_s {
 
 	struct compiler_streams *target;
 
+	int complex_threshold; // threshold for switching structures to ptrs (#398)
+
     asn1p_t *asn;
     asn1_namespace_t *ns;
     asn1p_expr_t *expr;

--- a/skeletons/ANY.c
+++ b/skeletons/ANY.c
@@ -11,6 +11,7 @@ asn_OCTET_STRING_specifics_t asn_SPC_ANY_specs = {
     ASN_OSUBV_ANY
 };
 asn_TYPE_operation_t asn_OP_ANY = {
+    .kind = ASN_KIND_PRIMITIVE,
     OCTET_STRING_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     OCTET_STRING_print,

--- a/skeletons/BIT_STRING.c
+++ b/skeletons/BIT_STRING.c
@@ -17,6 +17,7 @@ asn_OCTET_STRING_specifics_t asn_SPC_BIT_STRING_specs = {
     ASN_OSUBV_BIT
 };
 asn_TYPE_operation_t asn_OP_BIT_STRING = {
+    .kind = ASN_KIND_PRIMITIVE,
     OCTET_STRING_free,         /* Implemented in terms of OCTET STRING */
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     BIT_STRING_print,

--- a/skeletons/BMPString.c
+++ b/skeletons/BMPString.c
@@ -25,6 +25,7 @@ static asn_per_constraints_t asn_DEF_BMPString_per_constraints = {
 };
 #endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
 asn_TYPE_operation_t asn_OP_BMPString = {
+    .kind = ASN_KIND_PRIMITIVE,
     OCTET_STRING_free,  /* Implemented in terms of OCTET STRING */
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     BMPString_print,

--- a/skeletons/BOOLEAN.c
+++ b/skeletons/BOOLEAN.c
@@ -12,6 +12,7 @@ static const ber_tlv_tag_t asn_DEF_BOOLEAN_tags[] = {
     (ASN_TAG_CLASS_UNIVERSAL | (1 << 2))
 };
 asn_TYPE_operation_t asn_OP_BOOLEAN = {
+    .kind = ASN_KIND_PRIMITIVE,
     BOOLEAN_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     BOOLEAN_print,

--- a/skeletons/ENUMERATED.c
+++ b/skeletons/ENUMERATED.c
@@ -13,6 +13,7 @@ static const ber_tlv_tag_t asn_DEF_ENUMERATED_tags[] = {
     (ASN_TAG_CLASS_UNIVERSAL | (10 << 2))
 };
 asn_TYPE_operation_t asn_OP_ENUMERATED = {
+    .kind = ASN_KIND_PRIMITIVE,
     ASN__PRIMITIVE_TYPE_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     INTEGER_print,  /* Implemented in terms of INTEGER */

--- a/skeletons/GeneralString.c
+++ b/skeletons/GeneralString.c
@@ -13,6 +13,7 @@ static const ber_tlv_tag_t asn_DEF_GeneralString_tags[] = {
     (ASN_TAG_CLASS_UNIVERSAL | (4 << 2))    /* ... OCTET STRING */
 };
 asn_TYPE_operation_t asn_OP_GeneralString = {
+    .kind = ASN_KIND_PRIMITIVE,
     OCTET_STRING_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     OCTET_STRING_print,  /* non-ascii string */

--- a/skeletons/GeneralizedTime.c
+++ b/skeletons/GeneralizedTime.c
@@ -177,6 +177,7 @@ static asn_per_constraints_t asn_DEF_GeneralizedTime_per_constraints = {
 };
 #endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
 asn_TYPE_operation_t asn_OP_GeneralizedTime = {
+    .kind = ASN_KIND_PRIMITIVE,
     OCTET_STRING_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     GeneralizedTime_print,

--- a/skeletons/GraphicString.c
+++ b/skeletons/GraphicString.c
@@ -13,6 +13,7 @@ static const ber_tlv_tag_t asn_DEF_GraphicString_tags[] = {
     (ASN_TAG_CLASS_UNIVERSAL | (4 << 2))    /* ... OCTET STRING */
 };
 asn_TYPE_operation_t asn_OP_GraphicString = {
+    .kind = ASN_KIND_PRIMITIVE,
     OCTET_STRING_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     OCTET_STRING_print,  /* non-ascii string */

--- a/skeletons/IA5String.c
+++ b/skeletons/IA5String.c
@@ -20,6 +20,7 @@ static asn_per_constraints_t asn_DEF_IA5String_per_constraints = {
 };
 #endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
 asn_TYPE_operation_t asn_OP_IA5String = {
+    .kind = ASN_KIND_PRIMITIVE,
     OCTET_STRING_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     OCTET_STRING_print_utf8,  /* ASCII subset */

--- a/skeletons/INTEGER.c
+++ b/skeletons/INTEGER.c
@@ -7,7 +7,6 @@
 #include <INTEGER.h>
 #include <errno.h>
 #include <inttypes.h>
-
 /*
  * INTEGER basic type description.
  */
@@ -15,6 +14,7 @@ static const ber_tlv_tag_t asn_DEF_INTEGER_tags[] = {
     (ASN_TAG_CLASS_UNIVERSAL | (2 << 2))
 };
 asn_TYPE_operation_t asn_OP_INTEGER = {
+    .kind = ASN_KIND_PRIMITIVE,
     INTEGER_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     INTEGER_print,

--- a/skeletons/ISO646String.c
+++ b/skeletons/ISO646String.c
@@ -20,6 +20,7 @@ static asn_per_constraints_t asn_DEF_ISO646String_per_constraints = {
 };
 #endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
 asn_TYPE_operation_t asn_OP_ISO646String = {
+    .kind = ASN_KIND_PRIMITIVE,
     OCTET_STRING_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     OCTET_STRING_print_utf8,  /* ASCII subset */

--- a/skeletons/Makefile.am
+++ b/skeletons/Makefile.am
@@ -83,7 +83,6 @@ libasn1cskeletons_la_SOURCES =                  \
     constr_SET_OF.c constr_SET_OF.h             \
     constr_SET_OF_oer.c                         \
     constr_TYPE.c constr_TYPE.h                 \
-    asn_type_kinds.h                            \
     constraints.c constraints.h                 \
     der_encoder.c der_encoder.h                 \
     oer_decoder.c oer_decoder.h                 \

--- a/skeletons/Makefile.am
+++ b/skeletons/Makefile.am
@@ -83,6 +83,7 @@ libasn1cskeletons_la_SOURCES =                  \
     constr_SET_OF.c constr_SET_OF.h             \
     constr_SET_OF_oer.c                         \
     constr_TYPE.c constr_TYPE.h                 \
+    asn_type_kinds.h                            \
     constraints.c constraints.h                 \
     der_encoder.c der_encoder.h                 \
     oer_decoder.c oer_decoder.h                 \

--- a/skeletons/NULL.c
+++ b/skeletons/NULL.c
@@ -12,6 +12,7 @@ static const ber_tlv_tag_t asn_DEF_NULL_tags[] = {
     (ASN_TAG_CLASS_UNIVERSAL | (5 << 2))
 };
 asn_TYPE_operation_t asn_OP_NULL = {
+    .kind = ASN_KIND_PRIMITIVE,
     NULL_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     NULL_print,

--- a/skeletons/NativeEnumerated.c
+++ b/skeletons/NativeEnumerated.c
@@ -19,6 +19,7 @@ static const ber_tlv_tag_t asn_DEF_NativeEnumerated_tags[] = {
     (ASN_TAG_CLASS_UNIVERSAL | (10 << 2))
 };
 asn_TYPE_operation_t asn_OP_NativeEnumerated = {
+    .kind = ASN_KIND_PRIMITIVE,
     NativeInteger_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     NativeInteger_print,

--- a/skeletons/NativeInteger.c
+++ b/skeletons/NativeInteger.c
@@ -20,6 +20,7 @@ static const ber_tlv_tag_t asn_DEF_NativeInteger_tags[] = {
     (ASN_TAG_CLASS_UNIVERSAL | (2 << 2))
 };
 asn_TYPE_operation_t asn_OP_NativeInteger = {
+    .kind = ASN_KIND_PRIMITIVE,
     NativeInteger_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     NativeInteger_print,

--- a/skeletons/NativeReal.c
+++ b/skeletons/NativeReal.c
@@ -39,6 +39,7 @@ static const ber_tlv_tag_t asn_DEF_NativeReal_tags[] = {
     (ASN_TAG_CLASS_UNIVERSAL | (9 << 2))
 };
 asn_TYPE_operation_t asn_OP_NativeReal = {
+    .kind = ASN_KIND_PRIMITIVE,
     NativeReal_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     NativeReal_print,

--- a/skeletons/NumericString.c
+++ b/skeletons/NumericString.c
@@ -40,6 +40,7 @@ static asn_per_constraints_t asn_DEF_NumericString_per_constraints = {
 };
 #endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
 asn_TYPE_operation_t asn_OP_NumericString = {
+    .kind = ASN_KIND_PRIMITIVE,
     OCTET_STRING_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     OCTET_STRING_print_utf8,  /* ASCII subset */

--- a/skeletons/OBJECT_IDENTIFIER.c
+++ b/skeletons/OBJECT_IDENTIFIER.c
@@ -17,6 +17,7 @@ static const ber_tlv_tag_t asn_DEF_OBJECT_IDENTIFIER_tags[] = {
     (ASN_TAG_CLASS_UNIVERSAL | (6 << 2))
 };
 asn_TYPE_operation_t asn_OP_OBJECT_IDENTIFIER = {
+    .kind = ASN_KIND_PRIMITIVE,
     ASN__PRIMITIVE_TYPE_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     OBJECT_IDENTIFIER_print,

--- a/skeletons/OCTET_STRING.c
+++ b/skeletons/OCTET_STRING.c
@@ -19,6 +19,7 @@ asn_OCTET_STRING_specifics_t asn_SPC_OCTET_STRING_specs = {
     ASN_OSUBV_STR
 };
 asn_TYPE_operation_t asn_OP_OCTET_STRING = {
+    .kind = ASN_KIND_PRIMITIVE,
     OCTET_STRING_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     OCTET_STRING_print,  /* OCTET STRING generally means a non-ascii sequence */

--- a/skeletons/OPEN_TYPE.c
+++ b/skeletons/OPEN_TYPE.c
@@ -7,6 +7,7 @@
 #include <constr_CHOICE.h>
 
 asn_TYPE_operation_t asn_OP_OPEN_TYPE = {
+    .kind = ASN_KIND_PRIMITIVE,
     OPEN_TYPE_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     OPEN_TYPE_print,

--- a/skeletons/OPEN_TYPE_xer.c
+++ b/skeletons/OPEN_TYPE_xer.c
@@ -387,7 +387,6 @@ OPEN_TYPE_xer_put(const asn_TYPE_descriptor_t *td, const void *sptr,
         /* Output closing tag (unless it's ASN.1 meta-syntax) */
         if(!skip_wrapper) {
             if(!(flags & XER_F_CANONICAL)) {
-                ASN__TEXT_INDENT(0, ilevel - 1);
                 ASN__CALLBACK3("</", 2, type_name, type_name_len, ">\n", 2);
             } else {
                 ASN__CALLBACK3("</", 2, type_name, type_name_len, ">", 1);

--- a/skeletons/OPEN_TYPE_xer.c
+++ b/skeletons/OPEN_TYPE_xer.c
@@ -392,10 +392,10 @@ OPEN_TYPE_xer_put(const asn_TYPE_descriptor_t *td, const void *sptr,
         if(!skip_wrapper) {
              if(!(flags & XER_F_CANONICAL)) {
                  if(selected.type_descriptor->elements_count > 0
-   && selected.type_descriptor->op->kind != ASN_KIND_SEQUENCE
-   && selected.type_descriptor->op->kind != ASN_KIND_SEQUENCE_OF
-   && selected.type_descriptor->op->kind != ASN_KIND_SET_OF
-   && selected.type_descriptor->op->kind != ASN_KIND_SET)
+                    && selected.type_descriptor->op->kind != ASN_KIND_SEQUENCE
+                    && selected.type_descriptor->op->kind != ASN_KIND_SEQUENCE_OF
+                    && selected.type_descriptor->op->kind != ASN_KIND_SET_OF
+                    && selected.type_descriptor->op->kind != ASN_KIND_SET)
                  {
                      ASN__TEXT_INDENT(0, ilevel);
                  }

--- a/skeletons/OPEN_TYPE_xer.c
+++ b/skeletons/OPEN_TYPE_xer.c
@@ -386,11 +386,7 @@ OPEN_TYPE_xer_put(const asn_TYPE_descriptor_t *td, const void *sptr,
         
         /* Output closing tag (unless it's ASN.1 meta-syntax) */
         if(!skip_wrapper) {
-            if(!(flags & XER_F_CANONICAL)) {
-                ASN__CALLBACK3("</", 2, type_name, type_name_len, ">\n", 2);
-            } else {
-                ASN__CALLBACK3("</", 2, type_name, type_name_len, ">", 1);
-            }
+            ASN__CALLBACK3("</", 2, type_name, type_name_len, ">", 1);
         }
         
         ASN__ENCODED_OK(er);

--- a/skeletons/OPEN_TYPE_xer.c
+++ b/skeletons/OPEN_TYPE_xer.c
@@ -392,11 +392,6 @@ OPEN_TYPE_xer_put(const asn_TYPE_descriptor_t *td, const void *sptr,
         if(!skip_wrapper) {
              if(!(flags & XER_F_CANONICAL)) {
                  if(selected.type_descriptor->elements_count > 0
-/*
-                    && selected.type_descriptor->op != &asn_OP_SEQUENCE
-                    && selected.type_descriptor->op != &asn_OP_SEQUENCE_OF
-                    && selected.type_descriptor->op != &asn_OP_SET_OF) 
-*/
    && selected.type_descriptor->op->kind != ASN_KIND_SEQUENCE
    && selected.type_descriptor->op->kind != ASN_KIND_SEQUENCE_OF
    && selected.type_descriptor->op->kind != ASN_KIND_SET_OF

--- a/skeletons/OPEN_TYPE_xer.c
+++ b/skeletons/OPEN_TYPE_xer.c
@@ -387,6 +387,7 @@ OPEN_TYPE_xer_put(const asn_TYPE_descriptor_t *td, const void *sptr,
         /* Output closing tag (unless it's ASN.1 meta-syntax) */
         if(!skip_wrapper) {
             if(!(flags & XER_F_CANONICAL)) {
+                ASN__TEXT_INDENT(1, ilevel - 1);
                 ASN__CALLBACK3("</", 2, type_name, type_name_len, ">\n", 2);
             } else {
                 ASN__CALLBACK3("</", 2, type_name, type_name_len, ">", 1);

--- a/skeletons/OPEN_TYPE_xer.c
+++ b/skeletons/OPEN_TYPE_xer.c
@@ -7,6 +7,10 @@
 #include <OPEN_TYPE.h>
 #include <constr_CHOICE.h>
 
+extern const asn_TYPE_operation_t asn_OP_SEQUENCE;
+extern const asn_TYPE_operation_t asn_OP_SEQUENCE_OF;
+extern const asn_TYPE_operation_t asn_OP_SET_OF;
+
 asn_dec_rval_t
 OPEN_TYPE_xer_get(const asn_codec_ctx_t *opt_codec_ctx,
                   const asn_TYPE_descriptor_t *td, void *sptr,
@@ -386,11 +390,17 @@ OPEN_TYPE_xer_put(const asn_TYPE_descriptor_t *td, const void *sptr,
         
         /* Output closing tag (unless it's ASN.1 meta-syntax) */
         if(!skip_wrapper) {
-            if(!(flags & XER_F_CANONICAL)) {
-                ASN__CALLBACK3("</", 2, type_name, type_name_len, ">\n", 2);
-            } else {
-                ASN__CALLBACK3("</", 2, type_name, type_name_len, ">", 1);
-            }
+             if(!(flags & XER_F_CANONICAL)) {
+                 if(selected.type_descriptor->elements_count > 0
+                    && selected.type_descriptor->op != &asn_OP_SEQUENCE
+                    && selected.type_descriptor->op != &asn_OP_SEQUENCE_OF
+                    && selected.type_descriptor->op != &asn_OP_SET_OF) {
+                     ASN__TEXT_INDENT(0, ilevel);
+                 }
+                 ASN__CALLBACK3("</", 2, type_name, type_name_len, ">\n", 2);
+             } else {
+                 ASN__CALLBACK3("</", 2, type_name, type_name_len, ">", 1);
+             }
         }
         
         ASN__ENCODED_OK(er);

--- a/skeletons/OPEN_TYPE_xer.c
+++ b/skeletons/OPEN_TYPE_xer.c
@@ -392,9 +392,16 @@ OPEN_TYPE_xer_put(const asn_TYPE_descriptor_t *td, const void *sptr,
         if(!skip_wrapper) {
              if(!(flags & XER_F_CANONICAL)) {
                  if(selected.type_descriptor->elements_count > 0
+/*
                     && selected.type_descriptor->op != &asn_OP_SEQUENCE
                     && selected.type_descriptor->op != &asn_OP_SEQUENCE_OF
-                    && selected.type_descriptor->op != &asn_OP_SET_OF) {
+                    && selected.type_descriptor->op != &asn_OP_SET_OF) 
+*/
+   && selected.type_descriptor->op->kind != ASN_KIND_SEQUENCE
+   && selected.type_descriptor->op->kind != ASN_KIND_SEQUENCE_OF
+   && selected.type_descriptor->op->kind != ASN_KIND_SET_OF
+   && selected.type_descriptor->op->kind != ASN_KIND_SET)
+                 {
                      ASN__TEXT_INDENT(0, ilevel);
                  }
                  ASN__CALLBACK3("</", 2, type_name, type_name_len, ">\n", 2);

--- a/skeletons/OPEN_TYPE_xer.c
+++ b/skeletons/OPEN_TYPE_xer.c
@@ -386,7 +386,11 @@ OPEN_TYPE_xer_put(const asn_TYPE_descriptor_t *td, const void *sptr,
         
         /* Output closing tag (unless it's ASN.1 meta-syntax) */
         if(!skip_wrapper) {
-            ASN__CALLBACK3("</", 2, type_name, type_name_len, ">", 1);
+            if(!(flags & XER_F_CANONICAL)) {
+                ASN__CALLBACK3("</", 2, type_name, type_name_len, ">\n", 2);
+            } else {
+                ASN__CALLBACK3("</", 2, type_name, type_name_len, ">", 1);
+            }
         }
         
         ASN__ENCODED_OK(er);

--- a/skeletons/OPEN_TYPE_xer.c
+++ b/skeletons/OPEN_TYPE_xer.c
@@ -387,7 +387,7 @@ OPEN_TYPE_xer_put(const asn_TYPE_descriptor_t *td, const void *sptr,
         /* Output closing tag (unless it's ASN.1 meta-syntax) */
         if(!skip_wrapper) {
             if(!(flags & XER_F_CANONICAL)) {
-                ASN__TEXT_INDENT(1, ilevel - 1);
+                ASN__TEXT_INDENT(0, ilevel - 1);
                 ASN__CALLBACK3("</", 2, type_name, type_name_len, ">\n", 2);
             } else {
                 ASN__CALLBACK3("</", 2, type_name, type_name_len, ">", 1);

--- a/skeletons/OPEN_TYPE_xer.c
+++ b/skeletons/OPEN_TYPE_xer.c
@@ -386,8 +386,11 @@ OPEN_TYPE_xer_put(const asn_TYPE_descriptor_t *td, const void *sptr,
         
         /* Output closing tag (unless it's ASN.1 meta-syntax) */
         if(!skip_wrapper) {
-            if(!(flags & XER_F_CANONICAL)) ASN__TEXT_INDENT(1, ilevel - 1);
-            ASN__CALLBACK3("</", 2, type_name, type_name_len, ">", 1);
+            if(!(flags & XER_F_CANONICAL)) {
+                ASN__CALLBACK3("</", 2, type_name, type_name_len, ">\n", 2);
+            } else {
+                ASN__CALLBACK3("</", 2, type_name, type_name_len, ">", 1);
+            }
         }
         
         ASN__ENCODED_OK(er);

--- a/skeletons/OPEN_TYPE_xer.c
+++ b/skeletons/OPEN_TYPE_xer.c
@@ -387,6 +387,7 @@ OPEN_TYPE_xer_put(const asn_TYPE_descriptor_t *td, const void *sptr,
         /* Output closing tag (unless it's ASN.1 meta-syntax) */
         if(!skip_wrapper) {
             if(!(flags & XER_F_CANONICAL)) {
+                ASN__TEXT_INDENT(0, ilevel - 1);
                 ASN__CALLBACK3("</", 2, type_name, type_name_len, ">\n", 2);
             } else {
                 ASN__CALLBACK3("</", 2, type_name, type_name_len, ">", 1);

--- a/skeletons/ObjectDescriptor.c
+++ b/skeletons/ObjectDescriptor.c
@@ -13,6 +13,7 @@ static const ber_tlv_tag_t asn_DEF_ObjectDescriptor_tags[] = {
     (ASN_TAG_CLASS_UNIVERSAL | (4 << 2))   /* ... OCTET STRING */
 };
 asn_TYPE_operation_t asn_OP_ObjectDescriptor = {
+    .kind = ASN_KIND_PRIMITIVE,
     OCTET_STRING_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     OCTET_STRING_print_utf8,  /* Treat as ASCII subset (it's not) */

--- a/skeletons/PrintableString.c
+++ b/skeletons/PrintableString.c
@@ -50,6 +50,7 @@ static asn_per_constraints_t asn_DEF_PrintableString_per_constraints = {
 };
 #endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
 asn_TYPE_operation_t asn_OP_PrintableString = {
+    .kind = ASN_KIND_PRIMITIVE,
     OCTET_STRING_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     OCTET_STRING_print_utf8,  /* ASCII subset */

--- a/skeletons/REAL.c
+++ b/skeletons/REAL.c
@@ -55,6 +55,7 @@ static const ber_tlv_tag_t asn_DEF_REAL_tags[] = {
     (ASN_TAG_CLASS_UNIVERSAL | (9 << 2))
 };
 asn_TYPE_operation_t asn_OP_REAL = {
+    .kind = ASN_KIND_PRIMITIVE,
     ASN__PRIMITIVE_TYPE_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     REAL_print,

--- a/skeletons/RELATIVE-OID.c
+++ b/skeletons/RELATIVE-OID.c
@@ -15,6 +15,7 @@ static const ber_tlv_tag_t asn_DEF_RELATIVE_OID_tags[] = {
     (ASN_TAG_CLASS_UNIVERSAL | (13 << 2))
 };
 asn_TYPE_operation_t asn_OP_RELATIVE_OID = {
+    .kind = ASN_KIND_PRIMITIVE,
     ASN__PRIMITIVE_TYPE_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     RELATIVE_OID_print,

--- a/skeletons/T61String.c
+++ b/skeletons/T61String.c
@@ -13,6 +13,7 @@ static const ber_tlv_tag_t asn_DEF_T61String_tags[] = {
     (ASN_TAG_CLASS_UNIVERSAL | (4 << 2))    /* ... OCTET STRING */
 };
 asn_TYPE_operation_t asn_OP_T61String = {
+    .kind = ASN_KIND_PRIMITIVE,
     OCTET_STRING_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     OCTET_STRING_print,  /* non-ascii string */

--- a/skeletons/TeletexString.c
+++ b/skeletons/TeletexString.c
@@ -13,6 +13,7 @@ static const ber_tlv_tag_t asn_DEF_TeletexString_tags[] = {
     (ASN_TAG_CLASS_UNIVERSAL | (4 << 2)),   /* ... OCTET STRING */
 };
 asn_TYPE_operation_t asn_OP_TeletexString = {
+    .kind = ASN_KIND_PRIMITIVE,
     OCTET_STRING_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     OCTET_STRING_print,  /* non-ascii string */

--- a/skeletons/UTCTime.c
+++ b/skeletons/UTCTime.c
@@ -31,6 +31,7 @@ static asn_per_constraints_t asn_DEF_UTCTime_constraints = {
 };
 #endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
 asn_TYPE_operation_t asn_OP_UTCTime = {
+    .kind = ASN_KIND_PRIMITIVE,
     OCTET_STRING_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     UTCTime_print,

--- a/skeletons/UTF8String.c
+++ b/skeletons/UTF8String.c
@@ -14,6 +14,7 @@ static const ber_tlv_tag_t asn_DEF_UTF8String_tags[] = {
     (ASN_TAG_CLASS_UNIVERSAL | (4 << 2)),   /* ... OCTET STRING */
 };
 asn_TYPE_operation_t asn_OP_UTF8String = {
+    .kind = ASN_KIND_PRIMITIVE,
     OCTET_STRING_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     UTF8String_print,

--- a/skeletons/UniversalString.c
+++ b/skeletons/UniversalString.c
@@ -25,6 +25,7 @@ static asn_per_constraints_t asn_DEF_UniversalString_per_constraints = {
 };
 #endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
 asn_TYPE_operation_t asn_OP_UniversalString = {
+    .kind = ASN_KIND_PRIMITIVE,
     OCTET_STRING_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     UniversalString_print,  /* Convert into UTF8 and print */

--- a/skeletons/VideotexString.c
+++ b/skeletons/VideotexString.c
@@ -13,6 +13,7 @@ static const ber_tlv_tag_t asn_DEF_VideotexString_tags[] = {
     (ASN_TAG_CLASS_UNIVERSAL | (4 << 2))    /* ... OCTET STRING */
 };
 asn_TYPE_operation_t asn_OP_VideotexString = {
+    .kind = ASN_KIND_PRIMITIVE,
     OCTET_STRING_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     OCTET_STRING_print,  /* non-ascii string */

--- a/skeletons/VisibleString.c
+++ b/skeletons/VisibleString.c
@@ -20,6 +20,7 @@ static asn_per_constraints_t asn_DEF_VisibleString_constraints = {
 };
 #endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
 asn_TYPE_operation_t asn_OP_VisibleString = {
+    .kind = ASN_KIND_PRIMITIVE,
     OCTET_STRING_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     OCTET_STRING_print_utf8,  /* ASCII subset */

--- a/skeletons/asn_internal.h
+++ b/skeletons/asn_internal.h
@@ -11,8 +11,6 @@
 #define __EXTENSIONS__          /* for Sun */
 #endif
 
-#ifndef ASN_TYPE_KINDS_H
-#define ASN_TYPE_KINDS_H
 typedef enum asn_type_kind {
     ASN_KIND_PRIMITIVE,
     ASN_KIND_SEQUENCE,
@@ -21,7 +19,6 @@ typedef enum asn_type_kind {
     ASN_KIND_SEQUENCE_OF,
     ASN_KIND_SET_OF,
 } asn_type_kind_t;
-#endif /* ASN_TYPE_KINDS_H */
 
 #include "asn_application.h"	/* Application-visible API */
 

--- a/skeletons/asn_internal.h
+++ b/skeletons/asn_internal.h
@@ -11,6 +11,18 @@
 #define __EXTENSIONS__          /* for Sun */
 #endif
 
+#ifndef ASN_TYPE_KINDS_H
+#define ASN_TYPE_KINDS_H
+typedef enum asn_type_kind {
+    ASN_KIND_PRIMITIVE,
+    ASN_KIND_SEQUENCE,
+    ASN_KIND_SET,
+    ASN_KIND_CHOICE,
+    ASN_KIND_SEQUENCE_OF,
+    ASN_KIND_SET_OF,
+} asn_type_kind_t;
+#endif /* ASN_TYPE_KINDS_H */
+
 #include "asn_application.h"	/* Application-visible API */
 
 #ifndef	__NO_ASSERT_H__		/* Include assert.h only for internal use. */

--- a/skeletons/constr_CHOICE.c
+++ b/skeletons/constr_CHOICE.c
@@ -6,6 +6,7 @@
 #include <constr_CHOICE.h>
 
 asn_TYPE_operation_t asn_OP_CHOICE = {
+    .kind = ASN_KIND_CHOICE,
     CHOICE_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     CHOICE_print,

--- a/skeletons/constr_CHOICE_xer.c
+++ b/skeletons/constr_CHOICE_xer.c
@@ -331,11 +331,7 @@ CHOICE_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
 
         /* Output closing tag (unless it's ASN.1 meta-syntax) */
         if(!skip_wrapper) {
-            if(!(flags & XER_F_CANONICAL)) {
-                ASN__CALLBACK3("</", 2, mname, mlen, ">\n", 2);
-            } else {
-                ASN__CALLBACK3("</", 2, mname, mlen, ">", 1);
-            }
+            ASN__CALLBACK3("</", 2, mname, mlen, ">", 1);
         }
     }
 

--- a/skeletons/constr_CHOICE_xer.c
+++ b/skeletons/constr_CHOICE_xer.c
@@ -331,12 +331,8 @@ CHOICE_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
 
         /* Output closing tag (unless it's ASN.1 meta-syntax) */
         if(!skip_wrapper) {
-            /* In non-canonical mode, output closing tag immediately after content,
-             * then newline and indent for the parent's closing tag. */
             if(!(flags & XER_F_CANONICAL)) {
                 ASN__CALLBACK3("</", 2, mname, mlen, ">\n", 2);
-                /* Position cursor for parent's closing tag (indent only, no newline) */
-                ASN__TEXT_INDENT(0, ilevel - 1);
             } else {
                 ASN__CALLBACK3("</", 2, mname, mlen, ">", 1);
             }

--- a/skeletons/constr_CHOICE_xer.c
+++ b/skeletons/constr_CHOICE_xer.c
@@ -26,6 +26,10 @@
         consumed_myself += num;                                   \
     } while(0)
 
+extern const asn_TYPE_operation_t asn_OP_SEQUENCE;
+extern const asn_TYPE_operation_t asn_OP_SEQUENCE_OF;
+extern const asn_TYPE_operation_t asn_OP_SET_OF;
+
 /*
  * Decode the XER (XML) data.
  */
@@ -332,7 +336,13 @@ CHOICE_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
         /* Output closing tag (unless it's ASN.1 meta-syntax) */
         if(!skip_wrapper) {
             if(!(flags & XER_F_CANONICAL)) {
-                ASN__CALLBACK3("</", 2, mname, mlen, ">\n", 2);
+                 if(elm->type->elements_count > 0
+                    && elm->type->op != &asn_OP_SEQUENCE
+                    && elm->type->op != &asn_OP_SEQUENCE_OF
+                    && elm->type->op != &asn_OP_SET_OF) {
+                     ASN__TEXT_INDENT(0, ilevel);
+                 }
+                 ASN__CALLBACK3("</", 2, mname, mlen, ">\n", 2);
             } else {
                 ASN__CALLBACK3("</", 2, mname, mlen, ">", 1);
             }

--- a/skeletons/constr_CHOICE_xer.c
+++ b/skeletons/constr_CHOICE_xer.c
@@ -332,6 +332,7 @@ CHOICE_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
         /* Output closing tag (unless it's ASN.1 meta-syntax) */
         if(!skip_wrapper) {
             if(!(flags & XER_F_CANONICAL)) {
+                ASN__TEXT_INDENT(0, ilevel - 1);
                 ASN__CALLBACK3("</", 2, mname, mlen, ">\n", 2);
             } else {
                 ASN__CALLBACK3("</", 2, mname, mlen, ">", 1);

--- a/skeletons/constr_CHOICE_xer.c
+++ b/skeletons/constr_CHOICE_xer.c
@@ -332,6 +332,7 @@ CHOICE_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
         /* Output closing tag (unless it's ASN.1 meta-syntax) */
         if(!skip_wrapper) {
             if(!(flags & XER_F_CANONICAL)) {
+                ASN__TEXT_INDENT(1, ilevel - 1);
                 ASN__CALLBACK3("</", 2, mname, mlen, ">\n", 2);
             } else {
                 ASN__CALLBACK3("</", 2, mname, mlen, ">", 1);

--- a/skeletons/constr_CHOICE_xer.c
+++ b/skeletons/constr_CHOICE_xer.c
@@ -332,7 +332,6 @@ CHOICE_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
         /* Output closing tag (unless it's ASN.1 meta-syntax) */
         if(!skip_wrapper) {
             if(!(flags & XER_F_CANONICAL)) {
-                ASN__TEXT_INDENT(0, ilevel - 1);
                 ASN__CALLBACK3("</", 2, mname, mlen, ">\n", 2);
             } else {
                 ASN__CALLBACK3("</", 2, mname, mlen, ">", 1);

--- a/skeletons/constr_CHOICE_xer.c
+++ b/skeletons/constr_CHOICE_xer.c
@@ -332,7 +332,7 @@ CHOICE_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
         /* Output closing tag (unless it's ASN.1 meta-syntax) */
         if(!skip_wrapper) {
             if(!(flags & XER_F_CANONICAL)) {
-                ASN__TEXT_INDENT(1, ilevel - 1);
+                ASN__TEXT_INDENT(0, ilevel - 1);
                 ASN__CALLBACK3("</", 2, mname, mlen, ">\n", 2);
             } else {
                 ASN__CALLBACK3("</", 2, mname, mlen, ">", 1);

--- a/skeletons/constr_CHOICE_xer.c
+++ b/skeletons/constr_CHOICE_xer.c
@@ -337,15 +337,10 @@ CHOICE_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
         if(!skip_wrapper) {
             if(!(flags & XER_F_CANONICAL)) {
                  if(elm->type->elements_count > 0
-/*
-                    && elm->type->op != &asn_OP_SEQUENCE
-                    && elm->type->op != &asn_OP_SEQUENCE_OF
-                    && elm->type->op != &asn_OP_SET_OF) {
-*/
-   && elm->type->op->kind != ASN_KIND_SEQUENCE
-   && elm->type->op->kind != ASN_KIND_SEQUENCE_OF
-   && elm->type->op->kind != ASN_KIND_SET_OF
-   && elm->type->op->kind != ASN_KIND_SET)
+                    && elm->type->op->kind != ASN_KIND_SEQUENCE
+                    && elm->type->op->kind != ASN_KIND_SEQUENCE_OF
+                    && elm->type->op->kind != ASN_KIND_SET_OF
+                    && elm->type->op->kind != ASN_KIND_SET)
                  {
                      ASN__TEXT_INDENT(0, ilevel);
                  }

--- a/skeletons/constr_CHOICE_xer.c
+++ b/skeletons/constr_CHOICE_xer.c
@@ -337,9 +337,16 @@ CHOICE_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
         if(!skip_wrapper) {
             if(!(flags & XER_F_CANONICAL)) {
                  if(elm->type->elements_count > 0
+/*
                     && elm->type->op != &asn_OP_SEQUENCE
                     && elm->type->op != &asn_OP_SEQUENCE_OF
                     && elm->type->op != &asn_OP_SET_OF) {
+*/
+   && elm->type->op->kind != ASN_KIND_SEQUENCE
+   && elm->type->op->kind != ASN_KIND_SEQUENCE_OF
+   && elm->type->op->kind != ASN_KIND_SET_OF
+   && elm->type->op->kind != ASN_KIND_SET)
+                 {
                      ASN__TEXT_INDENT(0, ilevel);
                  }
                  ASN__CALLBACK3("</", 2, mname, mlen, ">\n", 2);

--- a/skeletons/constr_CHOICE_xer.c
+++ b/skeletons/constr_CHOICE_xer.c
@@ -331,7 +331,11 @@ CHOICE_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
 
         /* Output closing tag (unless it's ASN.1 meta-syntax) */
         if(!skip_wrapper) {
-            ASN__CALLBACK3("</", 2, mname, mlen, ">", 1);
+            if(!(flags & XER_F_CANONICAL)) {
+                ASN__CALLBACK3("</", 2, mname, mlen, ">\n", 2);
+            } else {
+                ASN__CALLBACK3("</", 2, mname, mlen, ">", 1);
+            }
         }
     }
 

--- a/skeletons/constr_SEQUENCE.c
+++ b/skeletons/constr_SEQUENCE.c
@@ -7,6 +7,7 @@
 #include <constr_SEQUENCE.h>
 
 asn_TYPE_operation_t asn_OP_SEQUENCE = {
+    .kind = ASN_KIND_SEQUENCE,
     SEQUENCE_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     SEQUENCE_print,

--- a/skeletons/constr_SEQUENCE_OF.c
+++ b/skeletons/constr_SEQUENCE_OF.c
@@ -24,6 +24,7 @@ asn_TYPE_descriptor_t asn_DEF_SEQUENCE_OF = {
 };
 
 asn_TYPE_operation_t asn_OP_SEQUENCE_OF = {
+    .kind = ASN_KIND_SEQUENCE_OF,
     SEQUENCE_OF_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     SEQUENCE_OF_print,

--- a/skeletons/constr_SEQUENCE_OF_xer.c
+++ b/skeletons/constr_SEQUENCE_OF_xer.c
@@ -205,7 +205,7 @@ SEQUENCE_OF_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr,
         }
     }
 
-    /* Parent handles indentation for SEQUENCE_OF's closing tag */
+    if(!xcan) ASN__TEXT_INDENT(1, ilevel - 1);
 
     XER_ENCODER_RECURSION_DEPTH_DEC();
     ASN__ENCODED_OK(er);

--- a/skeletons/constr_SEQUENCE_OF_xer.c
+++ b/skeletons/constr_SEQUENCE_OF_xer.c
@@ -205,7 +205,7 @@ SEQUENCE_OF_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr,
         }
     }
 
-    if(!xcan) ASN__TEXT_INDENT(1, ilevel - 1);
+    if(!xcan) ASN__TEXT_INDENT(0, ilevel - 1);
 
     XER_ENCODER_RECURSION_DEPTH_DEC();
     ASN__ENCODED_OK(er);

--- a/skeletons/constr_SEQUENCE_OF_xer.c
+++ b/skeletons/constr_SEQUENCE_OF_xer.c
@@ -205,7 +205,7 @@ SEQUENCE_OF_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr,
         }
     }
 
-    if(!xcan) ASN__TEXT_INDENT(0, ilevel - 1);
+    /* Parent handles indentation for SEQUENCE_OF's closing tag */
 
     XER_ENCODER_RECURSION_DEPTH_DEC();
     ASN__ENCODED_OK(er);

--- a/skeletons/constr_SEQUENCE_xer.c
+++ b/skeletons/constr_SEQUENCE_xer.c
@@ -445,7 +445,15 @@ SEQUENCE_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr,
         er.encoded += tmper.encoded;
 
         if(!xcan) {
-            ASN__TEXT_INDENT(0, ilevel);
+            /* Check if child type is complex to determine if indent is needed */
+            int child_is_complex = (elm->flags & ATF_OPEN_TYPE) || 
+                                   (elm->type && elm->type->elements_count > 0);
+            
+            if(child_is_complex) {
+                /* Complex child - output indent before closing tag */
+                ASN__TEXT_INDENT(0, ilevel);
+            }
+            /* Output closing tag */
             ASN__CALLBACK3("</", 2, mname, mlen, ">\n", 2);
         } else {
             ASN__CALLBACK3("</", 2, mname, mlen, ">", 1);

--- a/skeletons/constr_SEQUENCE_xer.c
+++ b/skeletons/constr_SEQUENCE_xer.c
@@ -445,13 +445,14 @@ SEQUENCE_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr,
         er.encoded += tmper.encoded;
 
         if(!xcan) {
-            ASN__TEXT_INDENT(1, ilevel);
+            ASN__TEXT_INDENT(0, ilevel);
             ASN__CALLBACK3("</", 2, mname, mlen, ">\n", 2);
         } else {
             ASN__CALLBACK3("</", 2, mname, mlen, ">", 1);
         }
     }
 
+    /* Output indentation for SEQUENCE's own closing tag */
     if(!xcan) ASN__TEXT_INDENT(0, ilevel - 1);
 
     XER_ENCODER_RECURSION_DEPTH_DEC();

--- a/skeletons/constr_SEQUENCE_xer.c
+++ b/skeletons/constr_SEQUENCE_xer.c
@@ -459,7 +459,8 @@ SEQUENCE_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr,
         }
     }
 
-    /* Parent handles positioning for SEQUENCE's own closing tag */
+    /* Output indentation for SEQUENCE's own closing tag (parent will output the tag itself) */
+    if(!xcan) ASN__TEXT_INDENT(0, ilevel - 1);
 
     XER_ENCODER_RECURSION_DEPTH_DEC();
     ASN__ENCODED_OK(er);

--- a/skeletons/constr_SEQUENCE_xer.c
+++ b/skeletons/constr_SEQUENCE_xer.c
@@ -449,17 +449,17 @@ SEQUENCE_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr,
             int child_is_complex = (elm->type && elm->type->elements_count > 0);
             
             if(child_is_complex) {
-                /* Complex child - output newline and indent before closing tag */
-                ASN__TEXT_INDENT(1, ilevel);
+                /* Complex child outputs newline after content, just need indent before closing tag */
+                ASN__TEXT_INDENT(0, ilevel);
             }
-            /* Primitive child or after complex child - closing tag positioned by content */
+            /* Primitive child - closing tag immediately after content */
             ASN__CALLBACK3("</", 2, mname, mlen, ">\n", 2);
         } else {
             ASN__CALLBACK3("</", 2, mname, mlen, ">", 1);
         }
     }
 
-    if(!xcan) ASN__TEXT_INDENT(0, ilevel - 1);
+    /* Parent handles positioning for SEQUENCE's own closing tag */
 
     XER_ENCODER_RECURSION_DEPTH_DEC();
     ASN__ENCODED_OK(er);

--- a/skeletons/constr_SEQUENCE_xer.c
+++ b/skeletons/constr_SEQUENCE_xer.c
@@ -445,7 +445,7 @@ SEQUENCE_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr,
         er.encoded += tmper.encoded;
 
         if(!xcan) {
-            ASN__TEXT_INDENT(1, ilevel - 1);
+            ASN__TEXT_INDENT(1, ilevel);
             ASN__CALLBACK3("</", 2, mname, mlen, ">\n", 2);
         } else {
             ASN__CALLBACK3("</", 2, mname, mlen, ">", 1);

--- a/skeletons/constr_SEQUENCE_xer.c
+++ b/skeletons/constr_SEQUENCE_xer.c
@@ -445,6 +445,11 @@ SEQUENCE_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr,
         er.encoded += tmper.encoded;
 
         if(!xcan) {
+       		int add_indent = 0;
+	    	if(elm->flags & ATF_OPEN_TYPE) {
+    	       add_indent = 1;
+	       	}
+    	   	if(add_indent) ASN__TEXT_INDENT(0, ilevel);
             ASN__CALLBACK3("</", 2, mname, mlen, ">\n", 2);
         } else {
             ASN__CALLBACK3("</", 2, mname, mlen, ">", 1);

--- a/skeletons/constr_SEQUENCE_xer.c
+++ b/skeletons/constr_SEQUENCE_xer.c
@@ -445,25 +445,13 @@ SEQUENCE_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr,
         er.encoded += tmper.encoded;
 
         if(!xcan) {
-            /* Check if child needs indent before closing tag based on whether it outputs newlines */
-            /* OPEN_TYPE members are always complex (contain CHOICE or other complex types) */
-            /* Other complex types have elements_count > 0 */
-            int child_is_complex = (elm->flags & ATF_OPEN_TYPE) || 
-                                   (elm->type && elm->type->elements_count > 0);
-            
-            if(child_is_complex) {
-                /* Complex child outputs newline after content, just need indent before closing tag */
-                ASN__TEXT_INDENT(0, ilevel);
-            }
-            /* Primitive child - closing tag immediately after content */
             ASN__CALLBACK3("</", 2, mname, mlen, ">\n", 2);
         } else {
             ASN__CALLBACK3("</", 2, mname, mlen, ">", 1);
         }
     }
 
-    /* Output indentation for SEQUENCE's own closing tag (parent will output the tag itself) */
-    if(!xcan) ASN__TEXT_INDENT(0, ilevel - 1);
+    if(!xcan) ASN__TEXT_INDENT(1, ilevel - 1);
 
     XER_ENCODER_RECURSION_DEPTH_DEC();
     ASN__ENCODED_OK(er);

--- a/skeletons/constr_SEQUENCE_xer.c
+++ b/skeletons/constr_SEQUENCE_xer.c
@@ -445,8 +445,6 @@ SEQUENCE_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr,
         er.encoded += tmper.encoded;
 
         if(!xcan) {
-            /* Output newline+indent before member closing tag */
-            ASN__TEXT_INDENT(1, ilevel);
             ASN__CALLBACK3("</", 2, mname, mlen, ">\n", 2);
         } else {
             ASN__CALLBACK3("</", 2, mname, mlen, ">", 1);

--- a/skeletons/constr_SEQUENCE_xer.c
+++ b/skeletons/constr_SEQUENCE_xer.c
@@ -445,13 +445,14 @@ SEQUENCE_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr,
         er.encoded += tmper.encoded;
 
         if(!xcan) {
+            ASN__TEXT_INDENT(1, ilevel - 1);
             ASN__CALLBACK3("</", 2, mname, mlen, ">\n", 2);
         } else {
             ASN__CALLBACK3("</", 2, mname, mlen, ">", 1);
         }
     }
 
-    if(!xcan) ASN__TEXT_INDENT(1, ilevel - 1);
+    if(!xcan) ASN__TEXT_INDENT(0, ilevel - 1);
 
     XER_ENCODER_RECURSION_DEPTH_DEC();
     ASN__ENCODED_OK(er);

--- a/skeletons/constr_SEQUENCE_xer.c
+++ b/skeletons/constr_SEQUENCE_xer.c
@@ -451,7 +451,7 @@ SEQUENCE_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr,
         }
     }
 
-    if(!xcan) ASN__TEXT_INDENT(0, ilevel - 1);
+    if(!xcan) ASN__TEXT_INDENT(1, ilevel - 1);
 
     XER_ENCODER_RECURSION_DEPTH_DEC();
     ASN__ENCODED_OK(er);

--- a/skeletons/constr_SEQUENCE_xer.c
+++ b/skeletons/constr_SEQUENCE_xer.c
@@ -451,7 +451,7 @@ SEQUENCE_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr,
         }
     }
 
-    if(!xcan) ASN__TEXT_INDENT(1, ilevel - 1);
+    if(!xcan) ASN__TEXT_INDENT(0, ilevel - 1);
 
     XER_ENCODER_RECURSION_DEPTH_DEC();
     ASN__ENCODED_OK(er);

--- a/skeletons/constr_SEQUENCE_xer.c
+++ b/skeletons/constr_SEQUENCE_xer.c
@@ -445,14 +445,20 @@ SEQUENCE_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr,
         er.encoded += tmper.encoded;
 
         if(!xcan) {
-            ASN__TEXT_INDENT(0, ilevel);
+            /* Check if child type is complex (has elements) to determine formatting */
+            int child_is_complex = (elm->type && elm->type->elements_count > 0);
+            
+            if(child_is_complex) {
+                /* Complex child - output newline and indent before closing tag */
+                ASN__TEXT_INDENT(1, ilevel);
+            }
+            /* Primitive child or after complex child - closing tag positioned by content */
             ASN__CALLBACK3("</", 2, mname, mlen, ">\n", 2);
         } else {
             ASN__CALLBACK3("</", 2, mname, mlen, ">", 1);
         }
     }
 
-    /* Output indentation for SEQUENCE's own closing tag */
     if(!xcan) ASN__TEXT_INDENT(0, ilevel - 1);
 
     XER_ENCODER_RECURSION_DEPTH_DEC();

--- a/skeletons/constr_SEQUENCE_xer.c
+++ b/skeletons/constr_SEQUENCE_xer.c
@@ -445,11 +445,11 @@ SEQUENCE_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr,
         er.encoded += tmper.encoded;
 
         if(!xcan) {
-       		int add_indent = 0;
-	    	if(elm->flags & ATF_OPEN_TYPE) {
-    	       add_indent = 1;
-	       	}
-    	   	if(add_indent) ASN__TEXT_INDENT(0, ilevel);
+            int add_indent = 0;
+            if(elm->flags & ATF_OPEN_TYPE) {
+                add_indent = 1;
+            }
+            if(add_indent) ASN__TEXT_INDENT(0, ilevel);
             ASN__CALLBACK3("</", 2, mname, mlen, ">\n", 2);
         } else {
             ASN__CALLBACK3("</", 2, mname, mlen, ">", 1);

--- a/skeletons/constr_SEQUENCE_xer.c
+++ b/skeletons/constr_SEQUENCE_xer.c
@@ -445,8 +445,11 @@ SEQUENCE_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr,
         er.encoded += tmper.encoded;
 
         if(!xcan) {
-            /* Check if child type is complex (has elements) to determine formatting */
-            int child_is_complex = (elm->type && elm->type->elements_count > 0);
+            /* Check if child needs indent before closing tag based on whether it outputs newlines */
+            /* OPEN_TYPE members are always complex (contain CHOICE or other complex types) */
+            /* Other complex types have elements_count > 0 */
+            int child_is_complex = (elm->flags & ATF_OPEN_TYPE) || 
+                                   (elm->type && elm->type->elements_count > 0);
             
             if(child_is_complex) {
                 /* Complex child outputs newline after content, just need indent before closing tag */

--- a/skeletons/constr_SEQUENCE_xer.c
+++ b/skeletons/constr_SEQUENCE_xer.c
@@ -445,13 +445,14 @@ SEQUENCE_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr,
         er.encoded += tmper.encoded;
 
         if(!xcan) {
+            ASN__TEXT_INDENT(0, ilevel);
             ASN__CALLBACK3("</", 2, mname, mlen, ">\n", 2);
         } else {
             ASN__CALLBACK3("</", 2, mname, mlen, ">", 1);
         }
     }
 
-    if(!xcan) ASN__TEXT_INDENT(1, ilevel - 1);
+    if(!xcan) ASN__TEXT_INDENT(0, ilevel - 1);
 
     XER_ENCODER_RECURSION_DEPTH_DEC();
     ASN__ENCODED_OK(er);

--- a/skeletons/constr_SEQUENCE_xer.c
+++ b/skeletons/constr_SEQUENCE_xer.c
@@ -445,15 +445,8 @@ SEQUENCE_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr,
         er.encoded += tmper.encoded;
 
         if(!xcan) {
-            /* Check if child type is complex to determine if indent is needed */
-            int child_is_complex = (elm->flags & ATF_OPEN_TYPE) || 
-                                   (elm->type && elm->type->elements_count > 0);
-            
-            if(child_is_complex) {
-                /* Complex child - output indent before closing tag */
-                ASN__TEXT_INDENT(0, ilevel);
-            }
-            /* Output closing tag */
+            /* Output newline+indent before member closing tag */
+            ASN__TEXT_INDENT(1, ilevel);
             ASN__CALLBACK3("</", 2, mname, mlen, ">\n", 2);
         } else {
             ASN__CALLBACK3("</", 2, mname, mlen, ">", 1);

--- a/skeletons/constr_SET.c
+++ b/skeletons/constr_SET.c
@@ -7,6 +7,7 @@
 #include <constr_SET.h>
 
 asn_TYPE_operation_t asn_OP_SET = {
+    .kind = ASN_KIND_SET,
     SET_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     SET_print,

--- a/skeletons/constr_SET_OF.c
+++ b/skeletons/constr_SET_OF.c
@@ -22,6 +22,7 @@ asn_TYPE_descriptor_t asn_DEF_SET_OF = {
 };
 
 asn_TYPE_operation_t asn_OP_SET_OF = {
+    .kind = ASN_KIND_SET_OF,
     SET_OF_free,
 #if !defined(ASN_DISABLE_PRINT_SUPPORT)
     SET_OF_print,

--- a/skeletons/constr_SET_OF_xer.c
+++ b/skeletons/constr_SET_OF_xer.c
@@ -534,7 +534,7 @@ SET_OF_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
 
     }
 
-    if(!xcan) ASN__TEXT_INDENT(1, ilevel - 1);
+    if(!xcan) ASN__TEXT_INDENT(0, ilevel - 1);
 
     if(encs) {
         xer_tmp_enc_t *enc = encs;

--- a/skeletons/constr_SET_OF_xer.c
+++ b/skeletons/constr_SET_OF_xer.c
@@ -534,7 +534,7 @@ SET_OF_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
 
     }
 
-    /* Parent handles indentation for SET_OF's closing tag */
+    if(!xcan) ASN__TEXT_INDENT(1, ilevel - 1);
 
     if(encs) {
         xer_tmp_enc_t *enc = encs;

--- a/skeletons/constr_SET_OF_xer.c
+++ b/skeletons/constr_SET_OF_xer.c
@@ -534,7 +534,7 @@ SET_OF_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
 
     }
 
-    if(!xcan) ASN__TEXT_INDENT(0, ilevel - 1);
+    /* Parent handles indentation for SET_OF's closing tag */
 
     if(encs) {
         xer_tmp_enc_t *enc = encs;

--- a/skeletons/constr_SET_xer.c
+++ b/skeletons/constr_SET_xer.c
@@ -324,7 +324,7 @@ SET_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
         }
     }
 
-    if(!xcan) ASN__TEXT_INDENT(1, ilevel - 1);
+    if(!xcan) ASN__TEXT_INDENT(0, ilevel - 1);
 
     XER_ENCODER_RECURSION_DEPTH_DEC();
     ASN__ENCODED_OK(er);

--- a/skeletons/constr_SET_xer.c
+++ b/skeletons/constr_SET_xer.c
@@ -324,7 +324,7 @@ SET_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
         }
     }
 
-    /* Parent handles indentation for SET's closing tag */
+    if(!xcan) ASN__TEXT_INDENT(1, ilevel - 1);
 
     XER_ENCODER_RECURSION_DEPTH_DEC();
     ASN__ENCODED_OK(er);

--- a/skeletons/constr_SET_xer.c
+++ b/skeletons/constr_SET_xer.c
@@ -63,10 +63,6 @@ SET_decode_xer(const asn_codec_ctx_t *opt_codec_ctx,
      */
     ctx = (asn_struct_ctx_t *)((char *)st + specs->ctx_offset);
 
-    /* Check recursion depth to prevent stack overflow */
-    if(ASN__STACK_OVERFLOW_CHECK(opt_codec_ctx))
-        RETURN(RC_FAIL);
-
     /*
      * Phases of XER/XML processing:
      * Phase 0: Check that the opening tag matches our expectations.
@@ -263,9 +259,6 @@ SET_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
     if(!sptr)
         ASN__ENCODE_FAILED;
 
-    /* Check recursion depth to prevent stack overflow */
-    XER_ENCODER_RECURSION_DEPTH_INC();
-
     assert(t2m_count == td->elements_count);
 
     er.encoded = 0;
@@ -288,47 +281,29 @@ SET_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
                 if(elm->optional)
                     continue;
                 /* Mandatory element missing */
-                XER_ENCODER_RECURSION_DEPTH_DEC();
                 ASN__ENCODE_FAILED;
             }
         } else {
             memb_ptr = (const void *)((const char *)sptr + elm->memb_offset);
         }
 
-        if(!xcan) {
-            if(edx == 0 || er.encoded == 0) {
-                /* First member: output newline + indent */
-                ASN__TEXT_INDENT(1, ilevel);
-            } else {
-                /* Subsequent members: output only indent (newline comes from previous closing tag) */
-                int tmp_i;
-                for(tmp_i = 0; tmp_i < ilevel; tmp_i++) ASN__CALLBACK("    ", 4);
-            }
-        }
+        if(!xcan)
+            ASN__TEXT_INDENT(1, ilevel);
         ASN__CALLBACK3("<", 1, mname, mlen, ">", 1);
 
         /* Print the member itself */
         tmper = elm->type->op->xer_encoder(elm->type, memb_ptr,
                                            ilevel + 1, flags,
                                            cb, app_key);
-        if(tmper.encoded == -1) {
-            XER_ENCODER_RECURSION_DEPTH_DEC();
-            return tmper;
-        }
+        if(tmper.encoded == -1) return tmper;
         er.encoded += tmper.encoded;
 
-        if(!xcan) {
-            ASN__CALLBACK3("</", 2, mname, mlen, ">\n", 2);
-        } else {
-            ASN__CALLBACK3("</", 2, mname, mlen, ">", 1);
-        }
+        ASN__CALLBACK3("</", 2, mname, mlen, ">", 1);
     }
 
     if(!xcan) ASN__TEXT_INDENT(0, ilevel - 1);
 
-    XER_ENCODER_RECURSION_DEPTH_DEC();
     ASN__ENCODED_OK(er);
 cb_failed:
-    XER_ENCODER_RECURSION_DEPTH_DEC();
     ASN__ENCODE_FAILED;
 }

--- a/skeletons/constr_SET_xer.c
+++ b/skeletons/constr_SET_xer.c
@@ -324,7 +324,7 @@ SET_encode_xer(const asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
         }
     }
 
-    if(!xcan) ASN__TEXT_INDENT(0, ilevel - 1);
+    /* Parent handles indentation for SET's closing tag */
 
     XER_ENCODER_RECURSION_DEPTH_DEC();
     ASN__ENCODED_OK(er);

--- a/skeletons/constr_TYPE.h
+++ b/skeletons/constr_TYPE.h
@@ -11,6 +11,8 @@
 #ifndef	_CONSTR_TYPE_H_
 #define	_CONSTR_TYPE_H_
 
+#include "asn_internal.h"
+
 #include <ber_tlv_length.h>
 #include <ber_tlv_tag.h>
 
@@ -182,6 +184,7 @@ typedef asn_type_selector_result_t(asn_type_selector_f)(
  * May be directly invoked by applications.
  */
 typedef struct asn_TYPE_operation_s {
+    asn_type_kind_t kind;   /* The kind/category of this type */
     asn_struct_free_f *free_struct;     /* Free the structure */
     asn_struct_print_f *print_struct;   /* Human readable output */
     asn_struct_compare_f *compare_struct; /* Compare two structures */

--- a/tests/Makefile.am.libasncodec
+++ b/tests/Makefile.am.libasncodec
@@ -101,6 +101,7 @@ ASN_MODULE_HDRS+=ber_tlv_length.h
 ASN_MODULE_SRCS+=ber_tlv_length.c
 ASN_MODULE_HDRS+=ber_tlv_tag.h
 ASN_MODULE_SRCS+=ber_tlv_tag.c
+ASN_MODULE_HDRS+=asn_type_kinds.h
 ASN_MODULE_HDRS+=constr_TYPE.h
 ASN_MODULE_SRCS+=constr_TYPE.c
 ASN_MODULE_HDRS+=constraints.h

--- a/tests/Makefile.am.libasncodec
+++ b/tests/Makefile.am.libasncodec
@@ -101,7 +101,6 @@ ASN_MODULE_HDRS+=ber_tlv_length.h
 ASN_MODULE_SRCS+=ber_tlv_length.c
 ASN_MODULE_HDRS+=ber_tlv_tag.h
 ASN_MODULE_SRCS+=ber_tlv_tag.c
-ASN_MODULE_HDRS+=asn_type_kinds.h
 ASN_MODULE_HDRS+=constr_TYPE.h
 ASN_MODULE_SRCS+=constr_TYPE.c
 ASN_MODULE_HDRS+=constraints.h

--- a/tests/tests-skeletons/check-APER-INTEGER-extensible-semi.c
+++ b/tests/tests-skeletons/check-APER-INTEGER-extensible-semi.c
@@ -226,6 +226,9 @@ int main() {
     TEST_ROOT(200, 100);
     TEST_ROOT(1000, 100);
 
+    TEST_EXT(100, 100);
+    TEST_EXT(200, 100);
+
     printf("\n=== All extensible semi-constrained INTEGER tests passed! ===\n");
     return 0;
 }


### PR DESCRIPTION
Closes #398  and #396  

May still need to refactor `OPEN_TYPE_xer.c` to eliminate direct references to `asn_OP_SET_OF` and such.