### PR TITLE
Fix IOC table descriptor for inline-constrained built-in types

### DIFF
--- a/libasn1compiler/asn1c_ioc.c
+++ b/libasn1compiler/asn1c_ioc.c
@@ -343,9 +343,12 @@ emit_ioc_value(arg_t *arg, struct asn1p_ioc_cell_s *cell, asn1p_expr_t *objset) 
 
 /*
  * Emit a single IOC cell initializer.
- * FIX: for TYPE cells, resolve to the concrete descriptor symbol using TNF_RSAFE
- *      so we reference e.g. &asn_DEF_SEQUENCE_OF_CommTxPDU_1 instead of
- *      the non-descriptor placeholder &asn_DEF_SEQUENCE_OF.
+ *
+ * TYPE cells need two behaviors:
+ *  - Constructed anonymous types (SEQUENCE OF, etc.) use a concrete
+ *    suffixed descriptor generated in this TU: asn_DEF_<id>_<n>.
+ *  - Built-in inline-constrained types (e.g. OCTET STRING (SIZE(3)))
+ *    must use the base built-in descriptor: asn_DEF_OCTET_STRING.
  */
 static int
 emit_ioc_cell(arg_t *arg, struct asn1p_ioc_cell_s *cell, asn1p_expr_t *objset) {
@@ -365,30 +368,33 @@ emit_ioc_cell(arg_t *arg, struct asn1p_ioc_cell_s *cell, asn1p_expr_t *objset) {
         OUT("&asn_VAL_%s_%d_%s", objset_name, cell->value->_type_unique_index, MKID(cell->value));
         free(objset_name);
 
-    /* } else if(cell->value->meta_type == AMT_TYPE) { */
-    /*     /\* Anonymous / constructed type (e.g., SEQUENCE OF CommTxPDU): */
-    /*      * reference the concrete, suffixed descriptor defined in this TU. *\/ */
-    /*     GEN_INCLUDE(asn1c_type_name(arg, cell->value, TNF_INCLUDE)); */
-    /*     OUT("aioc__type, &asn_DEF_%s_%d", */
-    /*         MKID(cell->value), cell->value->_type_unique_index); */
-
-    /* } else if(cell->value->meta_type == AMT_TYPEREF) { */
-    /*     /\* Named type reference: use SAFE so we get the proper (usually */
-    /*      * unsuffixed) descriptor symbol defined in its own TU. *\/ */
-    /*     GEN_INCLUDE(asn1c_type_name(arg, cell->value, TNF_INCLUDE)); */
-    /*     OUT("aioc__type, &asn_DEF_%s", */
-    /*         asn1c_type_name(arg, cell->value, TNF_SAFE)); */
-
     } else if(cell->value->meta_type == AMT_TYPEREF) {
-        /* Named type reference: use SAFE for the standard descriptor name */
+        /* Named type reference (X.680 §14): defined in its own TU,
+         * use SAFE for the canonical descriptor symbol. */
         GEN_INCLUDE(asn1c_type_name(arg, cell->value, TNF_INCLUDE));
         OUT("aioc__type, &asn_DEF_%s", asn1c_type_name(arg, cell->value, TNF_SAFE));
     } else if(cell->value->meta_type == AMT_TYPE) {
-        /* Anonymous/constructed type: reference the suffixed descriptor */
+        /*
+         * Anonymous inline type in an IOC TYPE field (X.681 §9.3).
+         *
+         * Constructed types (SEQUENCE, SEQUENCE OF, …) get a local
+         * asn_TYPE_descriptor_t with a unique suffix emitted in this TU;
+         * reference the suffixed symbol.
+         *
+         * Built-in / string types with subtype constraints (X.680 §49,
+         * e.g. OCTET STRING (SIZE(3))) share the base type's encoding
+         * and don't get a local descriptor; reference the skeleton
+         * descriptor directly (asn_DEF_OCTET_STRING, etc.).
+         */
         GEN_INCLUDE(asn1c_type_name(arg, cell->value, TNF_INCLUDE));
-        OUT("aioc__type, &asn_DEF_%s_%d", 
-            MKID(cell->value), cell->value->_type_unique_index);
-        
+        if(cell->value->expr_type & ASN_CONSTR_MASK) {
+            OUT("aioc__type, &asn_DEF_%s_%d",
+                MKID(cell->value), cell->value->_type_unique_index);
+        } else {
+            OUT("aioc__type, &asn_DEF_%s",
+                asn1c_type_name(arg, cell->value, TNF_SAFE));
+        }
+
     } else {
         return -1;
     }
@@ -399,25 +405,9 @@ emit_ioc_cell(arg_t *arg, struct asn1p_ioc_cell_s *cell, asn1p_expr_t *objset) {
 }
 
 /*
- * Refer to skeletons/asn_ioc.h
+ * Emit the Information Object Set table (X.681 §11).
+ * Refer to skeletons/asn_ioc.h for the runtime representation.
  */
-/* ============================================================================
- * COMPLETE FIX - Replace emit_ioc_table() in asn1c_ioc.c
- * 
- * The Problem: Forward declarations were always using "extern" but definitions
- * could be "static", causing a storage class mismatch.
- * 
- * The Solution: Forward declarations must match the storage class that will be
- * used in the actual definition. This depends on:
- * - A1C_ALL_DEFS_GLOBAL flag: if set, all defs are non-static (extern)
- * - Otherwise, anonymous/constructed types are static
- * ============================================================================ */
-
-/* ============================================================================
- * PART 1: Fix in asn1c_ioc.c - emit_ioc_table()
- * This fixes the IOC table type forward declarations
- * ============================================================================ */
-
 int
 emit_ioc_table(arg_t *arg, asn1p_expr_t *context, asn1c_ioc_table_and_objset_t ioc_tao) {
     size_t columns = 0;
@@ -445,10 +435,10 @@ emit_ioc_table(arg_t *arg, asn1p_expr_t *context, asn1c_ioc_table_and_objset_t i
     if(ioc_tao.ioct->rows == 0)
         return 0;
 
-    /* Forward-declare concrete descriptors referenced by TYPE cells.
-     * 
-     * IOC table types are ALWAYS embedded (anonymous members), so:
-     * - They're static UNLESS A1C_ALL_DEFS_GLOBAL is set
+    /* Forward-declare only constructed anonymous TYPE cell descriptors
+     * (X.681 §9.3 TypeFieldSpec).  Built-in types with subtype constraints
+     * (X.680 §49) use the globally-defined skeleton descriptor and must not
+     * get a suffixed forward (no matching definition would be emitted).
      */
     
     for(size_t rn = 0; rn < ioc_tao.ioct->rows; rn++) {
@@ -456,8 +446,9 @@ emit_ioc_table(arg_t *arg, asn1p_expr_t *context, asn1c_ioc_table_and_objset_t i
         for(size_t cn = 0; cn < row->columns; cn++) {
             struct asn1p_ioc_cell_s *cell = &row->column[cn];
             
-            if(cell->value && cell->value->meta_type == AMT_TYPE) {
-                /* Anonymous/constructed type - will be static unless A1C_ALL_DEFS_GLOBAL */
+            if(cell->value && cell->value->meta_type == AMT_TYPE
+               && (cell->value->expr_type & ASN_CONSTR_MASK)) {
+                /* Constructed anonymous type: static unless -fall-defs-global. */
                 if(arg->flags & A1C_ALL_DEFS_GLOBAL) {
                     OUT("extern asn_TYPE_descriptor_t asn_DEF_%s_%d;\n",
                         MKID(cell->value), cell->value->_type_unique_index);

--- a/tests/tests-asn1c-compiler/144-ios-parameterization-OK.asn1.+-P
+++ b/tests/tests-asn1c-compiler/144-ios-parameterization-OK.asn1.+-P
@@ -141,14 +141,12 @@ extern asn_TYPE_member_t asn_MBR_RegionalExtension_1[2];
 
 static const long asn_VAL_RegionalExtension_1_1 = 1;
 static const long asn_VAL_RegionalExtension_2_2 = 2;
-static asn_TYPE_descriptor_t asn_DEF_INTEGER_1;
-static asn_TYPE_descriptor_t asn_DEF_BOOLEAN_2;
 
 static const asn_ioc_cell_t asn_IOS_RegionalExtension_1_rows[] = {
 	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_RegionalExtension_1_1 },
-	{ "&Type", aioc__type, &asn_DEF_INTEGER_1 },
+	{ "&Type", aioc__type, &asn_DEF_NativeInteger },
 	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_RegionalExtension_2_2 },
-	{ "&Type", aioc__type, &asn_DEF_BOOLEAN_2 }
+	{ "&Type", aioc__type, &asn_DEF_BOOLEAN }
 };
 static const asn_ioc_set_t asn_IOS_RegionalExtension_1[] = {
 	{ 2, 2, asn_IOS_RegionalExtension_1_rows }

--- a/tests/tests-asn1c-compiler/146-ios-parameterization-per-OK.asn1.+-P_-gen-UPER_-gen-APER
+++ b/tests/tests-asn1c-compiler/146-ios-parameterization-per-OK.asn1.+-P_-gen-UPER_-gen-APER
@@ -141,14 +141,12 @@ extern asn_TYPE_member_t asn_MBR_RegionalExtension_1[2];
 
 static const long asn_VAL_RegionalExtension_1_1 = 1;
 static const long asn_VAL_RegionalExtension_2_2 = 2;
-static asn_TYPE_descriptor_t asn_DEF_INTEGER_1;
-static asn_TYPE_descriptor_t asn_DEF_BOOLEAN_2;
 
 static const asn_ioc_cell_t asn_IOS_RegionalExtension_1_rows[] = {
 	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_RegionalExtension_1_1 },
-	{ "&Type", aioc__type, &asn_DEF_INTEGER_1 },
+	{ "&Type", aioc__type, &asn_DEF_NativeInteger },
 	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_RegionalExtension_2_2 },
-	{ "&Type", aioc__type, &asn_DEF_BOOLEAN_2 }
+	{ "&Type", aioc__type, &asn_DEF_BOOLEAN }
 };
 static const asn_ioc_set_t asn_IOS_RegionalExtension_1[] = {
 	{ 2, 2, asn_IOS_RegionalExtension_1_rows }

--- a/tests/tests-asn1c-compiler/155-parameterization-more-than-two-level-OK.asn1.+-P_-gen-UPER_-gen-APER
+++ b/tests/tests-asn1c-compiler/155-parameterization-more-than-two-level-OK.asn1.+-P_-gen-UPER_-gen-APER
@@ -751,12 +751,11 @@ extern asn_TYPE_member_t asn_MBR_ClassItem_1[3];
 static const long asn_VAL_ClassItem_1_id_TYPE1 = 1;
 static const long asn_VAL_ClassItem_1_blue = 2;
 static const long asn_VAL_ClassItem_1_crc_ok = 1;
-static asn_TYPE_descriptor_t asn_DEF_OCTET_STRING_1;
 
 static const asn_ioc_cell_t asn_IOS_ClassItem_1_rows[] = {
 	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_ClassItem_1_id_TYPE1 },
 	{ "&color", aioc__value, &asn_DEF_NativeEnumerated, &asn_VAL_ClassItem_1_blue },
-	{ "&Value", aioc__type, &asn_DEF_OCTET_STRING_1 },
+	{ "&Value", aioc__type, &asn_DEF_OCTET_STRING },
 	{ "&valid", aioc__value, &asn_DEF_NativeEnumerated, &asn_VAL_ClassItem_1_crc_ok }
 };
 static const asn_ioc_set_t asn_IOS_ClassItem_1[] = {

--- a/tests/tests-asn1c-compiler/156-union-ios-OK.asn1.+-P_-gen-UPER_-gen-APER
+++ b/tests/tests-asn1c-compiler/156-union-ios-OK.asn1.+-P_-gen-UPER_-gen-APER
@@ -154,26 +154,20 @@ static const long asn_VAL_TotalRegionExtension_3_3 = 3;
 static const long asn_VAL_TotalRegionExtension_4_1 = 1;
 static const long asn_VAL_TotalRegionExtension_5_2 = 2;
 static const long asn_VAL_TotalRegionExtension_6_3 = 3;
-static asn_TYPE_descriptor_t asn_DEF_INTEGER_1;
-static asn_TYPE_descriptor_t asn_DEF_BOOLEAN_2;
-static asn_TYPE_descriptor_t asn_DEF_OCTET_STRING_3;
-static asn_TYPE_descriptor_t asn_DEF_INTEGER_4;
-static asn_TYPE_descriptor_t asn_DEF_BOOLEAN_5;
-static asn_TYPE_descriptor_t asn_DEF_OCTET_STRING_6;
 
 static const asn_ioc_cell_t asn_IOS_TotalRegionExtension_1_rows[] = {
 	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_TotalRegionExtension_1_1 },
-	{ "&Type", aioc__type, &asn_DEF_INTEGER_1 },
+	{ "&Type", aioc__type, &asn_DEF_NativeInteger },
 	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_TotalRegionExtension_2_2 },
-	{ "&Type", aioc__type, &asn_DEF_BOOLEAN_2 },
+	{ "&Type", aioc__type, &asn_DEF_BOOLEAN },
 	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_TotalRegionExtension_3_3 },
-	{ "&Type", aioc__type, &asn_DEF_OCTET_STRING_3 },
+	{ "&Type", aioc__type, &asn_DEF_OCTET_STRING },
 	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_TotalRegionExtension_4_1 },
-	{ "&Type", aioc__type, &asn_DEF_INTEGER_4 },
+	{ "&Type", aioc__type, &asn_DEF_NativeInteger },
 	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_TotalRegionExtension_5_2 },
-	{ "&Type", aioc__type, &asn_DEF_BOOLEAN_5 },
+	{ "&Type", aioc__type, &asn_DEF_BOOLEAN },
 	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_TotalRegionExtension_6_3 },
-	{ "&Type", aioc__type, &asn_DEF_OCTET_STRING_6 }
+	{ "&Type", aioc__type, &asn_DEF_OCTET_STRING }
 };
 static const asn_ioc_set_t asn_IOS_TotalRegionExtension_1[] = {
 	{ 6, 2, asn_IOS_TotalRegionExtension_1_rows }

--- a/tests/tests-asn1c-compiler/160-multiple-parameterized-instance-OK.asn1.+-P_-gen-UPER_-gen-APER_-fcompound-names
+++ b/tests/tests-asn1c-compiler/160-multiple-parameterized-instance-OK.asn1.+-P_-gen-UPER_-gen-APER_-fcompound-names
@@ -386,54 +386,44 @@ static const long asn_VAL_TotalRegionExtension_3_3 = 3;
 static const long asn_VAL_TotalRegionExtension_4_1 = 1;
 static const long asn_VAL_TotalRegionExtension_5_2 = 2;
 static const long asn_VAL_TotalRegionExtension_6_3 = 3;
-static asn_TYPE_descriptor_t asn_DEF_INTEGER_1;
-static asn_TYPE_descriptor_t asn_DEF_BOOLEAN_2;
-static asn_TYPE_descriptor_t asn_DEF_OCTET_STRING_3;
-static asn_TYPE_descriptor_t asn_DEF_INTEGER_4;
-static asn_TYPE_descriptor_t asn_DEF_BOOLEAN_5;
-static asn_TYPE_descriptor_t asn_DEF_OCTET_STRING_6;
 
 static const asn_ioc_cell_t asn_IOS_TotalRegionExtension_1_rows[] = {
 	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_TotalRegionExtension_1_1 },
-	{ "&Type", aioc__type, &asn_DEF_INTEGER_1 },
+	{ "&Type", aioc__type, &asn_DEF_NativeInteger },
 	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_TotalRegionExtension_2_2 },
-	{ "&Type", aioc__type, &asn_DEF_BOOLEAN_2 },
+	{ "&Type", aioc__type, &asn_DEF_BOOLEAN },
 	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_TotalRegionExtension_3_3 },
-	{ "&Type", aioc__type, &asn_DEF_OCTET_STRING_3 },
+	{ "&Type", aioc__type, &asn_DEF_OCTET_STRING },
 	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_TotalRegionExtension_4_1 },
-	{ "&Type", aioc__type, &asn_DEF_INTEGER_4 },
+	{ "&Type", aioc__type, &asn_DEF_NativeInteger },
 	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_TotalRegionExtension_5_2 },
-	{ "&Type", aioc__type, &asn_DEF_BOOLEAN_5 },
+	{ "&Type", aioc__type, &asn_DEF_BOOLEAN },
 	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_TotalRegionExtension_6_3 },
-	{ "&Type", aioc__type, &asn_DEF_OCTET_STRING_6 }
+	{ "&Type", aioc__type, &asn_DEF_OCTET_STRING }
 };
 static const asn_ioc_set_t asn_IOS_TotalRegionExtension_1[] = {
 	{ 6, 2, asn_IOS_TotalRegionExtension_1_rows }
 };
 static const long asn_VAL_RegionalExtension3_7_1 = 1;
 static const long asn_VAL_RegionalExtension3_8_4 = 4;
-static asn_TYPE_descriptor_t asn_DEF_OCTET_STRING_7;
-static asn_TYPE_descriptor_t asn_DEF_OCTET_STRING_8;
 
 static const asn_ioc_cell_t asn_IOS_RegionalExtension3_1_rows[] = {
 	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_RegionalExtension3_7_1 },
-	{ "&Type", aioc__type, &asn_DEF_OCTET_STRING_7 },
+	{ "&Type", aioc__type, &asn_DEF_OCTET_STRING },
 	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_RegionalExtension3_8_4 },
-	{ "&Type", aioc__type, &asn_DEF_OCTET_STRING_8 }
+	{ "&Type", aioc__type, &asn_DEF_OCTET_STRING }
 };
 static const asn_ioc_set_t asn_IOS_RegionalExtension3_1[] = {
 	{ 2, 2, asn_IOS_RegionalExtension3_1_rows }
 };
 static const long asn_VAL_RegionalExtension4_9_5 = 5;
 static const long asn_VAL_RegionalExtension4_10_6 = 6;
-static asn_TYPE_descriptor_t asn_DEF_INTEGER_9;
-static asn_TYPE_descriptor_t asn_DEF_OCTET_STRING_5__10;
 
 static const asn_ioc_cell_t asn_IOS_RegionalExtension4_1_rows[] = {
 	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_RegionalExtension4_9_5 },
-	{ "&Type", aioc__type, &asn_DEF_INTEGER_9 },
+	{ "&Type", aioc__type, &asn_DEF_NativeInteger },
 	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_RegionalExtension4_10_6 },
-	{ "&Type", aioc__type, &asn_DEF_OCTET_STRING_5__10 }
+	{ "&Type", aioc__type, &asn_DEF_OCTET_STRING }
 };
 static const asn_ioc_set_t asn_IOS_RegionalExtension4_1[] = {
 	{ 2, 2, asn_IOS_RegionalExtension4_1_rows }

--- a/tests/tests-asn1c-compiler/169-cross-file-param-specialization-OK.asn1.+-P_-fcompound-names
+++ b/tests/tests-asn1c-compiler/169-cross-file-param-specialization-OK.asn1.+-P_-fcompound-names
@@ -366,12 +366,11 @@ extern asn_TYPE_member_t asn_MBR_AnotherIEs_5[3];
 static const long asn_VAL_SampleIEs_1_1 = 1;
 static const long asn_VAL_SampleIEs_1_reject = 0;
 static const long asn_VAL_SampleIEs_1_mandatory = 2;
-static asn_TYPE_descriptor_t asn_DEF_INTEGER_1;
 
 static const asn_ioc_cell_t asn_IOS_SampleIEs_1_rows[] = {
 	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_SampleIEs_1_1 },
 	{ "&criticality", aioc__value, &asn_DEF_NativeEnumerated, &asn_VAL_SampleIEs_1_reject },
-	{ "&Value", aioc__type, &asn_DEF_INTEGER_1 },
+	{ "&Value", aioc__type, &asn_DEF_NativeInteger },
 	{ "&presence", aioc__value, &asn_DEF_NativeEnumerated, &asn_VAL_SampleIEs_1_mandatory }
 };
 static const asn_ioc_set_t asn_IOS_SampleIEs_1[] = {
@@ -380,12 +379,11 @@ static const asn_ioc_set_t asn_IOS_SampleIEs_1[] = {
 static const long asn_VAL_AnotherIEs_2_2 = 2;
 static const long asn_VAL_AnotherIEs_2_ignore = 1;
 static const long asn_VAL_AnotherIEs_2_optional = 0;
-static asn_TYPE_descriptor_t asn_DEF_BOOLEAN_2;
 
 static const asn_ioc_cell_t asn_IOS_AnotherIEs_1_rows[] = {
 	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_AnotherIEs_2_2 },
 	{ "&criticality", aioc__value, &asn_DEF_NativeEnumerated, &asn_VAL_AnotherIEs_2_ignore },
-	{ "&Value", aioc__type, &asn_DEF_BOOLEAN_2 },
+	{ "&Value", aioc__type, &asn_DEF_BOOLEAN },
 	{ "&presence", aioc__value, &asn_DEF_NativeEnumerated, &asn_VAL_AnotherIEs_2_optional }
 };
 static const asn_ioc_set_t asn_IOS_AnotherIEs_1[] = {

--- a/tests/tests-asn1c-compiler/170-private-ie-field-OK.asn1.+-P_-fno-include-deps_-findirect-choice_-fcompound-names
+++ b/tests/tests-asn1c-compiler/170-private-ie-field-OK.asn1.+-P_-fno-include-deps_-findirect-choice_-fcompound-names
@@ -341,12 +341,11 @@ extern asn_TYPE_member_t asn_MBR_PrivateMessage_IEs_1[3];
 static const long asn_VAL_PrivateMessage_IEs_1_1 = 1;
 static const long asn_VAL_PrivateMessage_IEs_1_reject = 0;
 static const long asn_VAL_PrivateMessage_IEs_1_mandatory = 2;
-static asn_TYPE_descriptor_t asn_DEF_INTEGER_1;
 
 static const asn_ioc_cell_t asn_IOS_PrivateMessage_IEs_1_rows[] = {
 	{ "&id", aioc__value, &asn_DEF_NativeInteger, &asn_VAL_PrivateMessage_IEs_1_1 },
 	{ "&criticality", aioc__value, &asn_DEF_NativeEnumerated, &asn_VAL_PrivateMessage_IEs_1_reject },
-	{ "&Value", aioc__type, &asn_DEF_INTEGER_1 },
+	{ "&Value", aioc__type, &asn_DEF_NativeInteger },
 	{ "&presence", aioc__value, &asn_DEF_NativeEnumerated, &asn_VAL_PrivateMessage_IEs_1_mandatory }
 };
 static const asn_ioc_set_t asn_IOS_PrivateMessage_IEs_1[] = {

--- a/tests/tests-asn1c-smoke/Makefile.am
+++ b/tests/tests-asn1c-smoke/Makefile.am
@@ -24,6 +24,7 @@ TESTS += check-SEQUENCE_OF_INTEGER.sh
 TESTS += check-Time.sh
 TESTS += check-JER-open-type.sh
 TESTS += check-JER-enumerated-opentype.sh
+TESTS += check-APER-inline-constrained-ioc.sh
 TESTS += check-fprefix-link.sh
 
 CLEANFILES = Makefile.am.* *.[acho] check-*.log check-*.trs

--- a/tests/tests-asn1c-smoke/check-APER-inline-constrained-ioc.sh
+++ b/tests/tests-asn1c-smoke/check-APER-inline-constrained-ioc.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Regression: inline-constrained types in IOC TYPE cells (X.681 §9.3).
+#
+# An IOC entry like  EXTENSION OCTET STRING (SIZE(3))  is an AMT_TYPE with a
+# subtype constraint (X.680 §49).  The code generator must reference the base
+# built-in descriptor (asn_DEF_OCTET_STRING), not a suffixed symbol that is
+# forward-declared but never defined.  Without the fix in asn1c_ioc.c, the
+# OPEN TYPE codec dereferences a zero-initialized descriptor and segfaults.
+#
+# Real-world trigger: 3GPP F1AP RRC-Version-ExtIEs (TS 38.473).
+#
+
+set -e
+set -o pipefail
+
+top_builddir=${top_builddir:-../..}
+top_srcdir=${top_srcdir:-../..}
+
+testdir=test-APER-inline-constrained-ioc
+cleanup() {
+    rm -rf "${testdir}"
+}
+trap cleanup EXIT
+
+rm -rf "${testdir}"
+mkdir "${testdir}"
+cd "${testdir}"
+
+# Minimal CLASS with an inline-constrained OPEN TYPE field.
+cat > test-inline-ioc.asn1 << 'EOF'
+TestModule DEFINITIONS AUTOMATIC TAGS ::= BEGIN
+    TESTCLASS ::= CLASS {
+        &id        INTEGER UNIQUE,
+        &Extension
+    } WITH SYNTAX { ID &id EXTENSION &Extension }
+
+    MyExtIEs TESTCLASS ::= {
+        { ID 1 EXTENSION OCTET STRING (SIZE(3)) },
+        ...
+    }
+
+    MyContainer ::= SEQUENCE {
+        id        TESTCLASS.&id({MyExtIEs}),
+        extension TESTCLASS.&Extension({MyExtIEs}{@id})
+    }
+END
+EOF
+
+../"${top_builddir}"/asn1c/asn1c \
+    -fcompound-names \
+    -findirect-choice \
+    -flink-skeletons \
+    -S ../"${top_srcdir}"/skeletons \
+    test-inline-ioc.asn1
+
+# APER encode + decode round-trip; segfaults (exit 139) without the fix.
+cat > test_program.c << 'EOF'
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "MyContainer.h"
+#include "OCTET_STRING.h"
+#include "aper_decoder.h"
+#include "aper_encoder.h"
+
+int main(void) {
+    MyContainer_t pdu;
+    MyContainer_t *decoded = NULL;
+    asn_enc_rval_t er;
+    asn_dec_rval_t dr;
+    uint8_t encoded[128];
+    size_t encoded_len;
+
+    memset(&pdu, 0, sizeof(pdu));
+    pdu.id = 1;
+
+    pdu.extension.present = MyContainer__extension_PR_OCTET_STRING_SIZE_3_;
+    if(OCTET_STRING_fromBuf(&pdu.extension.choice.OCTET_STRING_SIZE_3_, "\x01\x02\x03", 3) != 0) {
+        fprintf(stderr, "OCTET_STRING_fromBuf failed\n");
+        return 1;
+    }
+
+    er = aper_encode_to_buffer(&asn_DEF_MyContainer, NULL, &pdu, encoded, sizeof(encoded));
+    if(er.encoded < 0) {
+        fprintf(stderr, "APER encode failed\n");
+        ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_MyContainer, &pdu);
+        return 1;
+    }
+
+    encoded_len = (size_t)((er.encoded + 7) / 8);
+    dr = aper_decode_complete(NULL, &asn_DEF_MyContainer, (void **)&decoded, encoded, encoded_len);
+    if(dr.code != RC_OK) {
+        fprintf(stderr, "APER decode failed (code=%d consumed=%zu)\n", dr.code, dr.consumed);
+        ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_MyContainer, &pdu);
+        if(decoded) ASN_STRUCT_FREE(asn_DEF_MyContainer, decoded);
+        return 1;
+    }
+
+    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_MyContainer, &pdu);
+    ASN_STRUCT_FREE(asn_DEF_MyContainer, decoded);
+    return 0;
+}
+EOF
+
+${MAKE:-make} -f converter-example.mk
+
+${CC:-cc} -DASN_PDU_COLLECTION -I. -o test_program test_program.c libasncodec.a -lm
+
+./test_program


### PR DESCRIPTION
When an Information Object Class TYPE cell contains an inline-constrained built-in type (e.g. OCTET STRING (SIZE(3))), the code generator emitted a suffixed descriptor reference (asn_DEF_OCTET_STRING_46) with a forward declaration but no matching definition.

The zero-initialized static caused a segfault when the OPEN TYPE codec dereferenced ->op.
Real-world trigger: 3GPP F1AP RRC-Version-ExtIEs (TS 38.473).

Discriminate AMT_TYPE cells by ASN_CONSTR_MASK: constructed types (SEQUENCE, SEQUENCE OF, etc.) keep the suffixed symbol; built-in/string types with subtype constraints (X.680 §49) use the base skeleton descriptor (asn_DEF_OCTET_STRING, etc.) which is globally defined.