### PR TITLE
fix undefined behavior in asn1f_fix_constr_ext

### DIFF
--- a/libasn1fix/asn1fix_constr.c
+++ b/libasn1fix/asn1fix_constr.c
@@ -89,11 +89,13 @@ asn1f_pull_components_of(arg_t *arg) {
  */
 int
 asn1f_fix_constr_ext(arg_t *arg) {
+	typedef TQ_HEAD(asn1p_expr_t) asn1p_expr_list_t;
+
 	asn1p_expr_t *expr = arg->expr;
 	asn1p_expr_t *v;
-	TQ_HEAD(asn1p_expr_t) root_list;
-	TQ_HEAD(asn1p_expr_t) ext_list;
-	TQ_HEAD(asn1p_expr_t) *cur_list;
+	asn1p_expr_list_t root_list;
+	asn1p_expr_list_t ext_list;
+	asn1p_expr_list_t *cur_list;
 	int r_value = 0;
 	int ext_count = 0;
 
@@ -110,7 +112,7 @@ asn1f_fix_constr_ext(arg_t *arg) {
 
 	TQ_INIT(&root_list);
 	TQ_INIT(&ext_list);
-	cur_list = (void *)&root_list;
+	cur_list = &root_list;
 
 	/*
 	 * Split the set of fields into two lists, the root list
@@ -120,11 +122,11 @@ asn1f_fix_constr_ext(arg_t *arg) {
 		if(v->expr_type == A1TC_EXTENSIBLE) {
 			ext_count++;
 			switch(ext_count) {
-			case 1: cur_list = (void *)&ext_list; break;
+			case 1: cur_list = &ext_list; break;
 			case 2:
 				/* Second extension marker: continue with extensions,
 				 * do not switch back to root_list */
-				cur_list = (void *)&ext_list;
+				cur_list = &ext_list;
 				if(v->value) {
 					FATAL("Optional extension marker "
 						"must not contain "


### PR DESCRIPTION
The check_fixer executable crashed on non-Ubuntu systems when compiling with enabled optimization flags.