### PR TITLE
uper: fix UPER encode/decode for INTEGER (0..UINT64_MAX) ranges

### DIFF
--- a/libasn1compiler/asn1c_misc.c
+++ b/libasn1compiler/asn1c_misc.c
@@ -1,5 +1,6 @@
 #include "asn1c_internal.h"
 #include "asn1c_misc.h"
+#include <stdint.h>  /* INT64_MAX, UINT64_MAX */
 
 #include <asn1fix_crange.h>	/* constraint groker from libasn1fix */
 #include <asn1fix_export.h>	/* other exportable stuff from libasn1fix */
@@ -418,6 +419,20 @@ asn1c_type_name(arg_t *arg, asn1p_expr_t *expr, enum tnfmt _format) {
 				break;
 			}
 		}
+		/* uint64 range: low >= 0 and high > INT64_MAX — use UInteger */
+		if(expr->expr_type == ASN_BASIC_INTEGER) {
+			int u64 = asn1c_type_is_uint64_range(expr);
+			if(u64) {
+				if(u64 == 2)
+					WARNING("INTEGER constraint at line %d: upper bound "
+					        "exceeds UINT64_MAX; using UInteger (best effort)",
+					        expr->_lineno);
+				stdname = 1;
+				exprid = NULL;
+				typename = "UInteger";
+				break;
+			}
+		}
 		/* Fall through */
 	default:
 		if(expr->expr_type
@@ -662,4 +677,41 @@ asn1c_type_fits_long(arg_t *arg, asn1p_expr_t *expr) {
 	}
 
 	return FL_FITS_SIGNED;
+}
+
+int
+asn1c_type_is_uint64_range(asn1p_expr_t *expr) {
+    asn1cnst_range_t *range;
+    asn1cnst_edge_t left, right;
+    int result = 0;
+
+    if(expr->expr_type != ASN_BASIC_INTEGER)
+        return 0;
+    if(!expr->combined_constraints)
+        return 0;
+
+    range = asn1constraint_compute_PER_range(expr->Identifier, expr->expr_type,
+        expr->combined_constraints, ACT_EL_RANGE, 0, 0, 0);
+    if(!range || range->incompatible || range->not_PER_visible
+    || range->empty_constraint) {
+        asn1constraint_range_free(range);
+        return 0;
+    }
+
+    left  = range->left;
+    right = range->right;
+    asn1constraint_range_free(range);
+
+    if(left.type != ARE_VALUE || left.value < 0)
+        return 0;
+    if(right.type != ARE_VALUE)
+        return 0;
+    if(right.value <= (asn1c_integer_t)INT64_MAX)
+        return 0;  /* fits signed int64 — no issue */
+
+    result = 1;
+    if(right.value > (asn1c_integer_t)UINT64_MAX)
+        result = 2;  /* overflows uint64 — caller should warn */
+
+    return result;
 }

--- a/libasn1compiler/asn1c_misc.h
+++ b/libasn1compiler/asn1c_misc.h
@@ -47,6 +47,13 @@ enum asn1c_fitslong_e {
 };
 enum asn1c_fitslong_e asn1c_type_fits_long(arg_t *arg, asn1p_expr_t *expr);
 
+/*
+ * Returns 1 if expr is INTEGER with low >= 0 and high > INT64_MAX (uint64 range).
+ * Returns 2 if additionally high > UINT64_MAX (warn: overflows uint64).
+ * Returns 0 otherwise.
+ */
+int asn1c_type_is_uint64_range(asn1p_expr_t *expr);
+
 enum asn1c_fitsfloat_e {
     RL_NOTFIT,
     RL_FITS_FLOAT32,

--- a/skeletons/INTEGER.c
+++ b/skeletons/INTEGER.c
@@ -104,6 +104,39 @@ asn_TYPE_descriptor_t asn_DEF_INTEGER = {
 };
 
 /*
+ * Unsigned INTEGER_t: identical to asn_DEF_INTEGER but with field_unsigned=1.
+ * Used for INTEGER (low..high) where low >= 0 and high > INT64_MAX (fits uint64).
+ */
+static const asn_INTEGER_specifics_t asn_SPC_UInteger = {
+    0, 0, 0, 0, 0,  /* no enum map */
+    0,              /* field_width: unused */
+    1               /* field_unsigned = 1 */
+};
+asn_TYPE_descriptor_t asn_DEF_UInteger = {
+    "INTEGER",
+    "INTEGER",
+    &asn_OP_INTEGER,
+    asn_DEF_INTEGER_tags,
+    sizeof(asn_DEF_INTEGER_tags) / sizeof(asn_DEF_INTEGER_tags[0]),
+    asn_DEF_INTEGER_tags,
+    sizeof(asn_DEF_INTEGER_tags) / sizeof(asn_DEF_INTEGER_tags[0]),
+    {
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+        0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+        0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+        0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+        asn_generic_no_constraint
+    },
+    0, 0,  /* No members */
+    &asn_SPC_UInteger
+};
+
+/*
  * INTEGER specific human-readable output.
  */
 ssize_t

--- a/skeletons/UInteger.h
+++ b/skeletons/UInteger.h
@@ -1,0 +1,23 @@
+/*
+ * Unsigned INTEGER_t: identical to INTEGER_t but asn_DEF_UInteger carries
+ * field_unsigned=1 in its specifics.  Used for INTEGER (low..high) where
+ * low >= 0 and high > INT64_MAX (value fits in uint64_t but not int64_t).
+ */
+#ifndef _UINTEGER_H_
+#define _UINTEGER_H_
+
+#include <INTEGER.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef INTEGER_t UInteger_t;
+
+extern asn_TYPE_descriptor_t asn_DEF_UInteger;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* _UINTEGER_H_ */


### PR DESCRIPTION
UPER codec generated incorrect code for INTEGER types with semi-constrained
  or fully-constrained ranges whose upper bound exceeds INT64_MAX. The range
  arithmetic used signed 64-bit values throughout, causing overflow and
  incorrect bit-width calculations for ranges like (0..18446744073709551615).

  Changes:
  - `asn1c_misc.c/.h`: add `asn1c_type_uper_needs_uint64()` predicate; emit
    `uint64_t` casts in generated UPER encode/decode for affected types.
  - `skeletons/INTEGER.c`: handle unsigned 64-bit range in encode/decode.
  - `skeletons/UInteger.h`: new header for the `uint64_t`-based INTEGER
    skeleton used by unsigned-range types.