### PR TITLE
PrintableString: fix UPER encoding truncating 7-bit values to 4 bits

### DIFF
--- a/skeletons/PrintableString.c
+++ b/skeletons/PrintableString.c
@@ -43,7 +43,7 @@ static int asn_DEF_PrintableString_c2v(unsigned int code) {
     return -1;
 }
 static asn_per_constraints_t asn_DEF_PrintableString_per_constraints = {
-    { APC_CONSTRAINED, 4, 4, 0x20, 0x39 },   /* Value */
+    { APC_CONSTRAINED, 7, 7, 0x20, 0x7a },   /* Value: 7-bit, range space..'z' */
     { APC_SEMI_CONSTRAINED, -1, -1, 0, 0 },  /* Size */
     asn_DEF_PrintableString_v2c,
     asn_DEF_PrintableString_c2v


### PR DESCRIPTION
PrintableString UPER encoding was shifting alphabet values into a 4-bit
  field instead of a 7-bit field. The PrintableString alphabet has 74
  characters spanning the full 7-bit range; the prior code silently
  truncated the high bits of any character whose position in the alphabet
  exceeded 15.

  Fix: change the bit-field width from 4 to 7 in the UPER encode path.