### PR TITLE
Potential fix for code scanning alert no. 11: Wrong type of arguments to formatting function

### DIFF
--- a/libasn1print/asn1print.c
+++ b/libasn1print/asn1print.c
@@ -867,15 +867,15 @@ asn1print_expr(asn1p_t *asn, asn1p_module_t *mod, asn1p_expr_t *tc, enum asn1pri
 				struct asn1p_ioc_cell_s *cell;
 				cell = &row->column[col];
 				if(r < 0) {
-					safe_printf("[%*s]", maxidlen,
+					safe_printf("[%*s]", (int)maxidlen,
 						cell->field->Identifier);
 					continue;
 				}
 				if(!cell->value) {
-					safe_printf(" %*s ", maxidlen, "<no entry>");
+					safe_printf(" %*s ", (int)maxidlen, "<no entry>");
 					continue;
 				}
-				safe_printf(" %*s ", maxidlen,
+				safe_printf(" %*s ", (int)maxidlen,
 					cell->value->Identifier);
 			}
 			safe_printf("\n");

--- a/libasn1print/asn1print.c
+++ b/libasn1print/asn1print.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <errno.h>
 #include <assert.h>
+#include <limits.h>
 
 #include <asn1_buffer.h>
 #include <asn1_namespace.h>
@@ -857,6 +858,7 @@ asn1print_expr(asn1p_t *asn, asn1p_module_t *mod, asn1p_expr_t *tc, enum asn1pri
 				tc->ioc_table->rows,
 				tc->ioc_table->rows==1 ? "y" : "ies");
 		maxidlen = asn1p_ioc_table_max_identifier_length(tc->ioc_table);
+		int width = (maxidlen > (size_t)INT_MAX) ? INT_MAX : (int)maxidlen;
 		for(ssize_t r = -1; r < (ssize_t)tc->ioc_table->rows; r++) {
 			asn1p_ioc_row_t *row;
 			row = tc->ioc_table->row[r<0?0:r];
@@ -867,15 +869,15 @@ asn1print_expr(asn1p_t *asn, asn1p_module_t *mod, asn1p_expr_t *tc, enum asn1pri
 				struct asn1p_ioc_cell_s *cell;
 				cell = &row->column[col];
 				if(r < 0) {
-					safe_printf("[%*s]", (int)maxidlen,
+					safe_printf("[%*s]", width,
 						cell->field->Identifier);
 					continue;
 				}
 				if(!cell->value) {
-					safe_printf(" %*s ", (int)maxidlen, "<no entry>");
+					safe_printf(" %*s ", width, "<no entry>");
 					continue;
 				}
-				safe_printf(" %*s ", (int)maxidlen,
+				safe_printf(" %*s ", width,
 					cell->value->Identifier);
 			}
 			safe_printf("\n");

--- a/libasn1print/asn1print.c
+++ b/libasn1print/asn1print.c
@@ -848,6 +848,7 @@ asn1print_expr(asn1p_t *asn, asn1p_module_t *mod, asn1p_expr_t *tc, enum asn1pri
 
 	if(flags & APF_PRINT_CLASS_MATRIX) do {
 		size_t col, maxidlen;
+		int width;
 		if(tc->ioc_table == NULL) {
             if(tc->expr_type == A1TC_CLASSDEF) {
                 safe_printf("\n-- Information Object Class table is empty");
@@ -858,7 +859,7 @@ asn1print_expr(asn1p_t *asn, asn1p_module_t *mod, asn1p_expr_t *tc, enum asn1pri
 				tc->ioc_table->rows,
 				tc->ioc_table->rows==1 ? "y" : "ies");
 		maxidlen = asn1p_ioc_table_max_identifier_length(tc->ioc_table);
-		int width = (maxidlen > (size_t)INT_MAX) ? INT_MAX : (int)maxidlen;
+		width = (maxidlen > (size_t)INT_MAX) ? INT_MAX : (int)maxidlen;
 		for(ssize_t r = -1; r < (ssize_t)tc->ioc_table->rows; r++) {
 			asn1p_ioc_row_t *row;
 			row = tc->ioc_table->row[r<0?0:r];


### PR DESCRIPTION
Potential fix for [https://github.com/mouse07410/asn1c/security/code-scanning/11](https://github.com/mouse07410/asn1c/security/code-scanning/11)

To fix this safely and without changing behavior, convert the width argument passed to `%*s` from `size_t` to `int` at the call sites that use `maxidlen` with `%*s`. The best minimal fix in the shown region is to cast `maxidlen` to `int` in both affected calls (line 870 and line 878). This aligns argument type with format expectations and resolves the CodeQL finding.

In `libasn1print/asn1print.c`, within the `if(flags & APF_PRINT_CLASS_MATRIX)` block, update:
- `safe_printf("[%*s]", maxidlen, cell->field->Identifier);`
- `safe_printf(" %*s ", maxidlen, cell->value->Identifier);`

to pass `(int)maxidlen` for the width argument. No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
