### PR TITLE
aper: fix memory leak on OPEN TYPE CHOICE decode failure

### DIFF
--- a/skeletons/OPEN_TYPE_aper.c
+++ b/skeletons/OPEN_TYPE_aper.c
@@ -17,6 +17,7 @@ OPEN_TYPE_aper_get(const asn_codec_ctx_t *opt_codec_ctx,
     void **memb_ptr2; /* Pointer to that pointer */
     void *inner_value;
     asn_dec_rval_t rv;
+    int choice_wrapper_allocated = 0;
 
     if(!(elm->flags & ATF_OPEN_TYPE)) {
         ASN__DECODE_FAILED;
@@ -37,6 +38,11 @@ OPEN_TYPE_aper_get(const asn_codec_ctx_t *opt_codec_ctx,
 
     selected = elm->type_selector(td, sptr);
     if(!selected.presence_index) {
+        ASN__DECODE_FAILED;
+    }
+    if(!selected.type_descriptor) {
+        ASN_DEBUG("Open Type %s->%s: selected type descriptor is NULL",
+                  td->name, elm->name);
         ASN__DECODE_FAILED;
     }
 
@@ -85,6 +91,7 @@ OPEN_TYPE_aper_get(const asn_codec_ctx_t *opt_codec_ctx,
             if(*memb_ptr2 == NULL) {
                 ASN__DECODE_FAILED;
             }
+            choice_wrapper_allocated = 1;
         } else {
             /* Make sure we reset the structure first before decoding */
             if(CHOICE_variant_set_presence(elm->type, *memb_ptr2, 0)
@@ -177,13 +184,38 @@ OPEN_TYPE_aper_get(const asn_codec_ctx_t *opt_codec_ctx,
     case RC_WMORE:
     case RC_FAIL:
         ASN_DEBUG("Cleaning up after failure, code=%d", rv.code);
-        if(*memb_ptr2) {
+        if(elm->type->elements_count > 0) {
+            /*
+             * CHOICE wrapper mode.  For indirect CHOICE variants,
+             * aper_open_type_get() may allocate inner_value before the
+             * decoded pointer is copied back into the actual CHOICE field.
+             * If decoding fails at that point, the parent tree cannot see
+             * inner_value, so it must be released here.
+             */
+            if(variant_elm && (variant_elm->flags & ATF_POINTER)) {
+                if(inner_value)
+                    ASN_STRUCT_FREE(*selected.type_descriptor, inner_value);
+            } else {
+                if(inner_value)
+                    ASN_STRUCT_RESET(*selected.type_descriptor, inner_value);
+            }
+
+            if(*memb_ptr2)
+                CHOICE_variant_set_presence(elm->type, *memb_ptr2, 0);
+
+            if(choice_wrapper_allocated && *memb_ptr2) {
+                ASN_STRUCT_FREE(*elm->type, *memb_ptr2);
+                *memb_ptr2 = NULL;
+            }
+        } else {
+            /* Direct type mode. */
             if(elm->flags & ATF_POINTER) {
-                ASN_STRUCT_FREE(*selected.type_descriptor, inner_value);
+                if(inner_value)
+                    ASN_STRUCT_FREE(*selected.type_descriptor, inner_value);
                 *memb_ptr2 = NULL;
             } else {
-                ASN_STRUCT_RESET(*selected.type_descriptor,
-                                              inner_value);
+                if(inner_value)
+                    ASN_STRUCT_RESET(*selected.type_descriptor, inner_value);
             }
         }
     }

--- a/skeletons/OPEN_TYPE_uper.c
+++ b/skeletons/OPEN_TYPE_uper.c
@@ -17,6 +17,7 @@ OPEN_TYPE_uper_get(const asn_codec_ctx_t *opt_codec_ctx,
     void **memb_ptr2; /* Pointer to that pointer */
     void *inner_value;
     asn_dec_rval_t rv;
+    int choice_wrapper_allocated = 0;
 
     if(!(elm->flags & ATF_OPEN_TYPE)) {
         ASN__DECODE_FAILED;
@@ -37,6 +38,11 @@ OPEN_TYPE_uper_get(const asn_codec_ctx_t *opt_codec_ctx,
 
     selected = elm->type_selector(td, sptr);
     if(!selected.presence_index) {
+        ASN__DECODE_FAILED;
+    }
+    if(!selected.type_descriptor) {
+        ASN_DEBUG("Open Type %s->%s: selected type descriptor is NULL",
+                  td->name, elm->name);
         ASN__DECODE_FAILED;
     }
 
@@ -81,6 +87,7 @@ OPEN_TYPE_uper_get(const asn_codec_ctx_t *opt_codec_ctx,
             if(*memb_ptr2 == NULL) {
                 ASN__DECODE_FAILED;
             }
+            choice_wrapper_allocated = 1;
         } else {
             /* Make sure we reset the structure first before decoding */
             if(CHOICE_variant_set_presence(elm->type, *memb_ptr2, 0)
@@ -167,13 +174,38 @@ OPEN_TYPE_uper_get(const asn_codec_ctx_t *opt_codec_ctx,
         /* Fall through */
     case RC_WMORE:
     case RC_FAIL:
-        if(*memb_ptr2) {
+        if(elm->type->elements_count > 0) {
+            /*
+             * CHOICE wrapper mode.  For indirect CHOICE variants,
+             * uper_open_type_get() may allocate inner_value before the
+             * decoded pointer is copied back into the actual CHOICE field.
+             * If decoding fails at that point, the parent tree cannot see
+             * inner_value, so it must be released here.
+             */
+            if(variant_elm && (variant_elm->flags & ATF_POINTER)) {
+                if(inner_value)
+                    ASN_STRUCT_FREE(*selected.type_descriptor, inner_value);
+            } else {
+                if(inner_value)
+                    ASN_STRUCT_RESET(*selected.type_descriptor, inner_value);
+            }
+
+            if(*memb_ptr2)
+                CHOICE_variant_set_presence(elm->type, *memb_ptr2, 0);
+
+            if(choice_wrapper_allocated && *memb_ptr2) {
+                ASN_STRUCT_FREE(*elm->type, *memb_ptr2);
+                *memb_ptr2 = NULL;
+            }
+        } else {
+            /* Direct type mode. */
             if(elm->flags & ATF_POINTER) {
-                ASN_STRUCT_FREE(*selected.type_descriptor, inner_value);
+                if(inner_value)
+                    ASN_STRUCT_FREE(*selected.type_descriptor, inner_value);
                 *memb_ptr2 = NULL;
             } else {
-                ASN_STRUCT_RESET(*selected.type_descriptor,
-                                              inner_value);
+                if(inner_value)
+                    ASN_STRUCT_RESET(*selected.type_descriptor, inner_value);
             }
         }
     }

--- a/tests/tests-c-compiler/Makefile.am
+++ b/tests/tests-c-compiler/Makefile.am
@@ -63,6 +63,7 @@ TESTS += check-src/check-92.c
 TESTS += check-src/check-158.-fcompound-names.c
 TESTS += check-src/check-159.c
 TESTS += check-src/check-164.c
+TESTS += check-src/check-173.-findirect-choice.-fcompound-names.-gen-UPER.-gen-APER.c
 TESTS += check-src/check-201.c
 TESTS += check-src/check-202.-gen-CBOR.c
 

--- a/tests/tests-c-compiler/check-src/check-173.-findirect-choice.-fcompound-names.-gen-UPER.-gen-APER.c
+++ b/tests/tests-c-compiler/check-src/check-173.-findirect-choice.-fcompound-names.-gen-UPER.-gen-APER.c
@@ -1,0 +1,170 @@
+/*
+ * Regression test for decode-failure cleanup of IOC OPEN TYPE values
+ * represented as indirect CHOICE alternatives.
+ */
+#undef NDEBUG
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <aper_decoder.h>
+#include <aper_encoder.h>
+#include <uper_decoder.h>
+#include <uper_encoder.h>
+#include <OBJECT_IDENTIFIER.h>
+#include <OCTET_STRING.h>
+
+#include "ContentWrapper.h"
+#include "PersonInfo.h"
+
+static void
+fill_wrapper(ContentWrapper_t *wrapper) {
+    asn_oid_arc_t arcs[] = {1, 2, 3, 4, 1};
+    PersonInfo_t *person;
+
+    memset(wrapper, 0, sizeof(*wrapper));
+
+    assert(OBJECT_IDENTIFIER_set_arcs(&wrapper->contentType, arcs,
+                                      sizeof(arcs) / sizeof(arcs[0])) == 0);
+
+    person = calloc(1, sizeof(*person));
+    assert(person);
+
+    assert(OCTET_STRING_fromString(&person->name,
+                                   "Alice OpenType Regression") == 0);
+    person->age = 42;
+
+    person->email = calloc(1, sizeof(*person->email));
+    assert(person->email);
+    assert(OCTET_STRING_fromString(person->email,
+                                   "alice.opentype@example.test") == 0);
+
+    wrapper->content.present = ContentWrapper__content_PR_PersonInfo;
+    wrapper->content.choice.PersonInfo = person;
+}
+
+static void
+check_decoded(const ContentWrapper_t *wrapper) {
+    assert(wrapper);
+    assert(wrapper->content.present == ContentWrapper__content_PR_PersonInfo);
+    assert(wrapper->content.choice.PersonInfo);
+    assert(wrapper->content.choice.PersonInfo->age == 42);
+}
+
+static void
+check_aper_decode(const void *buffer, size_t size) {
+    ContentWrapper_t *decoded = NULL;
+    asn_dec_rval_t rval;
+
+    rval = aper_decode(0, &asn_DEF_ContentWrapper, (void **)&decoded,
+                       buffer, size, 0, 0);
+    assert(rval.code == RC_OK);
+    check_decoded(decoded);
+    ASN_STRUCT_FREE(asn_DEF_ContentWrapper, decoded);
+}
+
+static void
+check_uper_decode(const void *buffer, size_t size) {
+    ContentWrapper_t *decoded = NULL;
+    asn_dec_rval_t rval;
+
+    rval = uper_decode(0, &asn_DEF_ContentWrapper, (void **)&decoded,
+                       buffer, size, 0, 0);
+    assert(rval.code == RC_OK);
+    check_decoded(decoded);
+    ASN_STRUCT_FREE(asn_DEF_ContentWrapper, decoded);
+}
+
+static void
+check_truncated_aper_decode_cleanup(const void *buffer, size_t size) {
+    size_t cut;
+    int saw_failure = 0;
+
+    assert(size > 1);
+
+    for(cut = 1; cut < size; cut++) {
+        ContentWrapper_t *decoded = NULL;
+        asn_dec_rval_t rval;
+
+        rval = aper_decode(0, &asn_DEF_ContentWrapper, (void **)&decoded,
+                           buffer, cut, 0, 0);
+        if(rval.code == RC_OK) {
+            ASN_STRUCT_FREE(asn_DEF_ContentWrapper, decoded);
+            continue;
+        }
+
+        saw_failure = 1;
+        ASN_STRUCT_FREE(asn_DEF_ContentWrapper, decoded);
+    }
+
+    assert(saw_failure);
+}
+
+static void
+check_truncated_uper_decode_cleanup(const void *buffer, size_t size) {
+    size_t cut;
+    int saw_failure = 0;
+
+    assert(size > 1);
+
+    for(cut = 1; cut < size; cut++) {
+        ContentWrapper_t *decoded = NULL;
+        asn_dec_rval_t rval;
+
+        rval = uper_decode(0, &asn_DEF_ContentWrapper, (void **)&decoded,
+                           buffer, cut, 0, 0);
+        if(rval.code == RC_OK) {
+            ASN_STRUCT_FREE(asn_DEF_ContentWrapper, decoded);
+            continue;
+        }
+
+        saw_failure = 1;
+        ASN_STRUCT_FREE(asn_DEF_ContentWrapper, decoded);
+    }
+
+    assert(saw_failure);
+}
+
+int
+main(int ac, char **av) {
+    ContentWrapper_t wrapper;
+    void *aper_buffer = NULL;
+    void *uper_buffer = NULL;
+    ssize_t aper_size;
+    ssize_t uper_size;
+
+    (void)ac;
+    (void)av;
+
+    fill_wrapper(&wrapper);
+
+    aper_size = aper_encode_to_new_buffer(&asn_DEF_ContentWrapper, 0,
+                                          &wrapper, &aper_buffer);
+    assert(aper_size > 0);
+    assert(aper_buffer);
+
+    uper_size = uper_encode_to_new_buffer(&asn_DEF_ContentWrapper, 0,
+                                          &wrapper, &uper_buffer);
+    assert(uper_size > 0);
+    assert(uper_buffer);
+
+    check_aper_decode(aper_buffer, (size_t)aper_size);
+    check_uper_decode(uper_buffer, (size_t)uper_size);
+
+    /*
+     * Exercise decode-failure cleanup after OPEN TYPE starts decoding the
+     * selected indirect CHOICE alternative.  LeakSanitizer/ASan will catch a
+     * regression where the temporary inner pointer becomes unreachable before
+     * it is copied back into ContentWrapper.content.choice.PersonInfo.
+     */
+    check_truncated_aper_decode_cleanup(aper_buffer, (size_t)aper_size);
+    check_truncated_uper_decode_cleanup(uper_buffer, (size_t)uper_size);
+
+    free(aper_buffer);
+    free(uper_buffer);
+    ASN_STRUCT_RESET(asn_DEF_ContentWrapper, &wrapper);
+
+    return 0;
+}


### PR DESCRIPTION
When decoding an OPEN TYPE field backed by an indirect CHOICE variant, aper_open_type_get() may allocate the inner value before it is copied back into the actual CHOICE member.

If decoding fails before that hand-off completes, the allocated value is not reachable from the parent structure and therefore cannot be released by the normal parent cleanup path. This leaves leaked ASN.1 objects on decode failure.

Track whether the CHOICE wrapper was allocated in OPEN_TYPE_aper_get() and explicitly release the temporary inner value on failure. Also reset the CHOICE presence state and free the wrapper when it was allocated by this function.

Add a defensive check for a missing selected type descriptor before attempting to decode the selected OPEN TYPE.