### PR TITLE
libasn1compiler: apply -fprefix to anonymous typedef names

### DIFF
--- a/libasn1compiler/asn1c_C.c
+++ b/libasn1compiler/asn1c_C.c
@@ -415,7 +415,7 @@ asn1c_lang_C_type_SEQUENCE(arg_t *arg) {
 			if (arg->embed > 2) {
 				/* For deeply nested SEQUENCE OF, just use the type name */
 				OUT("%s%s", (expr->marker.flags & EM_INDIRECT)?"*":"",
-					c_name(arg).base_name);
+					c_name(arg).compound_name);
 				return asn1c_lang_C_type_SEQUENCE_def(arg, ioc_tao.ioct ? &ioc_tao : 0);
 			}
 			REDIR(OT_FWD_DEFS);
@@ -464,12 +464,12 @@ asn1c_lang_C_type_SEQUENCE(arg_t *arg) {
 
 	if (arg->embed && expr->_anonymous_type && arg->embed <= 2) {
 		OUT("} %s%s;\n", (expr->marker.flags & EM_INDIRECT)?"*":"",
-			c_name(arg).base_name);
+			c_name(arg).compound_name);
 
 		REDIR(saved_target);
 
 		OUT("%s%s", (expr->marker.flags & EM_INDIRECT)?"*":"",
-			c_name(arg).base_name);
+			c_name(arg).compound_name);
 	} else {
 		OUT("} %s%s", (expr->marker.flags & EM_INDIRECT)?"*":"",
 			arg->embed ? c_name(arg).as_member : c_name(arg).short_name);
@@ -717,12 +717,12 @@ asn1c_lang_C_type_SET(arg_t *arg) {
 
 	if (arg->embed && expr->_anonymous_type && arg->embed == 1) {
 		OUT("} %s%s;\n", (expr->marker.flags & EM_INDIRECT)?"*":"",
-			c_name(arg).base_name);
+			c_name(arg).compound_name);
 
 		REDIR(saved_target);
 
 		OUT("%s%s", (expr->marker.flags & EM_INDIRECT)?"*":"",
-			c_name(arg).base_name);
+			c_name(arg).compound_name);
 	} else {
 		OUT("} %s%s", (expr->marker.flags & EM_INDIRECT)?"*":"",
 			arg->embed ? c_name(arg).as_member : c_name(arg).short_name);
@@ -954,7 +954,7 @@ generate_typedef_for_constructed_member(arg_t *arg, asn1p_expr_t *expr, int targ
 	}
 	
 	PCTX_DEF;
-	OUT("} %s;\n", c_name(&tmp).base_name);
+	OUT("} %s;\n", c_name(&tmp).compound_name);
 	
 	/* Restore state */
 	REDIR(saved_target);
@@ -1115,9 +1115,9 @@ asn1c_lang_C_type_SEx_OF(arg_t *arg) {
 	PCTX_DEF;
 
 	if (arg->embed && expr->_anonymous_type && arg->embed >= 1) {
-		OUT("} %s%s;\n", (expr->marker.flags & EM_INDIRECT)?"*":"", c_name(arg).base_name);
+		OUT("} %s%s;\n", (expr->marker.flags & EM_INDIRECT)?"*":"", c_name(arg).compound_name);
 		REDIR(saved_target);
-		OUT("%s%s", (expr->marker.flags & EM_INDIRECT)?"*":"", c_name(arg).base_name);
+		OUT("%s%s", (expr->marker.flags & EM_INDIRECT)?"*":"", c_name(arg).compound_name);
 	} else {
 		OUT("} %s%s", (expr->marker.flags & EM_INDIRECT)?"*":"",
 		    arg->embed ? c_name(arg).as_member : c_name(arg).short_name);
@@ -1277,14 +1277,14 @@ asn1c_lang_C_type_CHOICE(arg_t *arg) {
 
 	if (arg->embed && expr->_anonymous_type) {
 		OUT("} %s%s;\n", (expr->marker.flags & EM_INDIRECT)?"*":"",
-			c_name(arg).base_name);
+			c_name(arg).compound_name);
 
 		REDIR(saved_target);
 
 		/* Don't output the type name if we're in STAT_DEFS context (member table) */
 		if(saved_target != OT_STAT_DEFS) {
 			OUT("%s%s", (expr->marker.flags & EM_INDIRECT)?"*":"",
-				c_name(arg).base_name);
+				c_name(arg).compound_name);
 		}
 	} else {
 		OUT("} %s%s", (expr->marker.flags & EM_INDIRECT)?"*":"",

--- a/libasn1compiler/asn1c_misc.c
+++ b/libasn1compiler/asn1c_misc.c
@@ -485,8 +485,18 @@ asn1c_type_name(arg_t *arg, asn1p_expr_t *expr, enum tnfmt _format) {
 		return asn1c_make_identifier(stdname ? 0 : AMI_USE_PREFIX, exprid,
 				exprid?"t":typename, exprid?0:"t", (char*)0);
 	case TNF_RSAFE:	/* Recursion-safe type */
+		/*
+		 * Keep the recursion-safe "struct" keyword outside the generated
+		 * type name, but still apply -fprefix to the struct tag itself.
+		 *
+		 * Pass an empty token after prefix so asn1c_make_identifier() does
+		 * not insert an extra '_' between a prefix such as "S1AP_" and
+		 * the generated type name. This yields
+		 * "struct S1AP_Foo", not "struct S1AP__Foo".
+		 */
 		return asn1c_make_identifier(AMI_CHECK_RESERVED | AMI_NODELIMITER, 0,
-			"struct", " ", prefix, MODULE_NAME_OF(exprid), typename, (char*)0);
+			"struct", " ", prefix, "", MODULE_NAME_OF(exprid), typename,
+			(char*)0);
 	}
 
 	assert(!"unreachable");

--- a/tests/tests-asn1c-compiler/139-component-relation-OK.asn1.+-P
+++ b/tests/tests-asn1c-compiler/139-component-relation-OK.asn1.+-P
@@ -29,13 +29,13 @@ typedef struct value {
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;
-} value;
+} Frame__value;
 
 /*** <<< TYPE-DECLS [Frame] >>> ***/
 
 typedef struct Frame {
 	long	 ident;
-	value value;
+	Frame__value value;
 	/*
 	 * This type is extensible,
 	 * possible extensions are below.

--- a/tests/tests-asn1c-compiler/140-component-relation-OK.asn1.+-P
+++ b/tests/tests-asn1c-compiler/140-component-relation-OK.asn1.+-P
@@ -29,13 +29,13 @@ typedef struct value {
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;
-} value;
+} Frame__value;
 
 /*** <<< TYPE-DECLS [Frame] >>> ***/
 
 typedef struct Frame {
 	long	 ident;
-	value value;
+	Frame__value value;
 	/*
 	 * This type is extensible,
 	 * possible extensions are below.

--- a/tests/tests-asn1c-compiler/141-component-relation-OK.asn1.+-P
+++ b/tests/tests-asn1c-compiler/141-component-relation-OK.asn1.+-P
@@ -30,13 +30,13 @@ typedef struct value {
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;
-} value;
+} Frame__value;
 
 /*** <<< TYPE-DECLS [Frame] >>> ***/
 
 typedef struct Frame {
 	ConstrainedInteger_t	 ident;
-	value value;
+	Frame__value value;
 	/*
 	 * This type is extensible,
 	 * possible extensions are below.

--- a/tests/tests-asn1c-compiler/144-ios-parameterization-OK.asn1.+-P
+++ b/tests/tests-asn1c-compiler/144-ios-parameterization-OK.asn1.+-P
@@ -119,13 +119,13 @@ typedef struct value {
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;
-} value;
+} RegionalExtension__value;
 
 /*** <<< TYPE-DECLS [SpecializedContent] >>> ***/
 
 typedef struct RegionalExtension {
 	long	 id;
-	value value;
+	RegionalExtension__value value;
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;

--- a/tests/tests-asn1c-compiler/146-ios-parameterization-per-OK.asn1.+-P_-gen-UPER_-gen-APER
+++ b/tests/tests-asn1c-compiler/146-ios-parameterization-per-OK.asn1.+-P_-gen-UPER_-gen-APER
@@ -119,13 +119,13 @@ typedef struct value {
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;
-} value;
+} RegionalExtension__value;
 
 /*** <<< TYPE-DECLS [SpecializedContent] >>> ***/
 
 typedef struct RegionalExtension {
 	long	 id;
-	value value;
+	RegionalExtension__value value;
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;

--- a/tests/tests-asn1c-compiler/155-parameterization-more-than-two-level-OK.asn1.+-P_-gen-UPER_-gen-APER
+++ b/tests/tests-asn1c-compiler/155-parameterization-more-than-two-level-OK.asn1.+-P_-gen-UPER_-gen-APER
@@ -727,14 +727,14 @@ typedef struct value {
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;
-} value;
+} ClassItem__value;
 
 /*** <<< TYPE-DECLS [Packet] >>> ***/
 
 typedef struct ClassItem {
 	PacketId_t	 id;
 	Color_t	 color;
-	value value;
+	ClassItem__value value;
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;

--- a/tests/tests-asn1c-compiler/156-union-ios-OK.asn1.+-P_-gen-UPER_-gen-APER
+++ b/tests/tests-asn1c-compiler/156-union-ios-OK.asn1.+-P_-gen-UPER_-gen-APER
@@ -128,13 +128,13 @@ typedef struct value {
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;
-} value;
+} TotalRegionExtension__value;
 
 /*** <<< TYPE-DECLS [SpecializedContent] >>> ***/
 
 typedef struct TotalRegionExtension {
 	long	 id;
-	value value;
+	TotalRegionExtension__value value;
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;

--- a/tests/tests-asn1c-compiler/31-set-of-OK.asn1.+-P_-fwide-types
+++ b/tests/tests-asn1c-compiler/31-set-of-OK.asn1.+-P_-fwide-types
@@ -237,7 +237,7 @@ typedef struct Member {
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;
-} Member;
+} Stuff__anything__Member;
 
 /*** <<< TYPE-DECLS [Stuff] >>> ***/
 
@@ -263,7 +263,7 @@ typedef struct Stuff {
 		asn_struct_ctx_t _asn_ctx;
 	} *other;
 	struct anything {
-		A_SET_OF(Member) list;
+		A_SET_OF(Stuff__anything__Member) list;
 		
 		/* Context for parsing across buffer boundaries */
 		asn_struct_ctx_t _asn_ctx;

--- a/tests/tests-asn1c-compiler/72-same-names-OK.asn1.+-P_-fwide-types
+++ b/tests/tests-asn1c-compiler/72-same-names-OK.asn1.+-P_-fwide-types
@@ -15,12 +15,12 @@ typedef struct Member {
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;
-} Member;
+} Type__Member;
 
 /*** <<< TYPE-DECLS [Type] >>> ***/
 
 typedef struct Type {
-	A_SET_OF(Member) list;
+	A_SET_OF(Type__Member) list;
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;

--- a/tests/tests-asn1c-compiler/92-circular-loops-OK.asn1.+-P_-findirect-choice
+++ b/tests/tests-asn1c-compiler/92-circular-loops-OK.asn1.+-P_-findirect-choice
@@ -903,12 +903,12 @@ typedef struct Member {
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;
-} Member;
+} Set__Member;
 
 /*** <<< TYPE-DECLS [Set] >>> ***/
 
 typedef struct Set {
-	A_SET_OF(Member) list;
+	A_SET_OF(Set__Member) list;
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;

--- a/tests/tests-asn1c-compiler/92-circular-loops-OK.asn1.+-P_-fwide-types
+++ b/tests/tests-asn1c-compiler/92-circular-loops-OK.asn1.+-P_-fwide-types
@@ -903,12 +903,12 @@ typedef struct Member {
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;
-} Member;
+} Set__Member;
 
 /*** <<< TYPE-DECLS [Set] >>> ***/
 
 typedef struct Set {
-	A_SET_OF(Member) list;
+	A_SET_OF(Set__Member) list;
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;


### PR DESCRIPTION
Use compound_name instead of base_name when emitting anonymous embedded SEQUENCE, SET, CHOICE, and SEQUENCE OF/SET OF typedefs.

With -fprefix=S1AP_, struct tags were generated with the prefix, but some anonymous typedef aliases still used the unprefixed base name, such as InitiatingMessage__value. This could leave generated headers with mixed prefixed and unprefixed type names.

Also adjust TNF_RSAFE generation so recursion-safe struct tags receive the configured prefix without introducing an extra delimiter, producing "struct S1AP_Foo" instead of "struct S1AP__Foo".