### PR TITLE
Fix -fprefix not applied to asn_MBR_ symbols

### DIFF
--- a/libasn1compiler/asn1c_naming.c
+++ b/libasn1compiler/asn1c_naming.c
@@ -147,6 +147,7 @@ c_name_impl(arg_t *arg, asn1p_expr_t *expr, int avoid_keywords) {
     static abuf b_presence_name;
     static abuf b_members_enum;
     static abuf b_members_name;
+    static abuf b_compound_name;
 
     abuf_clear(&b_type_asn_name);
     abuf_clear(&b_type_part_name);
@@ -163,6 +164,7 @@ c_name_impl(arg_t *arg, asn1p_expr_t *expr, int avoid_keywords) {
     abuf_clear(&b_presence_name);
     abuf_clear(&b_members_enum);
     abuf_clear(&b_members_name);
+    abuf_clear(&b_compound_name);
 
     abuf_str(&b_type_asn_name, asn1c_type_name(arg, expr, TNF_UNMODIFIED));
     abuf_str(&b_type_part_name, asn1c_type_name(arg, expr, TNF_SAFE));
@@ -231,6 +233,7 @@ c_name_impl(arg_t *arg, asn1p_expr_t *expr, int avoid_keywords) {
         abuf_printf(&b_presence_name, "%s_PR", tmp_compoundable_part_name.buffer);
         abuf_printf(&b_members_enum, "enum %s", b_base_name.buffer);
         abuf_printf(&b_members_name, "e_%s", tmp_compoundable_part_name.buffer);
+        abuf_printf(&b_compound_name, "%s", compound_part_name.buffer);
    } else {
         if(!expr->_anonymous_type) {
             if(arg->embed) {
@@ -244,6 +247,7 @@ c_name_impl(arg_t *arg, asn1p_expr_t *expr, int avoid_keywords) {
         abuf_printf(&b_presence_name, "%s%s_PR", asn1c_prefix_get(), tmp_compoundable_part_name.buffer);
         abuf_printf(&b_members_enum, "enum %s%s", asn1c_prefix_get(), b_base_name.buffer);
         abuf_printf(&b_members_name, "e_%s%s", asn1c_prefix_get(), tmp_compoundable_part_name.buffer);
+        abuf_printf(&b_compound_name, "%s%s", asn1c_prefix_get(), compound_part_name.buffer);
     }
 
     names.type.asn_name = b_type_asn_name.buffer;
@@ -261,7 +265,7 @@ c_name_impl(arg_t *arg, asn1p_expr_t *expr, int avoid_keywords) {
     names.presence_name = b_presence_name.buffer;
     names.members_enum = b_members_enum.buffer;
     names.members_name = b_members_name.buffer;
-    names.compound_name = compound_part_name.buffer;
+    names.compound_name = b_compound_name.buffer;
 
     /* A _subset_ of names is checked against being globally unique */
     register_global_name(expr, names.base_name);

--- a/tests/tests-asn1c-smoke/Makefile.am
+++ b/tests/tests-asn1c-smoke/Makefile.am
@@ -1,6 +1,7 @@
 TESTS_ENVIRONMENT= MAKE=${MAKE}                     \
                     top_builddir=${top_builddir}    \
-                    top_srcdir=${top_srcdir}
+                    top_srcdir=${top_srcdir}        \
+                    CC="${CC}"
 
 TESTS =
 TESTS += check-INTEGER.sh
@@ -27,7 +28,7 @@ TESTS += check-fprefix-link.sh
 
 CLEANFILES = Makefile.am.* *.[acho] check-*.log check-*.trs
 
-EXTRA_DIST = README $(srcdir)/check-*.sh
+EXTRA_DIST = README $(srcdir)/check-*.sh $(srcdir)/data/fprefix-link.asn
 
 clean-local:
 	rm -rf test-*

--- a/tests/tests-asn1c-smoke/Makefile.am
+++ b/tests/tests-asn1c-smoke/Makefile.am
@@ -23,6 +23,7 @@ TESTS += check-SEQUENCE_OF_INTEGER.sh
 TESTS += check-Time.sh
 TESTS += check-JER-open-type.sh
 TESTS += check-JER-enumerated-opentype.sh
+TESTS += check-fprefix-link.sh
 
 CLEANFILES = Makefile.am.* *.[acho] check-*.log check-*.trs
 

--- a/tests/tests-asn1c-smoke/check-fprefix-link.sh
+++ b/tests/tests-asn1c-smoke/check-fprefix-link.sh
@@ -21,7 +21,8 @@ cp "${srcdir}/data/fprefix-link.asn" test.asn
 
 for prefix in A_ B_; do
     mkdir "$prefix"
-    ../"${top_builddir}"/asn1c/asn1c test.asn -fprefix="$prefix" -D "$prefix"
+    ../"${top_builddir}"/asn1c/asn1c -S ../"${top_srcdir}"/skeletons -flink-skeletons \
+        test.asn -fprefix="$prefix" -D "$prefix"
 
     grep -F "asn_MBR_${prefix}Cause_" "${prefix}/${prefix}Cause.c"
     grep -F "asn_MBR_Cause_" "${prefix}/${prefix}Cause.c" && exit 1

--- a/tests/tests-asn1c-smoke/check-fprefix-link.sh
+++ b/tests/tests-asn1c-smoke/check-fprefix-link.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -ex
+set -o pipefail
+
+top_builddir=${top_builddir:-../..}
+top_srcdir=${top_srcdir:-../..}
+basepath=$(dirname "$0")
+cd "$basepath"
+
+testdir=test-fprefix-link
+cleanup() {
+    rm -rf "$testdir"
+}
+trap cleanup EXIT
+
+rm -rf "$testdir"
+mkdir "$testdir"
+cd "$testdir"
+
+cp ../data/fprefix-link.asn test.asn
+
+for prefix in A_ B_; do
+    mkdir "$prefix"
+    ../"${top_builddir}"/asn1c/asn1c test.asn -fprefix="$prefix" -D "$prefix"
+
+    grep -F "asn_MBR_${prefix}Cause_" "${prefix}/${prefix}Cause.c"
+    grep -F "asn_MBR_Cause_" "${prefix}/${prefix}Cause.c" && exit 1
+
+    "${CC:-cc}" -c -I"${prefix}" -I../"${top_srcdir}"/skeletons \
+        "${prefix}/${prefix}Cause.c" -o "${prefix}.o"
+done
+
+ld -r \
+    A_.o B_.o \
+    -o combined.o
+
+test -f combined.o

--- a/tests/tests-asn1c-smoke/check-fprefix-link.sh
+++ b/tests/tests-asn1c-smoke/check-fprefix-link.sh
@@ -31,8 +31,6 @@ for prefix in A_ B_; do
         "${prefix}/${prefix}Cause.c" -o "${prefix}.o"
 done
 
-ld -r \
-    A_.o B_.o \
-    -o combined.o
+"${CC:-cc}" -r A_.o B_.o -o combined.o
 
 test -f combined.o

--- a/tests/tests-asn1c-smoke/check-fprefix-link.sh
+++ b/tests/tests-asn1c-smoke/check-fprefix-link.sh
@@ -5,8 +5,7 @@ set -o pipefail
 
 top_builddir=${top_builddir:-../..}
 top_srcdir=${top_srcdir:-../..}
-basepath=$(dirname "$0")
-cd "$basepath"
+srcdir=$(cd "$(dirname "$0")" && pwd)
 
 testdir=test-fprefix-link
 cleanup() {
@@ -18,7 +17,7 @@ rm -rf "$testdir"
 mkdir "$testdir"
 cd "$testdir"
 
-cp ../data/fprefix-link.asn test.asn
+cp "${srcdir}/data/fprefix-link.asn" test.asn
 
 for prefix in A_ B_; do
     mkdir "$prefix"

--- a/tests/tests-asn1c-smoke/data/fprefix-link.asn
+++ b/tests/tests-asn1c-smoke/data/fprefix-link.asn
@@ -1,0 +1,12 @@
+Module DEFINITIONS AUTOMATIC TAGS ::= BEGIN
+
+Cause ::= CHOICE {
+    radioNetwork INTEGER,
+    transport INTEGER
+}
+
+ResetRequest ::= SEQUENCE {
+    cause Cause
+}
+
+END


### PR DESCRIPTION
This PR fixes issue https://github.com/mouse07410/asn1c/issues/476 (which has initial analysis and reproduction scenario).

Introduced additional smoke test, which can be run with:
```bash
pushd tests/tests-asn1c-smoke && make check TESTS=check-fprefix-link.sh; popd
```

#### Regression

The regression was introduced by commit [b207dd79](https://github.com/mouse07410/asn1c/commit/b207dd79) - "Fix duplicate member name collision in code generation"

This commit switched all `asn_MBR_` sites in `asn1c_C.c` from `c_name(arg).part_name` to `c_name(arg).compound_name`. The switch was correct in intent - compound_name includes the parent chain to disambiguate nested types with identical member names.

But `compound_name` was never built with the prefix, unlike `part_name`.