### PR TITLE
Potential fix for code scanning alert no. 10: Wrong type of arguments to formatting function

### DIFF
--- a/libasn1print/asn1print.c
+++ b/libasn1print/asn1print.c
@@ -862,7 +862,7 @@ asn1print_expr(asn1p_t *asn, asn1p_module_t *mod, asn1p_expr_t *tc, enum asn1pri
 			row = tc->ioc_table->row[r<0?0:r];
 			if(r < 0) safe_printf("--    %s", r > 9 ? " " : "");
             else
-                safe_printf("-- [%*ld]", (tc->ioc_table->rows > 9) + 1, (long)(r + 1));
+                safe_printf("-- [%*zd]", (tc->ioc_table->rows > 9) + 1, r + 1);
             for(col = 0; col < row->columns; col++) {
 				struct asn1p_ioc_cell_s *cell;
 				cell = &row->column[col];

--- a/libasn1print/asn1print.c
+++ b/libasn1print/asn1print.c
@@ -862,7 +862,7 @@ asn1print_expr(asn1p_t *asn, asn1p_module_t *mod, asn1p_expr_t *tc, enum asn1pri
 			row = tc->ioc_table->row[r<0?0:r];
 			if(r < 0) safe_printf("--    %s", r > 9 ? " " : "");
             else
-                safe_printf("-- [%*d]", (tc->ioc_table->rows > 9) + 1, r + 1);
+                safe_printf("-- [%*ld]", (tc->ioc_table->rows > 9) + 1, (long)(r + 1));
             for(col = 0; col < row->columns; col++) {
 				struct asn1p_ioc_cell_s *cell;
 				cell = &row->column[col];


### PR DESCRIPTION
Potential fix for [https://github.com/mouse07410/asn1c/security/code-scanning/10](https://github.com/mouse07410/asn1c/security/code-scanning/10)

The general fix is to make the format specifier match the actual argument type passed to the formatting function.

Best fix here: keep `r` as `ssize_t` and print `r + 1` with a `long` format specifier, explicitly casting the value to `long` to match `%ld`. The width argument `(tc->ioc_table->rows > 9) + 1` is already an `int`-compatible expression and can remain unchanged.  
So, in `libasn1print/asn1print.c`, update the `safe_printf` call on/around line 865 from `%*d` to `%*ld` and cast `r + 1` to `(long)`.

No new imports, helper methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
