### PR TITLE
Fix: Missing include for circular-referenced types in deeply nested struct typedefs

### DIFF
--- a/libasn1compiler/asn1c_C.c
+++ b/libasn1compiler/asn1c_C.c
@@ -939,6 +939,17 @@ generate_typedef_for_constructed_member(arg_t *arg, asn1p_expr_t *expr, int targ
 	/* Generate members */
 	asn1p_expr_t *memb;
 	TQ_FOR(memb, &(expr->members), next) {
+
+	/*
+	 * Detect recursive/circular references in members before generating
+	 * the struct body. Without this, expr_break_recursion runs later
+	 * (during DEPENDENCIES in the default callback), causing EM_INDIRECT
+	 * to be set after the struct has already been emitted with value form.
+	 * This produces mismatched struct definitions (value form) and member
+	 * tables (ATF_POINTER), and missing include.
+	 */
+
+	 	expr_break_recursion(&tmp, memb);
 		EMBED(memb);
 	}
 	


### PR DESCRIPTION

### Bug

When ASN.1 types form a circular reference chain through deeply nested structures (e.g., `TypeSpecification → TypeDescription → SEQUENCE OF → Member → componentType: TypeSpecification`), `asn1c` generated uncompilable code.

Given this ASN.1:
```asn1
TypeSpecification ::= CHOICE { typeDescription TypeDescription }
Foo ::= NULL
TypeDescription ::= CHOICE {
  structure [2] IMPLICIT SEQUENCE {
    components [1] IMPLICIT SEQUENCE OF SEQUENCE {
      componentType [1] TypeSpecification,
      foo [2] Foo
    }
  }
}
```

The generated `TypeDescription.h` had **three interrelated problems**:

```c
/* Forward declarations */
struct TypeSpecification;              // ← only declares struct tag, not typedef

/* Forward definitions */
typedef struct Member {
    TypeSpecification_t  componentType; // ← uses typedef by VALUE (needs full type)
    Foo_t                foo;
} Member;
```

1. **Struct uses value form** (`TypeSpecification_t componentType`) — the typedef `TypeSpecification_t` is undefined at this point
2. **Forward declaration is insufficient** — `struct TypeSpecification;` only declares the struct tag, not the `_t` typedef
3. **`#include "TypeSpecification.h"` is at the bottom** of the header (in the `OT_POST_INCLUDE` section, placed **after** the struct definition), so the typedef isn't available

Meanwhile the member table in the `.c` file used `ATF_POINTER` (because `EM_INDIRECT` was set later), creating an inconsistency with the struct's value form.

### Root Cause

`generate_typedef_for_constructed_member()` in `asn1c_C.c` generates pre-typedefs for deeply nested struct members **before** `expr_break_recursion()` runs. The call sequence was:

1. **`generate_typedef_for_constructed_member()`** — generates struct body with `EMBED(memb)` → `componentType` uses `TypeSpecification_t` by value (EM_INDIRECT not yet set)
2. **Later: `DEPENDENCIES` → `emit_include_dependencies()`** — calls `expr_break_recursion()` which detects the circular reference and sets `EM_INDIRECT | EM_UNRECURSE` → too late, struct already emitted with value form
3. `emit_include_dependencies()` then places `#include "TypeSpecification.h"` in `OT_POST_INCLUDE` (because `EM_UNRECURSE` means pointer access) and emits `struct TypeSpecification;` forward declaration

### Fix

Call `expr_break_recursion()` on each member **inside** `generate_typedef_for_constructed_member()`, before generating the struct body. 

After the fix, the generated code correctly uses pointer form:

```c
/* Forward declarations */
struct TypeSpecification;                  // ← forward decl of struct tag

/* Forward definitions */
typedef struct Member {
    struct TypeSpecification   *componentType; // ← pointer form ✓
    Foo_t                      foo;
} Member;
```

The `#include "TypeSpecification.h"` remains in `OT_POST_INCLUDE` (after the struct definition), which is correct for pointer access -- the forward declaration `struct TypeSpecification;` is sufficient, and the full type definition is available via the include for code that needs it.

---