### PR TITLE
Potential fix for code scanning alert no. 13: Wrong type of arguments to formatting function

### DIFF
--- a/libasn1print/asn1print.c
+++ b/libasn1print/asn1print.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <errno.h>
 #include <assert.h>
+#include <limits.h>
 
 #include <asn1_buffer.h>
 #include <asn1_namespace.h>
@@ -847,6 +848,7 @@ asn1print_expr(asn1p_t *asn, asn1p_module_t *mod, asn1p_expr_t *tc, enum asn1pri
 
 	if(flags & APF_PRINT_CLASS_MATRIX) do {
 		size_t col, maxidlen;
+        int maxidlen_printf;
 		if(tc->ioc_table == NULL) {
             if(tc->expr_type == A1TC_CLASSDEF) {
                 safe_printf("\n-- Information Object Class table is empty");
@@ -857,6 +859,7 @@ asn1print_expr(asn1p_t *asn, asn1p_module_t *mod, asn1p_expr_t *tc, enum asn1pri
 				tc->ioc_table->rows,
 				tc->ioc_table->rows==1 ? "y" : "ies");
 		maxidlen = asn1p_ioc_table_max_identifier_length(tc->ioc_table);
+        maxidlen_printf = (maxidlen > (size_t)INT_MAX) ? INT_MAX : (int)maxidlen;
 		for(ssize_t r = -1; r < (ssize_t)tc->ioc_table->rows; r++) {
 			asn1p_ioc_row_t *row;
 			row = tc->ioc_table->row[r<0?0:r];
@@ -867,15 +870,15 @@ asn1print_expr(asn1p_t *asn, asn1p_module_t *mod, asn1p_expr_t *tc, enum asn1pri
 				struct asn1p_ioc_cell_s *cell;
 				cell = &row->column[col];
 				if(r < 0) {
-					safe_printf("[%*s]", maxidlen,
+					safe_printf("[%*s]", maxidlen_printf,
 						cell->field->Identifier);
 					continue;
 				}
 				if(!cell->value) {
-					safe_printf(" %*s ", maxidlen, "<no entry>");
+					safe_printf(" %*s ", maxidlen_printf, "<no entry>");
 					continue;
 				}
-				safe_printf(" %*s ", maxidlen,
+				safe_printf(" %*s ", maxidlen_printf,
 					cell->value->Identifier);
 			}
 			safe_printf("\n");


### PR DESCRIPTION
Potential fix for [https://github.com/mouse07410/asn1c/security/code-scanning/13](https://github.com/mouse07410/asn1c/security/code-scanning/13)

General fix: for every `%*s` usage, ensure the corresponding width argument is of type `int`. Since source width is `size_t`, convert it safely to `int` and clamp if needed to avoid overflow.

Best fix in this snippet: in `libasn1print/asn1print.c`, inside the `APF_PRINT_CLASS_MATRIX` block (around lines 849–886), introduce a local `int maxidlen_printf` derived from `maxidlen` with clamping to `INT_MAX`, then use `maxidlen_printf` in both `%*s` calls (lines 870 and 878). This preserves behavior for normal values and removes undefined behavior for large widths. This requires adding `<limits.h>` for `INT_MAX`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
