### PR TITLE
Fix X.691 clause 13.2.6 constrained-length APER INTEGER for range > 65536

### DIFF
--- a/skeletons/INTEGER_aper.c
+++ b/skeletons/INTEGER_aper.c
@@ -6,6 +6,20 @@
 #include <asn_internal.h>
 #include <INTEGER.h>
 
+/* Return ceil(log2(v)) for positive v. */
+static unsigned
+aper_log2_ceil_size(size_t v) {
+    unsigned bits = 0;
+    size_t power = 1;
+
+    while(power < v) {
+        power <<= 1;
+        bits++;
+    }
+
+    return bits;
+}
+
 asn_dec_rval_t
 INTEGER_decode_aper(const asn_codec_ctx_t *opt_codec_ctx,
                     const asn_TYPE_descriptor_t *td,
@@ -77,37 +91,30 @@ INTEGER_decode_aper(const asn_codec_ctx_t *opt_codec_ctx,
         ASN_DEBUG("Integer with range %d bits", ct->range_bits);
         if(ct->range_bits >= 0) {
             if (ct->range_bits > 16) {
-                /* X.691 clause 11.5.7(d) - Range > 65536 uses length determinant */
-                ssize_t len;
+                /* X.691 13.2.6: constrained whole number with range > 65536. */
+                size_t max_range_bytes = ((size_t)ct->range_bits + 7) >> 3;
+                /* Length determinant is (len - 1) in ceil(log2(max_bytes)) bits. */
+                unsigned length_bits = aper_log2_ceil_size(max_range_bytes);
+                int len_minus_one;
+                size_t len;
                 intmax_t value = 0;
-                
-                ASN_DEBUG("Decoding constrained integer with range_bits=%d (>16)", ct->range_bits);
-                
-                /* Get the length using proper APER length determinant */
-                len = aper_get_length(pd, -1, -1, -1, &repeat);
-                if (len < 0) ASN__DECODE_STARVED;
-                if (repeat) {
-                    /* Fragmented encoding not expected for constrained integers */
-                    ASN_DEBUG("Unexpected fragmented encoding for constrained integer");
-                    ASN__DECODE_FAILED;
-                }
-                
-                ASN_DEBUG("Got length %zd bytes", len);
-                
-                /* Read the value bytes (big-endian) */
-                while (len > 0) {
+
+                len_minus_one = per_get_few_bits(pd, length_bits);
+                if(len_minus_one < 0) ASN__DECODE_STARVED;
+                len = (size_t)len_minus_one + 1;
+                if(len > max_range_bytes || len > sizeof(value)) ASN__DECODE_FAILED;
+                ASN_DEBUG("Constrained INTEGER>16 decode: range_bits=%d max_bytes=%" ASN_PRI_SIZE " len_bits=%u len=%" ASN_PRI_SIZE,
+                          ct->range_bits, max_range_bytes, length_bits, len);
+
+                if(aper_get_align(pd) < 0) ASN__DECODE_FAILED;
+
+                while(len-- > 0) {
                     int buf = per_get_few_bits(pd, 8);
-                    if (buf < 0)
-                        ASN__DECODE_STARVED;
+                    if(buf < 0) ASN__DECODE_STARVED;
+                    if(value > (INTMAX_MAX >> 8)) ASN__DECODE_FAILED;
                     value = (value << 8) | buf;
-                    len--;
                 }
 
-                /*
-                 * Before adding the lower bound, ensure that the decoded
-                 * offset is within a range that cannot overflow when
-                 * shifted by ct->lower_bound.
-                 */
                 if(ct->upper_bound < ct->lower_bound) {
                     ASN__DECODE_FAILED;
                 }
@@ -320,40 +327,40 @@ INTEGER_encode_aper(const asn_TYPE_descriptor_t *td,
             if(per_put_few_bits(po, 0x0000 | v, 16))
                 ASN__ENCODE_FAILED;
         } else {
-            /* X.691 clause 11.5.7(d) - Range > 65536 requires length determinant */
-            /* TODO: extend to >64 bits */
-            uint8_t buf[sizeof(uint64_t)];
-            uint64_t v64 = (uint64_t)v;
-            int need_eom = 0;
+            /* X.691 13.2.6: constrained whole number with range > 65536. */
+            size_t max_range_bytes = ((size_t)ct->range_bits + 7) >> 3;
+            /* Determinant width for (num_bytes - 1). */
+            unsigned length_bits = aper_log2_ceil_size(max_range_bytes);
             size_t num_bytes = 0;
-            int i;
-            
-            /* Calculate minimum number of bytes needed to represent v64 */
-            if (v64 == 0) {
-                num_bytes = 1;
-                buf[0] = 0;
-            } else {
-                /* Find the highest non-zero byte */
-                for (i = sizeof(uint64_t) - 1; i >= 0; i--) {
-                    uint8_t byte_val = (v64 >> (i * 8)) & 0xFF;
-                    if (byte_val != 0 || num_bytes > 0) {
-                        buf[num_bytes++] = byte_val;
-                    }
+            uint8_t buf[sizeof(v)];
+            uintmax_t tmp = v;
+
+            do {
+                num_bytes++;
+                tmp >>= 8;
+            } while(tmp);
+
+            if(num_bytes > max_range_bytes || num_bytes > sizeof(buf))
+                ASN__ENCODE_FAILED;
+            ASN_DEBUG("Constrained INTEGER>16 encode: range_bits=%d max_bytes=%" ASN_PRI_SIZE " len_bits=%u len=%" ASN_PRI_SIZE " offset=%" ASN_PRIuMAX,
+                      ct->range_bits, max_range_bytes, length_bits, num_bytes, v);
+
+            if(per_put_few_bits(po, num_bytes - 1, length_bits))
+                ASN__ENCODE_FAILED;
+
+            if(aper_put_align(po) < 0)
+                ASN__ENCODE_FAILED;
+
+            tmp = v;
+            {
+                size_t i;
+                for(i = 0; i < num_bytes; i++) {
+                    buf[num_bytes - i - 1] = (uint8_t)(tmp & 0xff);
+                    tmp >>= 8;
                 }
             }
-            
-            /* Use proper APER length determinant encoding */
-            ssize_t mayEncode = aper_put_length(po, -1, -1, num_bytes, &need_eom);
-            if (mayEncode < 0)
-                ASN__ENCODE_FAILED;
-            if ((size_t)mayEncode != num_bytes)
-                ASN__ENCODE_FAILED;
-            
-            /* Output the value bytes */
-            if (per_put_many_bits(po, buf, 8 * num_bytes))
-                ASN__ENCODE_FAILED;
-            
-            if (need_eom && (aper_put_length(po, -1, -1, 0, NULL) < 0))
+
+            if(per_put_many_bits(po, buf, 8 * num_bytes))
                 ASN__ENCODE_FAILED;
         }
         ASN__ENCODED_OK(er);

--- a/tests/tests-skeletons/Makefile.am
+++ b/tests/tests-skeletons/Makefile.am
@@ -31,6 +31,7 @@ check_PROGRAMS =                \
     check-APER-INTEGER-semiconstrained \
     check-APER-INTEGER-extensible-semi \
     check-APER-INTEGER-f1ap     \
+    check-APER-INTEGER-x691-range \
     check-UPER-support          \
     check-UPER-UniversalString  \
     check-UPER-INTEGER          \

--- a/tests/tests-skeletons/check-APER-INTEGER-f1ap.c
+++ b/tests/tests-skeletons/check-APER-INTEGER-f1ap.c
@@ -120,43 +120,43 @@ int main() {
     printf("=== F1AP INTEGER (0..4294967295) APER Encoding Test ===\n\n");
     
     /* Test case 1 from issue: value 32 (0x20) */
-    /* Expected: 01 20 (0x01 = length determinant: 1 byte, then value 0x20) */
-    uint8_t expected_32[] = {0x01, 0x20};
+    /* Expected: 00 20 (2-bit constrained length "00", align, then value byte) */
+    uint8_t expected_32[] = {0x00, 0x20};
     check_f1ap_id_encoding(__LINE__, 32, expected_32, sizeof(expected_32));
     
     /* Test case 2 from issue: value 1 (0x01) */
-    /* Expected: 01 01 (0x01 = length determinant: 1 byte, then value 0x01) */
-    uint8_t expected_1[] = {0x01, 0x01};
+    /* Expected: 00 01 (2-bit constrained length "00", align, then value byte) */
+    uint8_t expected_1[] = {0x00, 0x01};
     check_f1ap_id_encoding(__LINE__, 1, expected_1, sizeof(expected_1));
     
     /* Additional test cases */
     
-    /* Value 0: Expected 01 00 (0x01 = length determinant: 1 byte, then value 0x00) */
-    uint8_t expected_0[] = {0x01, 0x00};
+    /* Value 0: Expected 00 00 (2-bit constrained length "00", align, then value 0x00) */
+    uint8_t expected_0[] = {0x00, 0x00};
     check_f1ap_id_encoding(__LINE__, 0, expected_0, sizeof(expected_0));
     
-    /* Value 255 (0xFF): Expected 01 FF (0x01 = length determinant: 1 byte, then value 0xFF) */
-    uint8_t expected_255[] = {0x01, 0xFF};
+    /* Value 255 (0xFF): Expected 00 FF (2-bit constrained length "00", align, then value 0xFF) */
+    uint8_t expected_255[] = {0x00, 0xFF};
     check_f1ap_id_encoding(__LINE__, 255, expected_255, sizeof(expected_255));
     
-    /* Value 256 (0x0100): Expected 02 01 00 (0x02 = length determinant: 2 bytes, then value 0x0100) */
-    uint8_t expected_256[] = {0x02, 0x01, 0x00};
+    /* Value 256 (0x0100): Expected 40 01 00 (2-bit constrained length "01", align, then value bytes) */
+    uint8_t expected_256[] = {0x40, 0x01, 0x00};
     check_f1ap_id_encoding(__LINE__, 256, expected_256, sizeof(expected_256));
     
-    /* Value 65535 (0xFFFF): Expected 02 FF FF (0x02 = length determinant: 2 bytes, then value 0xFFFF) */
-    uint8_t expected_65535[] = {0x02, 0xFF, 0xFF};
+    /* Value 65535 (0xFFFF): Expected 40 FF FF (2-bit constrained length "01", align, then value bytes) */
+    uint8_t expected_65535[] = {0x40, 0xFF, 0xFF};
     check_f1ap_id_encoding(__LINE__, 65535, expected_65535, sizeof(expected_65535));
     
-    /* Value 65536 (0x010000): Expected 03 01 00 00 (0x03 = length determinant: 3 bytes, then value 0x010000) */
-    uint8_t expected_65536[] = {0x03, 0x01, 0x00, 0x00};
+    /* Value 65536 (0x010000): Expected 80 01 00 00 (2-bit constrained length "10", align, then value bytes) */
+    uint8_t expected_65536[] = {0x80, 0x01, 0x00, 0x00};
     check_f1ap_id_encoding(__LINE__, 65536, expected_65536, sizeof(expected_65536));
     
-    /* Value 16777215 (0xFFFFFF): Expected 03 FF FF FF (0x03 = length determinant: 3 bytes, then value 0xFFFFFF) */
-    uint8_t expected_16777215[] = {0x03, 0xFF, 0xFF, 0xFF};
+    /* Value 16777215 (0xFFFFFF): Expected 80 FF FF FF (2-bit constrained length "10", align, then value bytes) */
+    uint8_t expected_16777215[] = {0x80, 0xFF, 0xFF, 0xFF};
     check_f1ap_id_encoding(__LINE__, 16777215, expected_16777215, sizeof(expected_16777215));
     
-    /* Max value 4294967295 (0xFFFFFFFF): Expected 04 FF FF FF FF (0x04 = length determinant: 4 bytes, then value 0xFFFFFFFF) */
-    uint8_t expected_max[] = {0x04, 0xFF, 0xFF, 0xFF, 0xFF};
+    /* Max value 4294967295 (0xFFFFFFFF): Expected C0 FF FF FF FF (2-bit constrained length "11", align, then value bytes) */
+    uint8_t expected_max[] = {0xC0, 0xFF, 0xFF, 0xFF, 0xFF};
     check_f1ap_id_encoding(__LINE__, 4294967295UL, expected_max, sizeof(expected_max));
     
     printf("=== All F1AP tests passed! ===\n");

--- a/tests/tests-skeletons/check-APER-INTEGER-x691-range.c
+++ b/tests/tests-skeletons/check-APER-INTEGER-x691-range.c
@@ -1,0 +1,315 @@
+/* X.691 constrained-length determinant test for APER INTEGER */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <INTEGER.h>
+#include <INTEGER.c>
+#include <INTEGER_aper.c>
+#include <aper_support.c>
+#include <aper_support.h>
+#include <per_support.c>
+#include <per_support.h>
+
+static int
+FailOut(const void *data, size_t size, void *op_key) {
+    (void)data;
+    (void)size;
+    (void)op_key;
+    assert(!"UNREACHABLE");
+    return 0;
+}
+
+struct test_case {
+    unsigned long value;
+    const uint8_t *expected;
+    size_t expected_len;
+};
+
+struct test_case_signed {
+    long value;
+    const uint8_t *expected;
+    size_t expected_len;
+};
+
+static void
+check_x691_constrained_range(const char *label, int lineno,
+                             const asn_per_constraints_t *cts,
+                             const struct test_case *tc) {
+    INTEGER_t st;
+    INTEGER_t *decoded_st = 0;
+    struct asn_INTEGER_specifics_s specs;
+    asn_enc_rval_t enc_rval;
+    asn_dec_rval_t dec_rval;
+    asn_per_outp_t po;
+    asn_per_data_t pd;
+    size_t encoded_len;
+
+    memset(&st, 0, sizeof(st));
+    memset(&specs, 0, sizeof(specs));
+    memset(&po, 0, sizeof(po));
+    memset(&pd, 0, sizeof(pd));
+
+    asn_ulong2INTEGER(&st, tc->value);
+
+    po.buffer = po.tmpspace;
+    po.nboff = 0;
+    po.nbits = 8 * sizeof(po.tmpspace);
+    po.output = FailOut;
+
+    specs.field_width = sizeof(unsigned long);
+    specs.field_unsigned = 1;
+    asn_DEF_INTEGER.specifics = &specs;
+
+    enc_rval = INTEGER_encode_aper(&asn_DEF_INTEGER, cts, &st, &po);
+    assert(enc_rval.encoded >= 0);
+
+    encoded_len = (size_t)(po.buffer - po.tmpspace) + ((po.nboff + 7) / 8);
+
+    printf("%s:%d value=%lu expected_len=%zu got_len=%zu\n", label, lineno,
+           tc->value, tc->expected_len, encoded_len);
+
+    assert(encoded_len == tc->expected_len);
+    assert(memcmp(po.tmpspace, tc->expected, tc->expected_len) == 0);
+
+    pd.buffer = po.tmpspace;
+    pd.nboff = 0;
+    pd.nbits = 8 * encoded_len;
+    pd.moved = 0;
+
+    dec_rval = INTEGER_decode_aper(0, &asn_DEF_INTEGER, cts, (void **)&decoded_st,
+                                   &pd);
+    assert(dec_rval.code == RC_OK);
+
+    {
+        unsigned long decoded_value = 0;
+        asn_INTEGER2ulong(decoded_st, &decoded_value);
+        assert(decoded_value == tc->value);
+    }
+
+    ASN_STRUCT_RESET(asn_DEF_INTEGER, &st);
+    ASN_STRUCT_FREE(asn_DEF_INTEGER, decoded_st);
+}
+
+static void
+check_x691_constrained_range_signed(const char *label, int lineno,
+                                    const asn_per_constraints_t *cts,
+                                    const struct test_case_signed *tc) {
+    INTEGER_t st;
+    INTEGER_t *decoded_st = 0;
+    struct asn_INTEGER_specifics_s specs;
+    asn_enc_rval_t enc_rval;
+    asn_dec_rval_t dec_rval;
+    asn_per_outp_t po;
+    asn_per_data_t pd;
+    size_t encoded_len;
+
+    memset(&st, 0, sizeof(st));
+    memset(&specs, 0, sizeof(specs));
+    memset(&po, 0, sizeof(po));
+    memset(&pd, 0, sizeof(pd));
+
+    asn_imax2INTEGER(&st, tc->value);
+
+    po.buffer = po.tmpspace;
+    po.nboff = 0;
+    po.nbits = 8 * sizeof(po.tmpspace);
+    po.output = FailOut;
+
+    specs.field_width = sizeof(long);
+    specs.field_unsigned = 0;
+    asn_DEF_INTEGER.specifics = &specs;
+
+    enc_rval = INTEGER_encode_aper(&asn_DEF_INTEGER, cts, &st, &po);
+    assert(enc_rval.encoded >= 0);
+
+    encoded_len = (size_t)(po.buffer - po.tmpspace) + ((po.nboff + 7) / 8);
+
+    printf("%s:%d value=%ld expected_len=%zu got_len=%zu\n", label, lineno,
+           tc->value, tc->expected_len, encoded_len);
+
+    assert(encoded_len == tc->expected_len);
+    assert(memcmp(po.tmpspace, tc->expected, tc->expected_len) == 0);
+
+    pd.buffer = po.tmpspace;
+    pd.nboff = 0;
+    pd.nbits = 8 * encoded_len;
+    pd.moved = 0;
+
+    dec_rval = INTEGER_decode_aper(0, &asn_DEF_INTEGER, cts, (void **)&decoded_st,
+                                   &pd);
+    assert(dec_rval.code == RC_OK);
+
+    {
+        intmax_t decoded_value = 0;
+        asn_INTEGER2imax(decoded_st, &decoded_value);
+        assert(decoded_value == tc->value);
+    }
+
+    ASN_STRUCT_RESET(asn_DEF_INTEGER, &st);
+    ASN_STRUCT_FREE(asn_DEF_INTEGER, decoded_st);
+}
+
+static void
+test_range_bits_36(void) {
+    static const uint8_t exp_0[] = {0x00, 0x00};
+    static const uint8_t exp_1[] = {0x00, 0x01};
+    static const uint8_t exp_255[] = {0x00, 0xFF};
+    static const uint8_t exp_256[] = {0x20, 0x01, 0x00};
+    static const uint8_t exp_65535[] = {0x20, 0xFF, 0xFF};
+    static const uint8_t exp_65536[] = {0x40, 0x01, 0x00, 0x00};
+    static const uint8_t exp_max[] = {0x80, 0x0F, 0xFF, 0xFF, 0xFF, 0xFF};
+
+    static const struct test_case cases[] = {
+        {0, exp_0, sizeof(exp_0)},
+        {1, exp_1, sizeof(exp_1)},
+        {255, exp_255, sizeof(exp_255)},
+        {256, exp_256, sizeof(exp_256)},
+        {65535, exp_65535, sizeof(exp_65535)},
+        {65536, exp_65536, sizeof(exp_65536)},
+        {68719476735UL, exp_max, sizeof(exp_max)},
+    };
+
+    asn_per_constraints_t cts;
+    size_t i;
+
+    memset(&cts, 0, sizeof(cts));
+    cts.value.flags = APC_CONSTRAINED;
+    cts.value.range_bits = 36;
+    cts.value.effective_bits = 36;
+    cts.value.lower_bound = 0;
+    cts.value.upper_bound = 68719476735UL;
+
+    for(i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        check_x691_constrained_range("range36", __LINE__, &cts, &cases[i]);
+    }
+}
+
+/*
+ * range_bits=17: smallest value that enters the >16 code path.
+ * INTEGER (0..131071), max_range_bytes=3, length_bits=2.
+ */
+static void
+test_range_bits_17(void) {
+    /* 2-bit length determinant: "00"=1byte, "01"=2bytes, "10"=3bytes */
+    static const uint8_t exp_0[]   = {0x00, 0x00};
+    static const uint8_t exp_1[]   = {0x00, 0x01};
+    static const uint8_t exp_255[] = {0x00, 0xFF};
+    static const uint8_t exp_256[] = {0x40, 0x01, 0x00};
+    static const uint8_t exp_65535[] = {0x40, 0xFF, 0xFF};
+    /* 131071 = 0x01FFFF → 3 bytes, len det "10" */
+    static const uint8_t exp_max[] = {0x80, 0x01, 0xFF, 0xFF};
+
+    static const struct test_case cases[] = {
+        {0, exp_0, sizeof(exp_0)},
+        {1, exp_1, sizeof(exp_1)},
+        {255, exp_255, sizeof(exp_255)},
+        {256, exp_256, sizeof(exp_256)},
+        {65535, exp_65535, sizeof(exp_65535)},
+        {131071, exp_max, sizeof(exp_max)},
+    };
+
+    asn_per_constraints_t cts;
+    size_t i;
+
+    memset(&cts, 0, sizeof(cts));
+    cts.value.flags = APC_CONSTRAINED;
+    cts.value.range_bits = 17;
+    cts.value.effective_bits = 17;
+    cts.value.lower_bound = 0;
+    cts.value.upper_bound = 131071;
+
+    for(i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        check_x691_constrained_range("range17", __LINE__, &cts, &cases[i]);
+    }
+}
+
+/*
+ * Non-zero lower_bound: INTEGER (1000..100000).
+ * range = 99001, range_bits=17, max_range_bytes=3, length_bits=2.
+ * Encoded offset = value - 1000.
+ */
+static void
+test_range_bits_17_offset(void) {
+    /* offset 0 */
+    static const uint8_t exp_lo[]  = {0x00, 0x00};
+    /* offset 1 */
+    static const uint8_t exp_lo1[] = {0x00, 0x01};
+    /* offset 255 */
+    static const uint8_t exp_255[] = {0x00, 0xFF};
+    /* offset 256 → 2 bytes, len det "01" */
+    static const uint8_t exp_256[] = {0x40, 0x01, 0x00};
+    /* offset 99000 = 0x0182B8 → 3 bytes, len det "10" */
+    static const uint8_t exp_hi[]  = {0x80, 0x01, 0x82, 0xB8};
+
+    static const struct test_case cases[] = {
+        {1000,   exp_lo,  sizeof(exp_lo)},
+        {1001,   exp_lo1, sizeof(exp_lo1)},
+        {1255,   exp_255, sizeof(exp_255)},
+        {1256,   exp_256, sizeof(exp_256)},
+        {100000, exp_hi,  sizeof(exp_hi)},
+    };
+
+    asn_per_constraints_t cts;
+    size_t i;
+
+    memset(&cts, 0, sizeof(cts));
+    cts.value.flags = APC_CONSTRAINED;
+    cts.value.range_bits = 17;
+    cts.value.effective_bits = 17;
+    cts.value.lower_bound = 1000;
+    cts.value.upper_bound = 100000;
+
+    for(i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        check_x691_constrained_range("offset17", __LINE__, &cts, &cases[i]);
+    }
+}
+
+/*
+ * Signed with negative lower_bound: INTEGER (-50000..50000).
+ * range = 100001, range_bits=17, max_range_bytes=3, length_bits=2.
+ * Encoded offset = value - (-50000) = value + 50000.
+ */
+static void
+test_range_bits_17_signed(void) {
+    /* offset 0 */
+    static const uint8_t exp_lo[]  = {0x00, 0x00};
+    /* offset 1 */
+    static const uint8_t exp_lo1[] = {0x00, 0x01};
+    /* offset 50000 = 0xC350 → 2 bytes, len det "01" */
+    static const uint8_t exp_mid[] = {0x40, 0xC3, 0x50};
+    /* offset 100000 = 0x0186A0 → 3 bytes, len det "10" */
+    static const uint8_t exp_hi[]  = {0x80, 0x01, 0x86, 0xA0};
+
+    static const struct test_case_signed cases[] = {
+        {-50000, exp_lo,  sizeof(exp_lo)},
+        {-49999, exp_lo1, sizeof(exp_lo1)},
+        {0,      exp_mid, sizeof(exp_mid)},
+        {50000,  exp_hi,  sizeof(exp_hi)},
+    };
+
+    asn_per_constraints_t cts;
+    size_t i;
+
+    memset(&cts, 0, sizeof(cts));
+    cts.value.flags = APC_CONSTRAINED;
+    cts.value.range_bits = 17;
+    cts.value.effective_bits = 17;
+    cts.value.lower_bound = -50000;
+    cts.value.upper_bound = 50000;
+
+    for(i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        check_x691_constrained_range_signed("signed17", __LINE__, &cts,
+                                            &cases[i]);
+    }
+}
+
+int
+main(void) {
+    test_range_bits_17();
+    test_range_bits_17_offset();
+    test_range_bits_17_signed();
+    test_range_bits_36();
+    return 0;
+}

--- a/tests/tests-skeletons/check-APER-INTEGER-x691-range.c
+++ b/tests/tests-skeletons/check-APER-INTEGER-x691-range.c
@@ -22,7 +22,7 @@ FailOut(const void *data, size_t size, void *op_key) {
 }
 
 struct test_case {
-    unsigned long value;
+    uint64_t value;
     const uint8_t *expected;
     size_t expected_len;
 };
@@ -51,14 +51,14 @@ check_x691_constrained_range(const char *label, int lineno,
     memset(&po, 0, sizeof(po));
     memset(&pd, 0, sizeof(pd));
 
-    asn_ulong2INTEGER(&st, tc->value);
+    asn_uint642INTEGER(&st, tc->value);
 
     po.buffer = po.tmpspace;
     po.nboff = 0;
     po.nbits = 8 * sizeof(po.tmpspace);
     po.output = FailOut;
 
-    specs.field_width = sizeof(unsigned long);
+    specs.field_width = sizeof(uint64_t);
     specs.field_unsigned = 1;
     asn_DEF_INTEGER.specifics = &specs;
 
@@ -67,8 +67,8 @@ check_x691_constrained_range(const char *label, int lineno,
 
     encoded_len = (size_t)(po.buffer - po.tmpspace) + ((po.nboff + 7) / 8);
 
-    printf("%s:%d value=%lu expected_len=%zu got_len=%zu\n", label, lineno,
-           tc->value, tc->expected_len, encoded_len);
+    printf("%s:%d value=%" ASN_PRIu64 " expected_len=%zu got_len=%zu\n", label,
+           lineno, tc->value, tc->expected_len, encoded_len);
 
     assert(encoded_len == tc->expected_len);
     assert(memcmp(po.tmpspace, tc->expected, tc->expected_len) == 0);
@@ -78,13 +78,13 @@ check_x691_constrained_range(const char *label, int lineno,
     pd.nbits = 8 * encoded_len;
     pd.moved = 0;
 
-    dec_rval = INTEGER_decode_aper(0, &asn_DEF_INTEGER, cts, (void **)&decoded_st,
-                                   &pd);
+    dec_rval = INTEGER_decode_aper(0, &asn_DEF_INTEGER, cts,
+                                   (void **)&decoded_st, &pd);
     assert(dec_rval.code == RC_OK);
 
     {
-        unsigned long decoded_value = 0;
-        asn_INTEGER2ulong(decoded_st, &decoded_value);
+        uint64_t decoded_value = 0;
+        asn_INTEGER2uint64(decoded_st, &decoded_value);
         assert(decoded_value == tc->value);
     }
 
@@ -137,8 +137,8 @@ check_x691_constrained_range_signed(const char *label, int lineno,
     pd.nbits = 8 * encoded_len;
     pd.moved = 0;
 
-    dec_rval = INTEGER_decode_aper(0, &asn_DEF_INTEGER, cts, (void **)&decoded_st,
-                                   &pd);
+    dec_rval = INTEGER_decode_aper(0, &asn_DEF_INTEGER, cts,
+                                   (void **)&decoded_st, &pd);
     assert(dec_rval.code == RC_OK);
 
     {
@@ -168,7 +168,7 @@ test_range_bits_36(void) {
         {256, exp_256, sizeof(exp_256)},
         {65535, exp_65535, sizeof(exp_65535)},
         {65536, exp_65536, sizeof(exp_65536)},
-        {68719476735UL, exp_max, sizeof(exp_max)},
+        {UINT64_C(68719476735), exp_max, sizeof(exp_max)},
     };
 
     asn_per_constraints_t cts;
@@ -179,7 +179,7 @@ test_range_bits_36(void) {
     cts.value.range_bits = 36;
     cts.value.effective_bits = 36;
     cts.value.lower_bound = 0;
-    cts.value.upper_bound = 68719476735UL;
+    cts.value.upper_bound = UINT64_C(68719476735);
 
     for(i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
         check_x691_constrained_range("range36", __LINE__, &cts, &cases[i]);
@@ -193,8 +193,8 @@ test_range_bits_36(void) {
 static void
 test_range_bits_17(void) {
     /* 2-bit length determinant: "00"=1byte, "01"=2bytes, "10"=3bytes */
-    static const uint8_t exp_0[]   = {0x00, 0x00};
-    static const uint8_t exp_1[]   = {0x00, 0x01};
+    static const uint8_t exp_0[] = {0x00, 0x00};
+    static const uint8_t exp_1[] = {0x00, 0x01};
     static const uint8_t exp_255[] = {0x00, 0xFF};
     static const uint8_t exp_256[] = {0x40, 0x01, 0x00};
     static const uint8_t exp_65535[] = {0x40, 0xFF, 0xFF};
@@ -233,7 +233,7 @@ test_range_bits_17(void) {
 static void
 test_range_bits_17_offset(void) {
     /* offset 0 */
-    static const uint8_t exp_lo[]  = {0x00, 0x00};
+    static const uint8_t exp_lo[] = {0x00, 0x00};
     /* offset 1 */
     static const uint8_t exp_lo1[] = {0x00, 0x01};
     /* offset 255 */
@@ -241,14 +241,12 @@ test_range_bits_17_offset(void) {
     /* offset 256 → 2 bytes, len det "01" */
     static const uint8_t exp_256[] = {0x40, 0x01, 0x00};
     /* offset 99000 = 0x0182B8 → 3 bytes, len det "10" */
-    static const uint8_t exp_hi[]  = {0x80, 0x01, 0x82, 0xB8};
+    static const uint8_t exp_hi[] = {0x80, 0x01, 0x82, 0xB8};
 
     static const struct test_case cases[] = {
-        {1000,   exp_lo,  sizeof(exp_lo)},
-        {1001,   exp_lo1, sizeof(exp_lo1)},
-        {1255,   exp_255, sizeof(exp_255)},
-        {1256,   exp_256, sizeof(exp_256)},
-        {100000, exp_hi,  sizeof(exp_hi)},
+        {1000, exp_lo, sizeof(exp_lo)},   {1001, exp_lo1, sizeof(exp_lo1)},
+        {1255, exp_255, sizeof(exp_255)}, {1256, exp_256, sizeof(exp_256)},
+        {100000, exp_hi, sizeof(exp_hi)},
     };
 
     asn_per_constraints_t cts;
@@ -274,19 +272,19 @@ test_range_bits_17_offset(void) {
 static void
 test_range_bits_17_signed(void) {
     /* offset 0 */
-    static const uint8_t exp_lo[]  = {0x00, 0x00};
+    static const uint8_t exp_lo[] = {0x00, 0x00};
     /* offset 1 */
     static const uint8_t exp_lo1[] = {0x00, 0x01};
     /* offset 50000 = 0xC350 → 2 bytes, len det "01" */
     static const uint8_t exp_mid[] = {0x40, 0xC3, 0x50};
     /* offset 100000 = 0x0186A0 → 3 bytes, len det "10" */
-    static const uint8_t exp_hi[]  = {0x80, 0x01, 0x86, 0xA0};
+    static const uint8_t exp_hi[] = {0x80, 0x01, 0x86, 0xA0};
 
     static const struct test_case_signed cases[] = {
-        {-50000, exp_lo,  sizeof(exp_lo)},
+        {-50000, exp_lo, sizeof(exp_lo)},
         {-49999, exp_lo1, sizeof(exp_lo1)},
-        {0,      exp_mid, sizeof(exp_mid)},
-        {50000,  exp_hi,  sizeof(exp_hi)},
+        {0, exp_mid, sizeof(exp_mid)},
+        {50000, exp_hi, sizeof(exp_hi)},
     };
 
     asn_per_constraints_t cts;


### PR DESCRIPTION
## Summary

Fix APER encoding/decoding for constrained INTEGER types with range > 65536
(e.g., `GNB-DU-ID ::= INTEGER (0..68719476735)` from 3GPP F1AP/E2AP).

The v1.4 code incorrectly used unconstrained length determinants (`aper_get_length`/`aper_put_length`) for these types.
Per **ITU-T X.691 clause 13.2.6**, the length of the value encoding must be a *constrained* whole number encoded in `ceil(log2(max_range_bytes))` bits, followed by octet alignment, then the value octets.
The unconstrained encoding consumed extra bits (8-bit length field after alignment vs. 2-3 bit constrained determinant), corrupting decoded values and misaligning the remainder of the bitstream.

**Symptoms**: all PDUs containing constrained integers with range > 65536
fail to decode — values are wrong and subsequent fields are garbled.

## Changes

- **`skeletons/INTEGER_aper.c`**: Restore X.691 13.2.6 constrained-length
  algorithm in both decoder (`INTEGER_decode_aper`) and encoder
  (`INTEGER_encode_aper`) for `range_bits > 16`. Add `aper_log2_ceil_size()`
  helper for `ceil(log2(v))`.
- **`tests/tests-skeletons/check-APER-INTEGER-x691-range.c`** (new): Regression
  test validating byte-exact APER encoding and decode round-trip for
  `range_bits=32` (0..4294967295) and `range_bits=36` (0..68719476735).
- **`tests/tests-skeletons/check-APER-INTEGER-f1ap.c`**: Update expected byte
  patterns from unconstrained to X.691-compliant constrained format.

## References

- ITU-T X.691 (2021), Clause 13.2.6 — constrained whole number encoding for range > 65536