### PR TITLE
NativeInteger: fix BER encoding for unsigned values > INT64_MAX

### DIFF
--- a/skeletons/NativeInteger_ber.c
+++ b/skeletons/NativeInteger_ber.c
@@ -100,26 +100,31 @@ asn_enc_rval_t
 NativeInteger_encode_der(const asn_TYPE_descriptor_t *sd, const void *ptr,
                          int tag_mode, ber_tlv_tag_t tag,
                          asn_app_consume_bytes_f *cb, void *app_key) {
+    const asn_INTEGER_specifics_t *specs =
+        (const asn_INTEGER_specifics_t *)sd->specifics;
     unsigned long native = *(const unsigned long *)ptr; /* Disable sign ext. */
     asn_enc_rval_t erval = {0,0,0};
     INTEGER_t tmp;
-
-#ifdef WORDS_BIGENDIAN  /* Opportunistic optimization */
-
-    tmp.buf = (uint8_t *)&native;
-    tmp.size = sizeof(native);
-
-#else  /* Works even if WORDS_BIGENDIAN is not set where should've been */
-    uint8_t buf[sizeof(native)];
+    uint8_t buf[sizeof(native) + 1]; /* +1 for sign/pad byte (X.690 §8.3.3) */
     uint8_t *p;
 
+    /* Sign/pad byte: 0xFF for signed negative, 0x00 otherwise.
+     * INTEGER_encode_der strips this byte when redundant, but keeps the 0x00
+     * pad when the first value byte has MSB=1 for unsigned types (X.690 §8.3.3).
+     * Without it, UINT64_MAX would canonicalise to a single byte 0xFF (= -1). */
+    buf[0] = (specs && specs->field_unsigned)
+             ? 0x00 : ((long)native < 0 ? 0xFF : 0x00);
+
+#ifdef WORDS_BIGENDIAN  /* Opportunistic optimization */
+    memcpy(buf + 1, &native, sizeof(native));
+#else  /* Works even if WORDS_BIGENDIAN is not set where should've been */
     /* Prepare a fake INTEGER */
-    for(p = buf + sizeof(buf) - 1; p >= buf; p--, native >>= 8)
+    for(p = buf + sizeof(buf) - 1; p >= buf + 1; p--, native >>= 8)
         *p = (uint8_t)native;
+#endif  /* WORDS_BIGENDIAN */
 
     tmp.buf = buf;
     tmp.size = sizeof(buf);
-#endif  /* WORDS_BIGENDIAN */
 
     /* Encode fake INTEGER */
     erval = INTEGER_encode_der(sd, &tmp, tag_mode, tag, cb, app_key);

--- a/tests/tests-skeletons/Makefile.am
+++ b/tests/tests-skeletons/Makefile.am
@@ -11,6 +11,7 @@ check_PROGRAMS =                \
     check-UTF8String            \
     check-UTCTime               \
     check-INTEGER               \
+    check-BER-NativeInteger-uint64 \
     check-REAL                  \
     check-XER                   \
     check-XER-base64            \
@@ -153,6 +154,8 @@ check_CBOR_SOURCES=check-CBOR.c
 CFLAGS = $(filter-out $(CODE_COVERAGE_CFLAGS), @CFLAGS@) \
     -I$(top_srcdir)/skeletons $(TESTSUITE_CFLAGS)
 LDADD = -lm $(top_builddir)/skeletons/libasn1cskeletons.la
+
+check_BER_NativeInteger_uint64_LDADD = $(LDADD)
 
 # Enable XER_ALLOW_EMPTY_OPTIONALS for the empty optionals test
 check_XER_empty_optionals_CFLAGS = -DXER_ALLOW_EMPTY_OPTIONALS $(CFLAGS)

--- a/tests/tests-skeletons/check-BER-NativeInteger-uint64.c
+++ b/tests/tests-skeletons/check-BER-NativeInteger-uint64.c
@@ -1,0 +1,150 @@
+/*
+ * Verify NativeInteger_encode_der produces X.690-conformant BER for
+ * unsigned long values > INT64_MAX (requires the 0x00 pad byte).
+ *
+ * Compile against the skeleton sources:
+ *   gcc -I../../skeletons -O0 check-BER-NativeInteger-uint64.c \
+ *       ../../skeletons/NativeInteger_ber.c \
+ *       ../../skeletons/INTEGER.c \
+ *       ../../skeletons/INTEGER_ber.c \
+ *       ../../skeletons/der_encoder.c \
+ *       ../../skeletons/ber_tlv_tag.c \
+ *       ../../skeletons/ber_tlv_length.c \
+ *       ../../skeletons/asn_application.c \
+ *       -o check-BER-NativeInteger-uint64
+ */
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <assert.h>
+#include <NativeInteger.h>
+#include <INTEGER.h>
+
+static int failures = 0;
+
+static const asn_INTEGER_specifics_t specs_unsigned = {
+    0, 0, 0, 0, 0,
+    sizeof(unsigned long), /* field_width */
+    1                      /* field_unsigned */
+};
+
+static const asn_INTEGER_specifics_t specs_signed = {
+    0, 0, 0, 0, 0,
+    sizeof(long),          /* field_width */
+    0                      /* field_unsigned (signed) */
+};
+
+static asn_TYPE_descriptor_t td_unsigned;
+static asn_TYPE_descriptor_t td_signed;
+
+/* Universal tag 2 (INTEGER), primitive. */
+static const ber_tlv_tag_t integer_tags[] = {
+    (ASN_TAG_CLASS_UNIVERSAL | (2 << 2))
+};
+
+/* Collect encoded bytes. */
+static uint8_t enc_buf[32];
+static size_t  enc_len;
+
+static int collect(const void *data, size_t size, void *key) {
+    (void)key;
+    memcpy(enc_buf + enc_len, data, size);
+    enc_len += size;
+    return 0;
+}
+
+static void check_encode(const char *name, const asn_TYPE_descriptor_t *td,
+                         unsigned long value,
+                         const uint8_t *expected, size_t expected_len) {
+    enc_len = 0;
+    asn_enc_rval_t r = NativeInteger_encode_der(td, &value, 0, 0, collect, 0);
+    if(r.encoded < 0 || enc_len != expected_len ||
+       memcmp(enc_buf, expected, expected_len) != 0) {
+        printf("FAIL  %s: got %zu bytes", name, enc_len);
+        for(size_t i = 0; i < enc_len; i++) printf(" %02x", enc_buf[i]);
+        printf(", expected %zu bytes", expected_len);
+        for(size_t i = 0; i < expected_len; i++) printf(" %02x", expected[i]);
+        printf("\n");
+        failures++;
+    } else {
+        printf("pass  %s\n", name);
+    }
+}
+
+static void check_roundtrip(const char *name, const asn_TYPE_descriptor_t *td,
+                             unsigned long value) {
+    enc_len = 0;
+    NativeInteger_encode_der(td, &value, 0, 0, collect, 0);
+
+    unsigned long decoded = 0;
+    void *ptr = &decoded;
+    asn_dec_rval_t dr = NativeInteger_decode_ber(0, td, &ptr, enc_buf, enc_len, 0);
+    if(dr.code != RC_OK || decoded != value) {
+        printf("FAIL  %s roundtrip: encoded value %lu decoded as %lu\n",
+               name, value, decoded);
+        failures++;
+    } else {
+        printf("pass  %s roundtrip\n", name);
+    }
+}
+
+int main(void) {
+    /* Initialise minimal type descriptors. */
+    memset(&td_unsigned, 0, sizeof(td_unsigned));
+    td_unsigned.name = "UnsignedInteger";
+    td_unsigned.xml_tag = "UnsignedInteger";
+    td_unsigned.op = &asn_OP_NativeInteger;
+    td_unsigned.specifics = &specs_unsigned;
+    td_unsigned.tags = integer_tags;
+    td_unsigned.tags_count = 1;
+    td_unsigned.all_tags = integer_tags;
+    td_unsigned.all_tags_count = 1;
+
+    memset(&td_signed, 0, sizeof(td_signed));
+    td_signed.name = "SignedInteger";
+    td_signed.xml_tag = "SignedInteger";
+    td_signed.op = &asn_OP_NativeInteger;
+    td_signed.specifics = &specs_signed;
+    td_signed.tags = integer_tags;
+    td_signed.tags_count = 1;
+    td_signed.all_tags = integer_tags;
+    td_signed.all_tags_count = 1;
+
+    printf("--- unsigned encoding ---\n");
+    /* 0: 02 01 00 */
+    check_encode("unsigned 0",        &td_unsigned, 0UL,
+                 (uint8_t[]){0x02,0x01,0x00}, 3);
+    /* 1: 02 01 01 */
+    check_encode("unsigned 1",        &td_unsigned, 1UL,
+                 (uint8_t[]){0x02,0x01,0x01}, 3);
+    /* INT64_MAX: 02 08 7f ff ff ff ff ff ff ff */
+    check_encode("unsigned INT64_MAX",&td_unsigned, (unsigned long)INT64_MAX,
+                 (uint8_t[]){0x02,0x08,0x7f,0xff,0xff,0xff,0xff,0xff,0xff,0xff}, 10);
+    /* INT64_MAX+1: 02 09 00 80 00 00 00 00 00 00 00 */
+    check_encode("unsigned INT64_MAX+1",&td_unsigned, (unsigned long)INT64_MAX + 1UL,
+                 (uint8_t[]){0x02,0x09,0x00,0x80,0x00,0x00,0x00,0x00,0x00,0x00,0x00}, 11);
+    /* UINT64_MAX: 02 09 00 ff ff ff ff ff ff ff ff */
+    check_encode("unsigned UINT64_MAX",&td_unsigned, UINT64_MAX,
+                 (uint8_t[]){0x02,0x09,0x00,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff}, 11);
+
+    printf("--- signed encoding (regression) ---\n");
+    /* -1: 02 01 ff */
+    check_encode("signed -1",         &td_signed,   (unsigned long)-1L,
+                 (uint8_t[]){0x02,0x01,0xff}, 3);
+    /* -128: 02 01 80 */
+    check_encode("signed -128",       &td_signed,   (unsigned long)-128L,
+                 (uint8_t[]){0x02,0x01,0x80}, 3);
+    /* INT64_MIN: 02 08 80 00 00 00 00 00 00 00 */
+    check_encode("signed INT64_MIN",  &td_signed,   (unsigned long)INT64_MIN,
+                 (uint8_t[]){0x02,0x08,0x80,0x00,0x00,0x00,0x00,0x00,0x00,0x00}, 10);
+
+    printf("--- round-trips ---\n");
+    check_roundtrip("unsigned 0",          &td_unsigned, 0UL);
+    check_roundtrip("unsigned 1",          &td_unsigned, 1UL);
+    check_roundtrip("unsigned INT64_MAX",  &td_unsigned, (unsigned long)INT64_MAX);
+    check_roundtrip("unsigned INT64_MAX+1",&td_unsigned, (unsigned long)INT64_MAX + 1UL);
+    check_roundtrip("unsigned UINT64_MAX", &td_unsigned, UINT64_MAX);
+
+    printf("\n%s\n", failures ? "FAILED" : "All tests passed.");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
`NativeInteger_encode_der` used an 8-byte buffer, which is too small for
  unsigned 64-bit values that require a 0x00 pad byte to signal positive sign
  (X.690 §8.3.2). For example, UINT64_MAX (0xFFFFFFFFFFFFFFFF) was being
  encoded without the leading 0x00, making it indistinguishable from -1 in
  DER; and INT64_MAX+1 was missing its required pad byte entirely.

  Fix: use a 9-byte buffer; fill buf[0] with the sign byte (0x00 for
  unsigned, 0xFF for negative) before the byte-fill loop so that
  `INTEGER_encode_der` can canonicalise correctly.

  Includes a new skeleton test (`check-BER-NativeInteger-uint64`) wired into
  `make check` that exercises UINT64_MAX, INT64_MAX+1, INT64_MAX, and 0.