### PR TITLE
Fix memory leak in parser

### DIFF
--- a/libasn1parser/asn1p_y.y
+++ b/libasn1parser/asn1p_y.y
@@ -2205,7 +2205,9 @@ PartialSpecification:
         asn1p_constraint_insert($$, ct);
         for(unsigned i = 0; i < $4->el_count; i++) {
             asn1p_constraint_insert($$, $4->elements[i]);
+            $4->elements[i] = NULL;
         }
+        asn1p_constraint_free($4);
     };
 TypeConstraints:
     NamedConstraint {


### PR DESCRIPTION
`$4` is no longer used and is being leaked directly, coming from https://github.com/mouse07410/asn1c/blob/1e306808c0f05de451ea2f8c8651508b0780efcc/libasn1parser/asn1p_y.y#L2212