### PR TITLE
compiler: fix circular dependency detection

### DIFF
--- a/libasn1compiler/asn1c_C.c
+++ b/libasn1compiler/asn1c_C.c
@@ -4391,11 +4391,14 @@ check_is_refer_to_enhanced(arg_t *arg, circ_detect_ctx_t *ctx) {
 		return 2; /* Direct circular dependency */
 	}
 	
-	/* Check if this terminal is already in our path (cycle detection)
-	 * If we hit a cycle without finding our target, stop this branch */
+	/* Check if this terminal is already in our path (cycle detection).
+	 * If we hit a cycle without finding our target, stop exploring this branch.
+	 * The cycle will be broken when processing the types that are actually
+	 * in the cycle - we don't need to add indirection here just because
+	 * we reference a type that's part of some other cycle. */
 	for(size_t i = 0; i < ctx->path_len; i++) {
 		if(ctx->path[i] == terminal) {
-			return 0; /* Cycle without reaching target */
+			return 0; /* Cycle detected but doesn't include our target */
 		}
 	}
 	
@@ -4494,7 +4497,12 @@ expr_defined_recursively(arg_t *arg, asn1p_expr_t *expr) {
 			.target = topmost
 		};
 		
-		result = check_is_refer_to_enhanced(arg, &ctx);
+		/* Create a temporary arg with expr set to the member we're analyzing,
+		 * not the container type that arg->expr currently points to */
+		arg_t tmp_arg = *arg;
+		tmp_arg.expr = expr;
+		
+		result = check_is_refer_to_enhanced(&tmp_arg, &ctx);
 		
 		if(ctx.path) {
 			free(ctx.path);

--- a/tests/tests-asn1c-compiler/104-param-1-OK.asn1.+-P_-fwide-types
+++ b/tests/tests-asn1c-compiler/104-param-1-OK.asn1.+-P_-fwide-types
@@ -149,19 +149,14 @@ asn_TYPE_descriptor_t asn_DEF_Collection_16P1 = {
 
 /*** <<< INCLUDES [Bunch] >>> ***/
 
+#include "Collection.h"
 #include <constr_SEQUENCE.h>
-
-/*** <<< FWD-DECLS [Bunch] >>> ***/
-
-struct Collection_16P0;
-struct Collection_16P1;
-struct Collection;
 
 /*** <<< TYPE-DECLS [Bunch] >>> ***/
 
 typedef struct Bunch {
-	struct Collection	*field_REAL;
-	struct Collection	*field_IA5String;
+	Collection_16P0_t	 field_REAL;
+	Collection_16P1_t	 field_IA5String;
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;
@@ -171,14 +166,10 @@ typedef struct Bunch {
 
 extern asn_TYPE_descriptor_t asn_DEF_Bunch;
 
-/*** <<< POST-INCLUDE [Bunch] >>> ***/
-
-#include "Collection.h"
-
 /*** <<< STAT-DEFS [Bunch] >>> ***/
 
 static asn_TYPE_member_t asn_MBR_Bunch_1[] = {
-	{ ATF_POINTER, 0, offsetof(struct Bunch, field_REAL),
+	{ ATF_NOFLAGS, 0, offsetof(struct Bunch, field_REAL),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (17 << 2)),
 		.tag_mode = 0,
 		.type = &asn_DEF_Collection_16P0,
@@ -198,7 +189,7 @@ static asn_TYPE_member_t asn_MBR_Bunch_1[] = {
 		0, 0, /* No default value */
 		.name = "field-REAL"
 		},
-	{ ATF_POINTER, 0, offsetof(struct Bunch, field_IA5String),
+	{ ATF_NOFLAGS, 0, offsetof(struct Bunch, field_IA5String),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (17 << 2)),
 		.tag_mode = 0,
 		.type = &asn_DEF_Collection_16P1,

--- a/tests/tests-asn1c-compiler/126-per-extensions-OK.asn1.+-P_-gen-UPER_-gen-APER
+++ b/tests/tests-asn1c-compiler/126-per-extensions-OK.asn1.+-P_-gen-UPER_-gen-APER
@@ -2,12 +2,13 @@
 /*** <<< INCLUDES [PDU] >>> ***/
 
 #include <IA5String.h>
+#include "Singleton.h"
 #include <constr_SEQUENCE.h>
 
 /*** <<< FWD-DECLS [PDU] >>> ***/
 
-struct Singleton;
 struct PDU_2;
+struct Singleton;
 
 /*** <<< TYPE-DECLS [PDU] >>> ***/
 
@@ -31,7 +32,6 @@ extern asn_TYPE_descriptor_t asn_DEF_PDU;
 
 /*** <<< POST-INCLUDE [PDU] >>> ***/
 
-#include "Singleton.h"
 #include "PDU-2.h"
 
 /*** <<< STAT-DEFS [PDU] >>> ***/

--- a/tests/tests-asn1c-compiler/142-anonymous-types-deco-OK.asn1.+-P_-fcompound-names
+++ b/tests/tests-asn1c-compiler/142-anonymous-types-deco-OK.asn1.+-P_-fcompound-names
@@ -1,6 +1,8 @@
 
 /*** <<< INCLUDES [CommonType] >>> ***/
 
+#include "Type1.h"
+#include "Type2.h"
 #include <constr_CHOICE.h>
 
 /*** <<< DEPS [CommonType] >>> ***/
@@ -11,18 +13,13 @@ typedef enum CommonType_PR {
 	CommonType_PR_t2
 } CommonType_PR;
 
-/*** <<< FWD-DECLS [CommonType] >>> ***/
-
-struct Type1;
-struct Type2;
-
 /*** <<< TYPE-DECLS [CommonType] >>> ***/
 
 typedef struct CommonType {
 	CommonType_PR present;
 	union CommonType_u {
-		struct Type1	*t1;
-		struct Type2	*t2;
+		Type1_t	 t1;
+		Type2_t	 t2;
 	} choice;
 	
 	/* Context for parsing across buffer boundaries */
@@ -33,15 +30,10 @@ typedef struct CommonType {
 
 extern asn_TYPE_descriptor_t asn_DEF_CommonType;
 
-/*** <<< POST-INCLUDE [CommonType] >>> ***/
-
-#include "Type1.h"
-#include "Type2.h"
-
 /*** <<< STAT-DEFS [CommonType] >>> ***/
 
 static asn_TYPE_member_t asn_MBR_CommonType_1[] = {
-	{ ATF_POINTER, 0, offsetof(struct CommonType, choice.t1),
+	{ ATF_NOFLAGS, 0, offsetof(struct CommonType, choice.t1),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = +1,	/* EXPLICIT tag at current level */
 		.type = &asn_DEF_Type1,
@@ -61,7 +53,7 @@ static asn_TYPE_member_t asn_MBR_CommonType_1[] = {
 		0, 0, /* No default value */
 		.name = "t1"
 		},
-	{ ATF_POINTER, 0, offsetof(struct CommonType, choice.t2),
+	{ ATF_NOFLAGS, 0, offsetof(struct CommonType, choice.t2),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (1 << 2)),
 		.tag_mode = +1,	/* EXPLICIT tag at current level */
 		.type = &asn_DEF_Type2,

--- a/tests/tests-asn1c-compiler/143-inner-parameterization-OK.asn1.+-P
+++ b/tests/tests-asn1c-compiler/143-inner-parameterization-OK.asn1.+-P
@@ -1,19 +1,14 @@
 
 /*** <<< INCLUDES [Message] >>> ***/
 
+#include "SpecializedContent.h"
 #include <constr_SEQUENCE.h>
-
-/*** <<< FWD-DECLS [Message] >>> ***/
-
-struct SpecializedContent_21P0;
-struct SpecializedContent_21P1;
-struct SpecializedContent;
 
 /*** <<< TYPE-DECLS [Message] >>> ***/
 
 typedef struct Message {
-	struct SpecializedContent	*content13;
-	struct SpecializedContent	*content42;
+	SpecializedContent_21P0_t	 content13;
+	SpecializedContent_21P1_t	 content42;
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;
@@ -23,14 +18,10 @@ typedef struct Message {
 
 extern asn_TYPE_descriptor_t asn_DEF_Message;
 
-/*** <<< POST-INCLUDE [Message] >>> ***/
-
-#include "SpecializedContent.h"
-
 /*** <<< STAT-DEFS [Message] >>> ***/
 
 static asn_TYPE_member_t asn_MBR_Message_1[] = {
-	{ ATF_POINTER, 0, offsetof(struct Message, content13),
+	{ ATF_NOFLAGS, 0, offsetof(struct Message, content13),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
 		.tag_mode = 0,
 		.type = &asn_DEF_SpecializedContent_21P0,
@@ -50,7 +41,7 @@ static asn_TYPE_member_t asn_MBR_Message_1[] = {
 		0, 0, /* No default value */
 		.name = "content13"
 		},
-	{ ATF_POINTER, 0, offsetof(struct Message, content42),
+	{ ATF_NOFLAGS, 0, offsetof(struct Message, content42),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
 		.tag_mode = 0,
 		.type = &asn_DEF_SpecializedContent_21P1,

--- a/tests/tests-asn1c-compiler/144-ios-parameterization-OK.asn1.+-P
+++ b/tests/tests-asn1c-compiler/144-ios-parameterization-OK.asn1.+-P
@@ -1,16 +1,13 @@
 
 /*** <<< INCLUDES [Message] >>> ***/
 
+#include "SpecializedContent.h"
 #include <constr_SEQUENCE.h>
-
-/*** <<< FWD-DECLS [Message] >>> ***/
-
-struct RegionalExtension;
 
 /*** <<< TYPE-DECLS [Message] >>> ***/
 
 typedef struct Message {
-	struct RegionalExtension	*content;
+	RegionalExtension_t	 content;
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;
@@ -20,14 +17,10 @@ typedef struct Message {
 
 extern asn_TYPE_descriptor_t asn_DEF_Message;
 
-/*** <<< POST-INCLUDE [Message] >>> ***/
-
-#include "SpecializedContent.h"
-
 /*** <<< STAT-DEFS [Message] >>> ***/
 
 static asn_TYPE_member_t asn_MBR_Message_1[] = {
-	{ ATF_POINTER, 0, offsetof(struct Message, content),
+	{ ATF_NOFLAGS, 0, offsetof(struct Message, content),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
 		.tag_mode = 0,
 		.type = &asn_DEF_RegionalExtension,

--- a/tests/tests-asn1c-compiler/146-ios-parameterization-per-OK.asn1.+-P_-gen-UPER_-gen-APER
+++ b/tests/tests-asn1c-compiler/146-ios-parameterization-per-OK.asn1.+-P_-gen-UPER_-gen-APER
@@ -1,16 +1,13 @@
 
 /*** <<< INCLUDES [Message] >>> ***/
 
+#include "SpecializedContent.h"
 #include <constr_SEQUENCE.h>
-
-/*** <<< FWD-DECLS [Message] >>> ***/
-
-struct RegionalExtension;
 
 /*** <<< TYPE-DECLS [Message] >>> ***/
 
 typedef struct Message {
-	struct RegionalExtension	*content;
+	RegionalExtension_t	 content;
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;
@@ -20,14 +17,10 @@ typedef struct Message {
 
 extern asn_TYPE_descriptor_t asn_DEF_Message;
 
-/*** <<< POST-INCLUDE [Message] >>> ***/
-
-#include "SpecializedContent.h"
-
 /*** <<< STAT-DEFS [Message] >>> ***/
 
 static asn_TYPE_member_t asn_MBR_Message_1[] = {
-	{ ATF_POINTER, 0, offsetof(struct Message, content),
+	{ ATF_NOFLAGS, 0, offsetof(struct Message, content),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
 		.tag_mode = 0,
 		.type = &asn_DEF_RegionalExtension,

--- a/tests/tests-asn1c-compiler/156-union-ios-OK.asn1.+-P_-gen-UPER_-gen-APER
+++ b/tests/tests-asn1c-compiler/156-union-ios-OK.asn1.+-P_-gen-UPER_-gen-APER
@@ -1,16 +1,13 @@
 
 /*** <<< INCLUDES [Message] >>> ***/
 
+#include "SpecializedContent.h"
 #include <constr_SEQUENCE.h>
-
-/*** <<< FWD-DECLS [Message] >>> ***/
-
-struct TotalRegionExtension;
 
 /*** <<< TYPE-DECLS [Message] >>> ***/
 
 typedef struct Message {
-	struct TotalRegionExtension	*content;
+	TotalRegionExtension_t	 content;
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;
@@ -20,14 +17,10 @@ typedef struct Message {
 
 extern asn_TYPE_descriptor_t asn_DEF_Message;
 
-/*** <<< POST-INCLUDE [Message] >>> ***/
-
-#include "SpecializedContent.h"
-
 /*** <<< STAT-DEFS [Message] >>> ***/
 
 static asn_TYPE_member_t asn_MBR_Message_1[] = {
-	{ ATF_POINTER, 0, offsetof(struct Message, content),
+	{ ATF_NOFLAGS, 0, offsetof(struct Message, content),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
 		.tag_mode = 0,
 		.type = &asn_DEF_TotalRegionExtension,

--- a/tests/tests-asn1c-compiler/160-multiple-parameterized-instance-OK.asn1.+-P_-gen-UPER_-gen-APER_-fcompound-names
+++ b/tests/tests-asn1c-compiler/160-multiple-parameterized-instance-OK.asn1.+-P_-gen-UPER_-gen-APER_-fcompound-names
@@ -1,16 +1,13 @@
 
 /*** <<< INCLUDES [Message1] >>> ***/
 
+#include "SpecializedContent.h"
 #include <constr_SEQUENCE.h>
-
-/*** <<< FWD-DECLS [Message1] >>> ***/
-
-struct TotalRegionExtension;
 
 /*** <<< TYPE-DECLS [Message1] >>> ***/
 
 typedef struct Message1 {
-	struct TotalRegionExtension	*content;
+	TotalRegionExtension_t	 content;
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;
@@ -20,14 +17,10 @@ typedef struct Message1 {
 
 extern asn_TYPE_descriptor_t asn_DEF_Message1;
 
-/*** <<< POST-INCLUDE [Message1] >>> ***/
-
-#include "SpecializedContent.h"
-
 /*** <<< STAT-DEFS [Message1] >>> ***/
 
 static asn_TYPE_member_t asn_MBR_Message1_1[] = {
-	{ ATF_POINTER, 0, offsetof(struct Message1, content),
+	{ ATF_NOFLAGS, 0, offsetof(struct Message1, content),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
 		.tag_mode = 0,
 		.type = &asn_DEF_TotalRegionExtension,
@@ -92,16 +85,13 @@ asn_TYPE_descriptor_t asn_DEF_Message1 = {
 
 /*** <<< INCLUDES [Message2] >>> ***/
 
+#include "SpecializedContent.h"
 #include <constr_SEQUENCE.h>
-
-/*** <<< FWD-DECLS [Message2] >>> ***/
-
-struct RegionalExtension3;
 
 /*** <<< TYPE-DECLS [Message2] >>> ***/
 
 typedef struct Message2 {
-	struct RegionalExtension3	*content;
+	RegionalExtension3_t	 content;
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;
@@ -111,14 +101,10 @@ typedef struct Message2 {
 
 extern asn_TYPE_descriptor_t asn_DEF_Message2;
 
-/*** <<< POST-INCLUDE [Message2] >>> ***/
-
-#include "SpecializedContent.h"
-
 /*** <<< STAT-DEFS [Message2] >>> ***/
 
 static asn_TYPE_member_t asn_MBR_Message2_1[] = {
-	{ ATF_POINTER, 0, offsetof(struct Message2, content),
+	{ ATF_NOFLAGS, 0, offsetof(struct Message2, content),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
 		.tag_mode = 0,
 		.type = &asn_DEF_RegionalExtension3,
@@ -183,16 +169,13 @@ asn_TYPE_descriptor_t asn_DEF_Message2 = {
 
 /*** <<< INCLUDES [Message3] >>> ***/
 
+#include "SpecializedContent.h"
 #include <constr_SEQUENCE.h>
-
-/*** <<< FWD-DECLS [Message3] >>> ***/
-
-struct RegionalExtension4;
 
 /*** <<< TYPE-DECLS [Message3] >>> ***/
 
 typedef struct Message3 {
-	struct RegionalExtension4	*content;
+	RegionalExtension4_t	 content;
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;
@@ -202,14 +185,10 @@ typedef struct Message3 {
 
 extern asn_TYPE_descriptor_t asn_DEF_Message3;
 
-/*** <<< POST-INCLUDE [Message3] >>> ***/
-
-#include "SpecializedContent.h"
-
 /*** <<< STAT-DEFS [Message3] >>> ***/
 
 static asn_TYPE_member_t asn_MBR_Message3_1[] = {
-	{ ATF_POINTER, 0, offsetof(struct Message3, content),
+	{ ATF_NOFLAGS, 0, offsetof(struct Message3, content),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
 		.tag_mode = 0,
 		.type = &asn_DEF_RegionalExtension4,

--- a/tests/tests-asn1c-compiler/169-cross-file-param-specialization-OK.asn1.+-P_-fcompound-names
+++ b/tests/tests-asn1c-compiler/169-cross-file-param-specialization-OK.asn1.+-P_-fcompound-names
@@ -1370,20 +1370,20 @@ asn_TYPE_descriptor_t asn_DEF_SampleList = {
 
 /*** <<< INCLUDES [TestPDU] >>> ***/
 
+#include "SampleContainer.h"
+#include "SampleList.h"
 #include <constr_SEQUENCE.h>
 
 /*** <<< FWD-DECLS [TestPDU] >>> ***/
 
-struct SampleContainer;
 struct AnotherContainer;
-struct SampleList;
 
 /*** <<< TYPE-DECLS [TestPDU] >>> ***/
 
 typedef struct TestPDU {
-	struct SampleContainer	*sampleContainer;
+	SampleContainer_t	 sampleContainer;
 	struct AnotherContainer	*anotherContainer;	/* OPTIONAL */
-	struct SampleList	*sampleList;
+	SampleList_t	 sampleList;
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;
@@ -1395,14 +1395,12 @@ extern asn_TYPE_descriptor_t asn_DEF_TestPDU;
 
 /*** <<< POST-INCLUDE [TestPDU] >>> ***/
 
-#include "SampleContainer.h"
 #include "AnotherContainer.h"
-#include "SampleList.h"
 
 /*** <<< STAT-DEFS [TestPDU] >>> ***/
 
 static asn_TYPE_member_t asn_MBR_TestPDU_1[] = {
-	{ ATF_POINTER, 0, offsetof(struct TestPDU, sampleContainer),
+	{ ATF_NOFLAGS, 0, offsetof(struct TestPDU, sampleContainer),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_SampleContainer,
@@ -1442,7 +1440,7 @@ static asn_TYPE_member_t asn_MBR_TestPDU_1[] = {
 		0, 0, /* No default value */
 		.name = "anotherContainer"
 		},
-	{ ATF_POINTER, 0, offsetof(struct TestPDU, sampleList),
+	{ ATF_NOFLAGS, 0, offsetof(struct TestPDU, sampleList),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (2 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_SampleList,

--- a/tests/tests-asn1c-compiler/170-complex-nesting-OK.asn1.+-P
+++ b/tests/tests-asn1c-compiler/170-complex-nesting-OK.asn1.+-P
@@ -115,22 +115,19 @@ asn_TYPE_descriptor_t asn_DEF_Container = {
 
 /*** <<< INCLUDES [ComplexType] >>> ***/
 
+#include "StructureA.h"
+#include "StructureB.h"
+#include "StructureC.h"
+#include "StructureD.h"
 #include <constr_SEQUENCE.h>
-
-/*** <<< FWD-DECLS [ComplexType] >>> ***/
-
-struct StructureA;
-struct StructureB;
-struct StructureC;
-struct StructureD;
 
 /*** <<< TYPE-DECLS [ComplexType] >>> ***/
 
 typedef struct ComplexType {
-	struct StructureA	*member1;
-	struct StructureB	*member2;
-	struct StructureC	*member3;
-	struct StructureD	*member4;
+	StructureA_t	 member1;
+	StructureB_t	 member2;
+	StructureC_t	 member3;
+	StructureD_t	 member4;
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;
@@ -142,17 +139,10 @@ extern asn_TYPE_descriptor_t asn_DEF_ComplexType;
 extern asn_SEQUENCE_specifics_t asn_SPC_ComplexType_specs_1;
 extern asn_TYPE_member_t asn_MBR_ComplexType_1[4];
 
-/*** <<< POST-INCLUDE [ComplexType] >>> ***/
-
-#include "StructureA.h"
-#include "StructureB.h"
-#include "StructureC.h"
-#include "StructureD.h"
-
 /*** <<< STAT-DEFS [ComplexType] >>> ***/
 
 asn_TYPE_member_t asn_MBR_ComplexType_1[] = {
-	{ ATF_POINTER, 0, offsetof(struct ComplexType, member1),
+	{ ATF_NOFLAGS, 0, offsetof(struct ComplexType, member1),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
 		.tag_mode = 0,
 		.type = &asn_DEF_StructureA,
@@ -172,7 +162,7 @@ asn_TYPE_member_t asn_MBR_ComplexType_1[] = {
 		0, 0, /* No default value */
 		.name = "member1"
 		},
-	{ ATF_POINTER, 0, offsetof(struct ComplexType, member2),
+	{ ATF_NOFLAGS, 0, offsetof(struct ComplexType, member2),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
 		.tag_mode = 0,
 		.type = &asn_DEF_StructureB,
@@ -192,7 +182,7 @@ asn_TYPE_member_t asn_MBR_ComplexType_1[] = {
 		0, 0, /* No default value */
 		.name = "member2"
 		},
-	{ ATF_POINTER, 0, offsetof(struct ComplexType, member3),
+	{ ATF_NOFLAGS, 0, offsetof(struct ComplexType, member3),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
 		.tag_mode = 0,
 		.type = &asn_DEF_StructureC,
@@ -212,7 +202,7 @@ asn_TYPE_member_t asn_MBR_ComplexType_1[] = {
 		0, 0, /* No default value */
 		.name = "member3"
 		},
-	{ ATF_POINTER, 0, offsetof(struct ComplexType, member4),
+	{ ATF_NOFLAGS, 0, offsetof(struct ComplexType, member4),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
 		.tag_mode = 0,
 		.type = &asn_DEF_StructureD,

--- a/tests/tests-asn1c-compiler/37-indirect-choice-OK.asn1.+-P_-fwide-types
+++ b/tests/tests-asn1c-compiler/37-indirect-choice-OK.asn1.+-P_-fwide-types
@@ -3,6 +3,8 @@
 
 #include <INTEGER.h>
 #include <OCTET_STRING.h>
+#include "Choice1.h"
+#include "Choice2.h"
 #include <constr_CHOICE.h>
 
 /*** <<< DEPS [T] >>> ***/
@@ -15,11 +17,6 @@ typedef enum T_PR {
 	T_PR_t_d
 } T_PR;
 
-/*** <<< FWD-DECLS [T] >>> ***/
-
-struct Choice1;
-struct Choice2;
-
 /*** <<< TYPE-DECLS [T] >>> ***/
 
 typedef struct T {
@@ -27,8 +24,8 @@ typedef struct T {
 	union T_u {
 		INTEGER_t	 t_a;
 		OCTET_STRING_t	 t_b;
-		struct Choice1	*t_c;
-		struct Choice2	*t_d;
+		Choice1_t	 t_c;
+		Choice2_t	 t_d;
 	} choice;
 	
 	/* Context for parsing across buffer boundaries */
@@ -38,11 +35,6 @@ typedef struct T {
 /*** <<< FUNC-DECLS [T] >>> ***/
 
 extern asn_TYPE_descriptor_t asn_DEF_T;
-
-/*** <<< POST-INCLUDE [T] >>> ***/
-
-#include "Choice1.h"
-#include "Choice2.h"
 
 /*** <<< STAT-DEFS [T] >>> ***/
 
@@ -87,7 +79,7 @@ static asn_TYPE_member_t asn_MBR_T_1[] = {
 		0, 0, /* No default value */
 		.name = "t-b"
 		},
-	{ ATF_POINTER, 0, offsetof(struct T, choice.t_c),
+	{ ATF_NOFLAGS, 0, offsetof(struct T, choice.t_c),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (1 << 2)),
 		.tag_mode = +1,	/* EXPLICIT tag at current level */
 		.type = &asn_DEF_Choice1,
@@ -107,7 +99,7 @@ static asn_TYPE_member_t asn_MBR_T_1[] = {
 		0, 0, /* No default value */
 		.name = "t-c"
 		},
-	{ ATF_POINTER, 0, offsetof(struct T, choice.t_d),
+	{ ATF_NOFLAGS, 0, offsetof(struct T, choice.t_d),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (3 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_Choice2,
@@ -291,6 +283,7 @@ asn_TYPE_descriptor_t asn_DEF_Choice1 = {
 
 #include <OCTET_STRING.h>
 #include <INTEGER.h>
+#include "Choice1.h"
 #include <constr_CHOICE.h>
 
 /*** <<< DEPS [Choice2] >>> ***/
@@ -303,10 +296,6 @@ typedef enum Choice2_PR {
 	Choice2_PR_c_e
 } Choice2_PR;
 
-/*** <<< FWD-DECLS [Choice2] >>> ***/
-
-struct Choice1;
-
 /*** <<< TYPE-DECLS [Choice2] >>> ***/
 
 typedef struct Choice2 {
@@ -314,8 +303,8 @@ typedef struct Choice2 {
 	union Choice2_u {
 		OCTET_STRING_t	 c_a;
 		INTEGER_t	 c_b;
-		struct Choice1	*c_d;
-		struct Choice1	*c_e;
+		Choice1_t	 c_d;
+		Choice1_t	 c_e;
 	} choice;
 	
 	/* Context for parsing across buffer boundaries */
@@ -327,10 +316,6 @@ typedef struct Choice2 {
 extern asn_TYPE_descriptor_t asn_DEF_Choice2;
 extern asn_CHOICE_specifics_t asn_SPC_Choice2_specs_1;
 extern asn_TYPE_member_t asn_MBR_Choice2_1[4];
-
-/*** <<< POST-INCLUDE [Choice2] >>> ***/
-
-#include "Choice1.h"
 
 /*** <<< STAT-DEFS [Choice2] >>> ***/
 
@@ -375,7 +360,7 @@ asn_TYPE_member_t asn_MBR_Choice2_1[] = {
 		0, 0, /* No default value */
 		.name = "c-b"
 		},
-	{ ATF_POINTER, 0, offsetof(struct Choice2, choice.c_d),
+	{ ATF_NOFLAGS, 0, offsetof(struct Choice2, choice.c_d),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (3 << 2)),
 		.tag_mode = +1,	/* EXPLICIT tag at current level */
 		.type = &asn_DEF_Choice1,
@@ -395,7 +380,7 @@ asn_TYPE_member_t asn_MBR_Choice2_1[] = {
 		0, 0, /* No default value */
 		.name = "c-d"
 		},
-	{ ATF_POINTER, 0, offsetof(struct Choice2, choice.c_e),
+	{ ATF_NOFLAGS, 0, offsetof(struct Choice2, choice.c_e),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (4 << 2)),
 		.tag_mode = +1,	/* EXPLICIT tag at current level */
 		.type = &asn_DEF_Choice1,

--- a/tests/tests-asn1c-compiler/42-real-life-OK.asn1.+-P_-R
+++ b/tests/tests-asn1c-compiler/42-real-life-OK.asn1.+-P_-R
@@ -224,13 +224,13 @@ asn_TYPE_descriptor_t asn_DEF_LogLine = {
 
 /*** <<< INCLUDES [VariablePartSet] >>> ***/
 
+#include "ActionItem.h"
 #include <asn_SEQUENCE_OF.h>
 #include <constr_SEQUENCE_OF.h>
 #include <constr_SEQUENCE.h>
 
 /*** <<< FWD-DECLS [VariablePartSet] >>> ***/
 
-struct ActionItem;
 struct VariablePart;
 
 /*** <<< TYPE-DECLS [VariablePartSet] >>> ***/
@@ -242,7 +242,7 @@ typedef struct VariablePartSet {
 		/* Context for parsing across buffer boundaries */
 		asn_struct_ctx_t _asn_ctx;
 	} vparts;
-	struct ActionItem	*resolution;
+	ActionItem_t	 resolution;
 	/*
 	 * This type is extensible,
 	 * possible extensions are below.
@@ -260,7 +260,6 @@ extern asn_TYPE_member_t asn_MBR_VariablePartSet_1[2];
 
 /*** <<< POST-INCLUDE [VariablePartSet] >>> ***/
 
-#include "ActionItem.h"
 #include "VariablePart.h"
 
 /*** <<< CODE [VariablePartSet] >>> ***/
@@ -377,7 +376,7 @@ asn_TYPE_member_t asn_MBR_VariablePartSet_1[] = {
 		0, 0, /* No default value */
 		.name = "vparts"
 		},
-	{ ATF_POINTER, 0, offsetof(struct VariablePartSet, resolution),
+	{ ATF_NOFLAGS, 0, offsetof(struct VariablePartSet, resolution),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
 		.tag_mode = 0,
 		.type = &asn_DEF_ActionItem,

--- a/tests/tests-asn1c-compiler/70-xer-test-OK.asn1.+-P_-fwide-types
+++ b/tests/tests-asn1c-compiler/70-xer-test-OK.asn1.+-P_-fwide-types
@@ -1,6 +1,21 @@
 
 /*** <<< INCLUDES [PDU] >>> ***/
 
+#include "Sequence.h"
+#include "Set.h"
+#include "SequenceOf.h"
+#include "ExtensibleSet.h"
+#include "ExtensibleSequence.h"
+#include "ExtensibleSequence2.h"
+#include "SetOfNULL.h"
+#include "SetOfREAL.h"
+#include "SetOfEnums.h"
+#include "NamedSetOfNULL.h"
+#include "NamedSetOfREAL.h"
+#include "NamedSetOfEnums.h"
+#include "SeqOfZuka.h"
+#include "SetOfChoice.h"
+#include "NamedSetOfChoice.h"
 #include <constr_CHOICE.h>
 
 /*** <<< DEPS [PDU] >>> ***/
@@ -26,44 +41,26 @@ typedef enum PDU_PR {
 	
 } PDU_PR;
 
-/*** <<< FWD-DECLS [PDU] >>> ***/
-
-struct Sequence;
-struct Set;
-struct SequenceOf;
-struct ExtensibleSet;
-struct ExtensibleSequence;
-struct ExtensibleSequence2;
-struct SetOfNULL;
-struct SetOfREAL;
-struct SetOfEnums;
-struct NamedSetOfNULL;
-struct NamedSetOfREAL;
-struct NamedSetOfEnums;
-struct SeqOfZuka;
-struct SetOfChoice;
-struct NamedSetOfChoice;
-
 /*** <<< TYPE-DECLS [PDU] >>> ***/
 
 typedef struct PDU {
 	PDU_PR present;
 	union PDU_u {
-		struct Sequence	*sequence;
-		struct Set	*set;
-		struct SequenceOf	*sequenceOf;
-		struct ExtensibleSet	*extensibleSet;
-		struct ExtensibleSequence	*extensibleSequence;
-		struct ExtensibleSequence2	*extensibleSequence2;
-		struct SetOfNULL	*setOfNULL;
-		struct SetOfREAL	*setOfREAL;
-		struct SetOfEnums	*setOfEnums;
-		struct NamedSetOfNULL	*namedSetOfNULL;
-		struct NamedSetOfREAL	*namedSetOfREAL;
-		struct NamedSetOfEnums	*namedSetOfEnums;
-		struct SeqOfZuka	*seqOfZuka;
-		struct SetOfChoice	*setOfChoice;
-		struct NamedSetOfChoice	*namedSetOfChoice;
+		Sequence_t	 sequence;
+		Set_t	 set;
+		SequenceOf_t	 sequenceOf;
+		ExtensibleSet_t	 extensibleSet;
+		ExtensibleSequence_t	 extensibleSequence;
+		ExtensibleSequence2_t	 extensibleSequence2;
+		SetOfNULL_t	 setOfNULL;
+		SetOfREAL_t	 setOfREAL;
+		SetOfEnums_t	 setOfEnums;
+		NamedSetOfNULL_t	 namedSetOfNULL;
+		NamedSetOfREAL_t	 namedSetOfREAL;
+		NamedSetOfEnums_t	 namedSetOfEnums;
+		SeqOfZuka_t	 seqOfZuka;
+		SetOfChoice_t	 setOfChoice;
+		NamedSetOfChoice_t	 namedSetOfChoice;
 		/*
 		 * This type is extensible,
 		 * possible extensions are below.
@@ -78,28 +75,10 @@ typedef struct PDU {
 
 extern asn_TYPE_descriptor_t asn_DEF_PDU;
 
-/*** <<< POST-INCLUDE [PDU] >>> ***/
-
-#include "Sequence.h"
-#include "Set.h"
-#include "SequenceOf.h"
-#include "ExtensibleSet.h"
-#include "ExtensibleSequence.h"
-#include "ExtensibleSequence2.h"
-#include "SetOfNULL.h"
-#include "SetOfREAL.h"
-#include "SetOfEnums.h"
-#include "NamedSetOfNULL.h"
-#include "NamedSetOfREAL.h"
-#include "NamedSetOfEnums.h"
-#include "SeqOfZuka.h"
-#include "SetOfChoice.h"
-#include "NamedSetOfChoice.h"
-
 /*** <<< STAT-DEFS [PDU] >>> ***/
 
 static asn_TYPE_member_t asn_MBR_PDU_1[] = {
-	{ ATF_POINTER, 0, offsetof(struct PDU, choice.sequence),
+	{ ATF_NOFLAGS, 0, offsetof(struct PDU, choice.sequence),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_Sequence,
@@ -119,7 +98,7 @@ static asn_TYPE_member_t asn_MBR_PDU_1[] = {
 		0, 0, /* No default value */
 		.name = "sequence"
 		},
-	{ ATF_POINTER, 0, offsetof(struct PDU, choice.set),
+	{ ATF_NOFLAGS, 0, offsetof(struct PDU, choice.set),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (1 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_Set,
@@ -139,7 +118,7 @@ static asn_TYPE_member_t asn_MBR_PDU_1[] = {
 		0, 0, /* No default value */
 		.name = "set"
 		},
-	{ ATF_POINTER, 0, offsetof(struct PDU, choice.sequenceOf),
+	{ ATF_NOFLAGS, 0, offsetof(struct PDU, choice.sequenceOf),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (2 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_SequenceOf,
@@ -159,7 +138,7 @@ static asn_TYPE_member_t asn_MBR_PDU_1[] = {
 		0, 0, /* No default value */
 		.name = "sequenceOf"
 		},
-	{ ATF_POINTER, 0, offsetof(struct PDU, choice.extensibleSet),
+	{ ATF_NOFLAGS, 0, offsetof(struct PDU, choice.extensibleSet),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (3 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_ExtensibleSet,
@@ -179,7 +158,7 @@ static asn_TYPE_member_t asn_MBR_PDU_1[] = {
 		0, 0, /* No default value */
 		.name = "extensibleSet"
 		},
-	{ ATF_POINTER, 0, offsetof(struct PDU, choice.extensibleSequence),
+	{ ATF_NOFLAGS, 0, offsetof(struct PDU, choice.extensibleSequence),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (4 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_ExtensibleSequence,
@@ -199,7 +178,7 @@ static asn_TYPE_member_t asn_MBR_PDU_1[] = {
 		0, 0, /* No default value */
 		.name = "extensibleSequence"
 		},
-	{ ATF_POINTER, 0, offsetof(struct PDU, choice.extensibleSequence2),
+	{ ATF_NOFLAGS, 0, offsetof(struct PDU, choice.extensibleSequence2),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (5 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_ExtensibleSequence2,
@@ -219,7 +198,7 @@ static asn_TYPE_member_t asn_MBR_PDU_1[] = {
 		0, 0, /* No default value */
 		.name = "extensibleSequence2"
 		},
-	{ ATF_POINTER, 0, offsetof(struct PDU, choice.setOfNULL),
+	{ ATF_NOFLAGS, 0, offsetof(struct PDU, choice.setOfNULL),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (6 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_SetOfNULL,
@@ -239,7 +218,7 @@ static asn_TYPE_member_t asn_MBR_PDU_1[] = {
 		0, 0, /* No default value */
 		.name = "setOfNULL"
 		},
-	{ ATF_POINTER, 0, offsetof(struct PDU, choice.setOfREAL),
+	{ ATF_NOFLAGS, 0, offsetof(struct PDU, choice.setOfREAL),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (7 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_SetOfREAL,
@@ -259,7 +238,7 @@ static asn_TYPE_member_t asn_MBR_PDU_1[] = {
 		0, 0, /* No default value */
 		.name = "setOfREAL"
 		},
-	{ ATF_POINTER, 0, offsetof(struct PDU, choice.setOfEnums),
+	{ ATF_NOFLAGS, 0, offsetof(struct PDU, choice.setOfEnums),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (8 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_SetOfEnums,
@@ -279,7 +258,7 @@ static asn_TYPE_member_t asn_MBR_PDU_1[] = {
 		0, 0, /* No default value */
 		.name = "setOfEnums"
 		},
-	{ ATF_POINTER, 0, offsetof(struct PDU, choice.namedSetOfNULL),
+	{ ATF_NOFLAGS, 0, offsetof(struct PDU, choice.namedSetOfNULL),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (9 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_NamedSetOfNULL,
@@ -299,7 +278,7 @@ static asn_TYPE_member_t asn_MBR_PDU_1[] = {
 		0, 0, /* No default value */
 		.name = "namedSetOfNULL"
 		},
-	{ ATF_POINTER, 0, offsetof(struct PDU, choice.namedSetOfREAL),
+	{ ATF_NOFLAGS, 0, offsetof(struct PDU, choice.namedSetOfREAL),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (10 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_NamedSetOfREAL,
@@ -319,7 +298,7 @@ static asn_TYPE_member_t asn_MBR_PDU_1[] = {
 		0, 0, /* No default value */
 		.name = "namedSetOfREAL"
 		},
-	{ ATF_POINTER, 0, offsetof(struct PDU, choice.namedSetOfEnums),
+	{ ATF_NOFLAGS, 0, offsetof(struct PDU, choice.namedSetOfEnums),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (11 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_NamedSetOfEnums,
@@ -339,7 +318,7 @@ static asn_TYPE_member_t asn_MBR_PDU_1[] = {
 		0, 0, /* No default value */
 		.name = "namedSetOfEnums"
 		},
-	{ ATF_POINTER, 0, offsetof(struct PDU, choice.seqOfZuka),
+	{ ATF_NOFLAGS, 0, offsetof(struct PDU, choice.seqOfZuka),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (12 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_SeqOfZuka,
@@ -359,7 +338,7 @@ static asn_TYPE_member_t asn_MBR_PDU_1[] = {
 		0, 0, /* No default value */
 		.name = "seqOfZuka"
 		},
-	{ ATF_POINTER, 0, offsetof(struct PDU, choice.setOfChoice),
+	{ ATF_NOFLAGS, 0, offsetof(struct PDU, choice.setOfChoice),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (13 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_SetOfChoice,
@@ -379,7 +358,7 @@ static asn_TYPE_member_t asn_MBR_PDU_1[] = {
 		0, 0, /* No default value */
 		.name = "setOfChoice"
 		},
-	{ ATF_POINTER, 0, offsetof(struct PDU, choice.namedSetOfChoice),
+	{ ATF_NOFLAGS, 0, offsetof(struct PDU, choice.namedSetOfChoice),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (14 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_NamedSetOfChoice,

--- a/tests/tests-asn1c-compiler/84-param-tags-OK.asn1.+-P_-fwide-types
+++ b/tests/tests-asn1c-compiler/84-param-tags-OK.asn1.+-P_-fwide-types
@@ -234,6 +234,7 @@ asn_TYPE_descriptor_t asn_DEF_TestType_16P1 = {
 
 /*** <<< INCLUDES [TestChoice] >>> ***/
 
+#include "TestType.h"
 #include <constr_CHOICE.h>
 
 /*** <<< DEPS [TestChoice] >>> ***/
@@ -244,19 +245,13 @@ typedef enum TestChoice_PR {
 	TestChoice_PR_type2
 } TestChoice_PR;
 
-/*** <<< FWD-DECLS [TestChoice] >>> ***/
-
-struct TestType_16P0;
-struct TestType_16P1;
-struct TestType;
-
 /*** <<< TYPE-DECLS [TestChoice] >>> ***/
 
 typedef struct TestChoice {
 	TestChoice_PR present;
 	union TestChoice_u {
-		struct TestType	*type1;
-		struct TestType	*type2;
+		TestType_16P0_t	 type1;
+		TestType_16P1_t	 type2;
 	} choice;
 	
 	/* Context for parsing across buffer boundaries */
@@ -267,14 +262,10 @@ typedef struct TestChoice {
 
 extern asn_TYPE_descriptor_t asn_DEF_TestChoice;
 
-/*** <<< POST-INCLUDE [TestChoice] >>> ***/
-
-#include "TestType.h"
-
 /*** <<< STAT-DEFS [TestChoice] >>> ***/
 
 static asn_TYPE_member_t asn_MBR_TestChoice_1[] = {
-	{ ATF_POINTER, 0, offsetof(struct TestChoice, choice.type1),
+	{ ATF_NOFLAGS, 0, offsetof(struct TestChoice, choice.type1),
 		.tag = (ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
 		.tag_mode = 0,
 		.type = &asn_DEF_TestType_16P0,
@@ -294,7 +285,7 @@ static asn_TYPE_member_t asn_MBR_TestChoice_1[] = {
 		0, 0, /* No default value */
 		.name = "type1"
 		},
-	{ ATF_POINTER, 0, offsetof(struct TestChoice, choice.type2),
+	{ ATF_NOFLAGS, 0, offsetof(struct TestChoice, choice.type2),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_TestType_16P1,
@@ -569,6 +560,7 @@ asn_TYPE_descriptor_t asn_DEF_AutoType_34P1 = {
 
 /*** <<< INCLUDES [AutoChoice] >>> ***/
 
+#include "AutoType.h"
 #include <constr_CHOICE.h>
 
 /*** <<< DEPS [AutoChoice] >>> ***/
@@ -579,19 +571,13 @@ typedef enum AutoChoice_PR {
 	AutoChoice_PR_type2
 } AutoChoice_PR;
 
-/*** <<< FWD-DECLS [AutoChoice] >>> ***/
-
-struct AutoType_34P0;
-struct AutoType_34P1;
-struct AutoType;
-
 /*** <<< TYPE-DECLS [AutoChoice] >>> ***/
 
 typedef struct AutoChoice {
 	AutoChoice_PR present;
 	union AutoChoice_u {
-		struct AutoType	*type1;
-		struct AutoType	*type2;
+		AutoType_34P0_t	 type1;
+		AutoType_34P1_t	 type2;
 	} choice;
 	
 	/* Context for parsing across buffer boundaries */
@@ -602,14 +588,10 @@ typedef struct AutoChoice {
 
 extern asn_TYPE_descriptor_t asn_DEF_AutoChoice;
 
-/*** <<< POST-INCLUDE [AutoChoice] >>> ***/
-
-#include "AutoType.h"
-
 /*** <<< STAT-DEFS [AutoChoice] >>> ***/
 
 static asn_TYPE_member_t asn_MBR_AutoChoice_1[] = {
-	{ ATF_POINTER, 0, offsetof(struct AutoChoice, choice.type1),
+	{ ATF_NOFLAGS, 0, offsetof(struct AutoChoice, choice.type1),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_AutoType_34P0,
@@ -629,7 +611,7 @@ static asn_TYPE_member_t asn_MBR_AutoChoice_1[] = {
 		0, 0, /* No default value */
 		.name = "type1"
 		},
-	{ ATF_POINTER, 0, offsetof(struct AutoChoice, choice.type2),
+	{ ATF_NOFLAGS, 0, offsetof(struct AutoChoice, choice.type2),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (1 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_AutoType_34P1,

--- a/tests/tests-asn1c-compiler/92-circular-loops-OK.asn1.+-P_-findirect-choice
+++ b/tests/tests-asn1c-compiler/92-circular-loops-OK.asn1.+-P_-findirect-choice
@@ -1,6 +1,13 @@
 
 /*** <<< INCLUDES [Everything] >>> ***/
 
+#include "Set.h"
+#include "Alpha.h"
+#include "Beta.h"
+#include "Gamma.h"
+#include "OneTwo.h"
+#include "TwoThree.h"
+#include "ThreeOne.h"
 #include <constr_SEQUENCE.h>
 
 /*** <<< FWD-DECLS [Everything] >>> ***/
@@ -8,13 +15,6 @@
 struct Choice1;
 struct Choice2;
 struct Choice3;
-struct Set;
-struct Alpha;
-struct Beta;
-struct Gamma;
-struct OneTwo;
-struct TwoThree;
-struct ThreeOne;
 
 /*** <<< TYPE-DECLS [Everything] >>> ***/
 
@@ -22,13 +22,13 @@ typedef struct Everything {
 	struct Choice1	*ch1;
 	struct Choice2	*ch2;
 	struct Choice3	*ch3;
-	struct Set	*set;
-	struct Alpha	*a;
-	struct Beta	*b;
-	struct Gamma	*g;
-	struct OneTwo	*ot;
-	struct TwoThree	*tt;
-	struct ThreeOne	*to;
+	Set_t	 set;
+	Alpha_t	 a;
+	Beta_t	 b;
+	Gamma_t	 g;
+	OneTwo_t	 ot;
+	TwoThree_t	 tt;
+	ThreeOne_t	 to;
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;
@@ -45,13 +45,6 @@ extern asn_TYPE_member_t asn_MBR_Everything_1[10];
 #include "Choice1.h"
 #include "Choice2.h"
 #include "Choice3.h"
-#include "Set.h"
-#include "Alpha.h"
-#include "Beta.h"
-#include "Gamma.h"
-#include "OneTwo.h"
-#include "TwoThree.h"
-#include "ThreeOne.h"
 
 /*** <<< STAT-DEFS [Everything] >>> ***/
 
@@ -116,7 +109,7 @@ asn_TYPE_member_t asn_MBR_Everything_1[] = {
 		0, 0, /* No default value */
 		.name = "ch3"
 		},
-	{ ATF_POINTER, 0, offsetof(struct Everything, set),
+	{ ATF_NOFLAGS, 0, offsetof(struct Everything, set),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (3 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_Set,
@@ -136,7 +129,7 @@ asn_TYPE_member_t asn_MBR_Everything_1[] = {
 		0, 0, /* No default value */
 		.name = "set"
 		},
-	{ ATF_POINTER, 0, offsetof(struct Everything, a),
+	{ ATF_NOFLAGS, 0, offsetof(struct Everything, a),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (4 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_Alpha,
@@ -156,7 +149,7 @@ asn_TYPE_member_t asn_MBR_Everything_1[] = {
 		0, 0, /* No default value */
 		.name = "a"
 		},
-	{ ATF_POINTER, 0, offsetof(struct Everything, b),
+	{ ATF_NOFLAGS, 0, offsetof(struct Everything, b),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (5 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_Beta,
@@ -176,7 +169,7 @@ asn_TYPE_member_t asn_MBR_Everything_1[] = {
 		0, 0, /* No default value */
 		.name = "b"
 		},
-	{ ATF_POINTER, 0, offsetof(struct Everything, g),
+	{ ATF_NOFLAGS, 0, offsetof(struct Everything, g),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (6 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_Gamma,
@@ -196,7 +189,7 @@ asn_TYPE_member_t asn_MBR_Everything_1[] = {
 		0, 0, /* No default value */
 		.name = "g"
 		},
-	{ ATF_POINTER, 0, offsetof(struct Everything, ot),
+	{ ATF_NOFLAGS, 0, offsetof(struct Everything, ot),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (7 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_OneTwo,
@@ -216,7 +209,7 @@ asn_TYPE_member_t asn_MBR_Everything_1[] = {
 		0, 0, /* No default value */
 		.name = "ot"
 		},
-	{ ATF_POINTER, 0, offsetof(struct Everything, tt),
+	{ ATF_NOFLAGS, 0, offsetof(struct Everything, tt),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (8 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_TwoThree,
@@ -236,7 +229,7 @@ asn_TYPE_member_t asn_MBR_Everything_1[] = {
 		0, 0, /* No default value */
 		.name = "tt"
 		},
-	{ ATF_POINTER, 0, offsetof(struct Everything, to),
+	{ ATF_NOFLAGS, 0, offsetof(struct Everything, to),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (9 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_ThreeOne,

--- a/tests/tests-asn1c-compiler/92-circular-loops-OK.asn1.+-P_-fwide-types
+++ b/tests/tests-asn1c-compiler/92-circular-loops-OK.asn1.+-P_-fwide-types
@@ -1,6 +1,13 @@
 
 /*** <<< INCLUDES [Everything] >>> ***/
 
+#include "Set.h"
+#include "Alpha.h"
+#include "Beta.h"
+#include "Gamma.h"
+#include "OneTwo.h"
+#include "TwoThree.h"
+#include "ThreeOne.h"
 #include <constr_SEQUENCE.h>
 
 /*** <<< FWD-DECLS [Everything] >>> ***/
@@ -8,13 +15,6 @@
 struct Choice1;
 struct Choice2;
 struct Choice3;
-struct Set;
-struct Alpha;
-struct Beta;
-struct Gamma;
-struct OneTwo;
-struct TwoThree;
-struct ThreeOne;
 
 /*** <<< TYPE-DECLS [Everything] >>> ***/
 
@@ -22,13 +22,13 @@ typedef struct Everything {
 	struct Choice1	*ch1;
 	struct Choice2	*ch2;
 	struct Choice3	*ch3;
-	struct Set	*set;
-	struct Alpha	*a;
-	struct Beta	*b;
-	struct Gamma	*g;
-	struct OneTwo	*ot;
-	struct TwoThree	*tt;
-	struct ThreeOne	*to;
+	Set_t	 set;
+	Alpha_t	 a;
+	Beta_t	 b;
+	Gamma_t	 g;
+	OneTwo_t	 ot;
+	TwoThree_t	 tt;
+	ThreeOne_t	 to;
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;
@@ -45,13 +45,6 @@ extern asn_TYPE_member_t asn_MBR_Everything_1[10];
 #include "Choice1.h"
 #include "Choice2.h"
 #include "Choice3.h"
-#include "Set.h"
-#include "Alpha.h"
-#include "Beta.h"
-#include "Gamma.h"
-#include "OneTwo.h"
-#include "TwoThree.h"
-#include "ThreeOne.h"
 
 /*** <<< STAT-DEFS [Everything] >>> ***/
 
@@ -116,7 +109,7 @@ asn_TYPE_member_t asn_MBR_Everything_1[] = {
 		0, 0, /* No default value */
 		.name = "ch3"
 		},
-	{ ATF_POINTER, 0, offsetof(struct Everything, set),
+	{ ATF_NOFLAGS, 0, offsetof(struct Everything, set),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (3 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_Set,
@@ -136,7 +129,7 @@ asn_TYPE_member_t asn_MBR_Everything_1[] = {
 		0, 0, /* No default value */
 		.name = "set"
 		},
-	{ ATF_POINTER, 0, offsetof(struct Everything, a),
+	{ ATF_NOFLAGS, 0, offsetof(struct Everything, a),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (4 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_Alpha,
@@ -156,7 +149,7 @@ asn_TYPE_member_t asn_MBR_Everything_1[] = {
 		0, 0, /* No default value */
 		.name = "a"
 		},
-	{ ATF_POINTER, 0, offsetof(struct Everything, b),
+	{ ATF_NOFLAGS, 0, offsetof(struct Everything, b),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (5 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_Beta,
@@ -176,7 +169,7 @@ asn_TYPE_member_t asn_MBR_Everything_1[] = {
 		0, 0, /* No default value */
 		.name = "b"
 		},
-	{ ATF_POINTER, 0, offsetof(struct Everything, g),
+	{ ATF_NOFLAGS, 0, offsetof(struct Everything, g),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (6 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_Gamma,
@@ -196,7 +189,7 @@ asn_TYPE_member_t asn_MBR_Everything_1[] = {
 		0, 0, /* No default value */
 		.name = "g"
 		},
-	{ ATF_POINTER, 0, offsetof(struct Everything, ot),
+	{ ATF_NOFLAGS, 0, offsetof(struct Everything, ot),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (7 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_OneTwo,
@@ -216,7 +209,7 @@ asn_TYPE_member_t asn_MBR_Everything_1[] = {
 		0, 0, /* No default value */
 		.name = "ot"
 		},
-	{ ATF_POINTER, 0, offsetof(struct Everything, tt),
+	{ ATF_NOFLAGS, 0, offsetof(struct Everything, tt),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (8 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_TwoThree,
@@ -236,7 +229,7 @@ asn_TYPE_member_t asn_MBR_Everything_1[] = {
 		0, 0, /* No default value */
 		.name = "tt"
 		},
-	{ ATF_POINTER, 0, offsetof(struct Everything, to),
+	{ ATF_NOFLAGS, 0, offsetof(struct Everything, to),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (9 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_ThreeOne,
@@ -438,6 +431,7 @@ asn_TYPE_descriptor_t asn_DEF_Choice1 = {
 
 /*** <<< INCLUDES [Choice2] >>> ***/
 
+#include "TypeRef.h"
 #include <constr_CHOICE.h>
 
 /*** <<< DEPS [Choice2] >>> ***/
@@ -451,7 +445,6 @@ typedef enum Choice2_PR {
 
 /*** <<< FWD-DECLS [Choice2] >>> ***/
 
-struct TypeRef;
 struct Everything;
 
 /*** <<< TYPE-DECLS [Choice2] >>> ***/
@@ -459,7 +452,7 @@ struct Everything;
 typedef struct Choice2 {
 	Choice2_PR present;
 	union Choice2_u {
-		struct TypeRef	*typeref;
+		TypeRef_t	 typeref;
 		/*
 		 * This type is extensible,
 		 * possible extensions are below.
@@ -479,13 +472,12 @@ extern asn_TYPE_member_t asn_MBR_Choice2_1[2];
 
 /*** <<< POST-INCLUDE [Choice2] >>> ***/
 
-#include "TypeRef.h"
 #include "Everything.h"
 
 /*** <<< STAT-DEFS [Choice2] >>> ***/
 
 asn_TYPE_member_t asn_MBR_Choice2_1[] = {
-	{ ATF_POINTER, 0, offsetof(struct Choice2, choice.typeref),
+	{ ATF_NOFLAGS, 0, offsetof(struct Choice2, choice.typeref),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_TypeRef,

--- a/tests/tests-asn1c-compiler/93-asn1c-controls-OK.asn1.+-P_-fwide-types
+++ b/tests/tests-asn1c-compiler/93-asn1c-controls-OK.asn1.+-P_-fwide-types
@@ -109,6 +109,7 @@ asn_TYPE_descriptor_t asn_DEF_Sequence = {
 
 /*** <<< INCLUDES [Set] >>> ***/
 
+#include "Sequence.h"
 #include <constr_SET.h>
 
 /*** <<< DEPS [Set] >>> ***/
@@ -129,7 +130,7 @@ struct Sequence;
 /*** <<< TYPE-DECLS [Set] >>> ***/
 
 typedef struct Set {
-	struct Sequence	*ainl;
+	Sequence_t	 ainl;
 	struct Sequence	*aptr;
 	
 	/* Presence bitmask: ASN_SET_ISPRESENT(pSet, Set_PR_x) */
@@ -151,7 +152,7 @@ extern asn_TYPE_descriptor_t asn_DEF_Set;
 /*** <<< STAT-DEFS [Set] >>> ***/
 
 static asn_TYPE_member_t asn_MBR_Set_1[] = {
-	{ ATF_POINTER, 0, offsetof(struct Set, ainl),
+	{ ATF_NOFLAGS, 0, offsetof(struct Set, ainl),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_Sequence,
@@ -244,6 +245,7 @@ asn_TYPE_descriptor_t asn_DEF_Set = {
 
 /*** <<< INCLUDES [Choice] >>> ***/
 
+#include "Sequence.h"
 #include <INTEGER.h>
 #include <asn_SET_OF.h>
 #include <constr_SET_OF.h>
@@ -274,7 +276,7 @@ typedef struct Choice {
 			asn_struct_ctx_t _asn_ctx;
 		} *setof;
 		struct Sequence	*aptr;
-		struct Sequence	*ainl;
+		Sequence_t	 ainl;
 	} choice;
 	
 	/* Context for parsing across buffer boundaries */
@@ -405,7 +407,7 @@ static asn_TYPE_member_t asn_MBR_Choice_1[] = {
 		0, 0, /* No default value */
 		.name = "aptr"
 		},
-	{ ATF_POINTER, 0, offsetof(struct Choice, choice.ainl),
+	{ ATF_NOFLAGS, 0, offsetof(struct Choice, choice.ainl),
 		.tag = (ASN_TAG_CLASS_CONTEXT | (2 << 2)),
 		.tag_mode = -1,	/* IMPLICIT tag at current level */
 		.type = &asn_DEF_Sequence,

--- a/tests/tests-c-compiler/check-src/check-42.c
+++ b/tests/tests-c-compiler/check-src/check-42.c
@@ -110,13 +110,12 @@ check_serialize() {
 
 	memset(&ll, 0, sizeof(ll));
 	vps = calloc(1, sizeof(*vps));
-	vps->resolution = calloc(1, sizeof(*vps->resolution));
 	vp = calloc(1, sizeof(*vp));
 	vpart = OCTET_STRING_new_fromBuf(&asn_DEF_VisibleString, "123", 3);
 
 	vp->present = VariablePart_PR_vset;
 	ASN_SET_ADD(&vp->choice.vset, vpart);
-	vps->resolution->accept_as = accept_as_unknown;
+	vps->resolution.accept_as = accept_as_unknown;
 	ASN_SEQUENCE_ADD(&vps->vparts, vp);
 	ASN_SEQUENCE_ADD(&ll.varsets, vps);
 	OCTET_STRING_fromBuf(&ll.line_digest, "zzz\007", 4);


### PR DESCRIPTION
With this PR, only real circles of types referencing each other are broken up. Beforehand, pretty much every non-trivial type has been represented as a pointer (indirection).

Please note that I am still not sure if this solves every corner case in my code base because the current vlm_master is broken for some specifications (see #407). I consider this PR as an improvement with respect to #398, though.