### PR TITLE
Potential fix for code scanning alert no. 15: Wrong type of arguments to formatting function

### DIFF
--- a/tests/tests-skeletons/check-CBOR.c
+++ b/tests/tests-skeletons/check-CBOR.c
@@ -276,7 +276,7 @@ test_bit_string_roundtrip(const uint8_t *bits, int nbytes, int bits_unused,
 
     if(decoded->size != nbytes || decoded->bits_unused != bits_unused) {
         fprintf(stderr, "FAIL: BIT_STRING mismatch %s: "
-                "size=%d (want %d), unused=%d (want %d)\n",
+                "size=%zu (want %zu), unused=%d (want %d)\n",
                 label, decoded->size, nbytes,
                 decoded->bits_unused, bits_unused);
         exit(1);

--- a/tests/tests-skeletons/check-CBOR.c
+++ b/tests/tests-skeletons/check-CBOR.c
@@ -276,7 +276,7 @@ test_bit_string_roundtrip(const uint8_t *bits, int nbytes, int bits_unused,
 
     if(decoded->size != nbytes || decoded->bits_unused != bits_unused) {
         fprintf(stderr, "FAIL: BIT_STRING mismatch %s: "
-                "size=%zu (want %zu), unused=%d (want %d)\n",
+                "size=%zu (want %d), unused=%d (want %d)\n",
                 label, decoded->size, nbytes,
                 decoded->bits_unused, bits_unused);
         exit(1);


### PR DESCRIPTION
Potential fix for [https://github.com/mouse07410/asn1c/security/code-scanning/15](https://github.com/mouse07410/asn1c/security/code-scanning/15)

The fix is to use the correct `printf`-style format specifier for size values: `%zu` for `size_t`.

Best targeted fix (no functionality change): in `tests/tests-skeletons/check-CBOR.c`, update the `fprintf` format string in the BIT_STRING mismatch branch so that `size` fields are printed with `%zu` instead of `%d`, while keeping `%d` for `bits_unused` values (which are integer fields). No new imports, helper methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
