### PR TITLE
aper: fix CHOICE encoder recursion depth leak

### DIFF
--- a/skeletons/constr_CHOICE_aper.c
+++ b/skeletons/constr_CHOICE_aper.c
@@ -185,13 +185,18 @@ CHOICE_encode_aper(const asn_TYPE_descriptor_t *td,
     }
 
     if(ct && ct->range_bits >= 0) {
+        asn_enc_rval_t rval;
+
         if(per_put_few_bits(po, present_enc, ct->range_bits)) {
             APER_ENCODER_RECURSION_DEPTH_DEC();
             ASN__ENCODE_FAILED;
         }
 
-        return elm->type->op->aper_encoder(elm->type, elm->encoding_constraints.per_constraints,
+        rval = elm->type->op->aper_encoder(elm->type, elm->encoding_constraints.per_constraints,
                                            memb_ptr, po);
+
+        APER_ENCODER_RECURSION_DEPTH_DEC();
+        return rval;
     } else {
         asn_enc_rval_t rval = {0,0,0};
         if(specs->ext_start == -1) {


### PR DESCRIPTION
CHOICE_encode_aper() increments the APER encoder recursion depth on entry, but the constrained CHOICE path returned directly after encoding the selected member.

As a result, the recursion depth counter was not decremented on successful encoding through this path. This could leave the encoder state inconsistent and cause later APER encoding attempts to fail unexpectedly.

Store the selected member encoder result, decrement the recursion depth, and then return the saved result.