### PR TITLE
Demote benign parameterized type diagnostic to debug

### DIFF
--- a/libasn1fix/asn1fix_retrieve.c
+++ b/libasn1fix/asn1fix_retrieve.c
@@ -334,7 +334,7 @@ asn1f_lookup_symbol_impl(arg_t *arg, asn1p_expr_t *rhs_pspecs, const asn1p_ref_t
             if(ref_tc) {
                 /* It is acceptable that we don't use input parameters */
                 if(rhs_pspecs && !ref_tc->lhs_params) {
-                    WARNING(
+                    DEBUG(
                         "Parameterized type %s expected "
                         "for %s at line %d",
                         ref_tc->Identifier, asn1f_printable_reference(ref),


### PR DESCRIPTION
## Summary

This changes a benign parameterization diagnostic in `asn1f_lookup_symbol_impl` from `WARNING` to `DEBUG`.

When a reference carries parameter specs but the resolved target type has no formal parameters, asn1c already continues successfully. The inverse case, where parameters are required but missing, remains a `FATAL` error path.

This pattern appears in public 3GPP ASN.1 modules such as E1AP, E2AP, F1AP, NGAP, RRC, and XnAP, where Information Object Class types can be referenced through parameterized containers. The current warning can produce thousands of duplicate messages in large schema builds and drown out real diagnostics.

## Fix

- Demote the diagnostic from `WARNING(` to `DEBUG(`.
- Preserve the message for developer builds with debug logging enabled.
- Leave parameterization behavior and generated output unchanged.