### PR TITLE
Potential fix for code scanning alert no. 9: Wrong type of arguments to formatting function

### DIFF
--- a/libasn1print/asn1print.c
+++ b/libasn1print/asn1print.c
@@ -853,7 +853,7 @@ asn1print_expr(asn1p_t *asn, asn1p_module_t *mod, asn1p_expr_t *tc, enum asn1pri
             }
 			break;
 		}
-		safe_printf("\n-- Information Object Set has %lu entr%s:\n",
+		safe_printf("\n-- Information Object Set has %zu entr%s:\n",
 				tc->ioc_table->rows,
 				tc->ioc_table->rows==1 ? "y" : "ies");
 		maxidlen = asn1p_ioc_table_max_identifier_length(tc->ioc_table);

--- a/libasn1print/asn1print.c
+++ b/libasn1print/asn1print.c
@@ -853,7 +853,7 @@ asn1print_expr(asn1p_t *asn, asn1p_module_t *mod, asn1p_expr_t *tc, enum asn1pri
             }
 			break;
 		}
-		safe_printf("\n-- Information Object Set has %d entr%s:\n",
+		safe_printf("\n-- Information Object Set has %lu entr%s:\n",
 				tc->ioc_table->rows,
 				tc->ioc_table->rows==1 ? "y" : "ies");
 		maxidlen = asn1p_ioc_table_max_identifier_length(tc->ioc_table);


### PR DESCRIPTION
Potential fix for [https://github.com/mouse07410/asn1c/security/code-scanning/9](https://github.com/mouse07410/asn1c/security/code-scanning/9)

Use a format specifier that matches the actual type of `tc->ioc_table->rows`. Since CodeQL reports it as `unsigned long`, replace `%d` with `%lu` for that argument.

Best minimal fix (no functionality change):
- **File:** `libasn1print/asn1print.c`
- **Region:** the `safe_printf` call printing “Information Object Set has … entries” (lines 856–858 in the snippet).
- Change:
  - `"\n-- Information Object Set has %d entr%s:\n"` → `"\n-- Information Object Set has %lu entr%s:\n"`

No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
