### PR TITLE
Bug/incorrect type selected

### DIFF
--- a/asn1c/asn1c.c
+++ b/asn1c/asn1c.c
@@ -161,6 +161,8 @@ main(int ac, char **av) {
                 char *known_type = optarg + 18;
                 ret = asn1f_make_known_external_type(known_type);
                 assert(ret == 0 || errno == EEXIST);
+            } else if(strcmp(optarg, "prefer-import-source") == 0) {
+                asn1_fixer_flags |= A1F_PREFER_IMPORT_SOURCE;
             } else if(strcmp(optarg, "native-types") == 0) {
                 fprintf(stderr, "-f%s: Deprecated option\n", optarg);
                 asn1_compiler_flags &= ~A1C_USE_WIDE_TYPES;

--- a/libasn1fix/asn1fix.c
+++ b/libasn1fix/asn1fix.c
@@ -74,6 +74,16 @@ asn1f_process(asn1p_t *asn, enum asn1f_flags flags,
 		}
 	}
 
+	if(flags & A1F_PREFER_IMPORT_SOURCE) {
+		arg.flags |= A1F_PREFER_IMPORT_SOURCE;
+		flags &= ~A1F_PREFER_IMPORT_SOURCE;
+		if(arg.debug) {
+			arg.debug(-1,
+				"IMPORTS resolution: require explicit xp_members match");
+		}
+	}
+
+
 	a1f_replace_me_with_proper_interface_arg = arg;
 
 	/*

--- a/libasn1fix/asn1fix.c
+++ b/libasn1fix/asn1fix.c
@@ -120,7 +120,13 @@ asn1f_process(asn1p_t *asn, enum asn1f_flags flags,
         arg.ns = 0;
     }
 
+    error_logger_f _saved_eh    = a1f_replace_me_with_proper_interface_arg.eh;
+    error_logger_f _saved_debug = a1f_replace_me_with_proper_interface_arg.debug;
+    enum asn1f_flags _saved_flags = a1f_replace_me_with_proper_interface_arg.flags;
     memset(&a1f_replace_me_with_proper_interface_arg, 0, sizeof(arg_t));
+    a1f_replace_me_with_proper_interface_arg.eh    = _saved_eh;
+    a1f_replace_me_with_proper_interface_arg.debug = _saved_debug;
+    a1f_replace_me_with_proper_interface_arg.flags = _saved_flags;
 
 	/*
 	 * Compute a return value.

--- a/libasn1fix/asn1fix.h
+++ b/libasn1fix/asn1fix.h
@@ -14,7 +14,9 @@ enum asn1f_flags {
 	A1F_NOFLAGS,
 	A1F_DEBUG			= 0x01,	/* Print debugging output */
 	A1F_EXTENDED_SizeConstraint	= 0x02,	/* Enable constraint gen code */
-	A1F_COMPOUND_NAMES		= 0x04  /* A1C_COMPOUND_NAMES  */
+	A1F_COMPOUND_NAMES		= 0x04,	/* A1C_COMPOUND_NAMES  */
+	A1F_PREFER_IMPORT_SOURCE	= 0x08	/* IMPORTS resolution: require explicit name in xp_members,
+						   skip whole-module fallback */
 };
 
 /*

--- a/libasn1fix/asn1fix_export.c
+++ b/libasn1fix/asn1fix_export.c
@@ -1,7 +1,6 @@
 #include "asn1fix_internal.h"
 #include "asn1fix_export.h"
 
-extern arg_t a1f_replace_me_with_proper_interface_arg;
 
 static asn1p_t *asn1f_ssn_asn_;
 
@@ -58,6 +57,7 @@ asn1f_lookup_symbol_ex(asn1p_t *asn, asn1_namespace_t *ns, asn1p_expr_t *expr,
     arg.expr = expr;
     arg.eh = a1f_replace_me_with_proper_interface_arg.eh;
     arg.debug = a1f_replace_me_with_proper_interface_arg.debug;
+    arg.flags = a1f_replace_me_with_proper_interface_arg.flags;
 
     return asn1f_lookup_symbol(&arg, expr->rhs_pspecs, ref);
 }
@@ -79,6 +79,7 @@ asn1f_class_access_ex(asn1p_t *asn,
 	arg.expr = expr;
 	arg.eh = a1f_replace_me_with_proper_interface_arg.eh;
 	arg.debug = a1f_replace_me_with_proper_interface_arg.debug;
+	arg.flags = a1f_replace_me_with_proper_interface_arg.flags;
 
     return asn1f_class_access(&arg, rhs_pspecs, ref);
 }
@@ -96,6 +97,7 @@ asn1f_find_terminal_type_ex(asn1p_t *asn, asn1_namespace_t *ns,
     arg.expr = expr;
     arg.eh = a1f_replace_me_with_proper_interface_arg.eh;
     arg.debug = a1f_replace_me_with_proper_interface_arg.debug;
+    arg.flags = a1f_replace_me_with_proper_interface_arg.flags;
 
     return asn1f_find_terminal_type(&arg, expr);
 }
@@ -111,6 +113,7 @@ asn1f_find_ancestor_type_with_PER_constraint_ex(asn1p_t *asn, asn1p_expr_t *expr
 	arg.expr = expr;
 	arg.eh = a1f_replace_me_with_proper_interface_arg.eh;
 	arg.debug = a1f_replace_me_with_proper_interface_arg.debug;
+	arg.flags = a1f_replace_me_with_proper_interface_arg.flags;
 
 	return asn1f_find_ancestor_type_with_PER_constraint(&arg, expr);
 }
@@ -127,6 +130,7 @@ asn1f_fix_dereference_values_ex(asn1p_t *asn, asn1p_module_t *mod,
 	arg.expr = expr;
 	arg.eh = a1f_replace_me_with_proper_interface_arg.eh;
 	arg.debug = a1f_replace_me_with_proper_interface_arg.debug;
+	arg.flags = a1f_replace_me_with_proper_interface_arg.flags;
 
 	return asn1f_fix_dereference_values(&arg);
 }

--- a/libasn1fix/asn1fix_export.h
+++ b/libasn1fix/asn1fix_export.h
@@ -6,7 +6,6 @@
 #define	ASN1FIX_EXPORT_H
 
 #include "asn1fix_tags.h"
-
 struct asn1_namespace_s;   /* Forward declaration. */
 
 void asn1f_use_standard_namespaces(asn1p_t *asn);

--- a/libasn1fix/asn1fix_internal.h
+++ b/libasn1fix/asn1fix_internal.h
@@ -57,6 +57,8 @@ typedef struct arg_s {
     enum asn1f_flags flags;
 } arg_t;
 
+extern arg_t a1f_replace_me_with_proper_interface_arg;
+
 /*
  * Functions performing normalization of various types.
  */

--- a/libasn1fix/asn1fix_retrieve.c
+++ b/libasn1fix/asn1fix_retrieve.c
@@ -60,6 +60,16 @@ asn1f_lookup_in_imports(arg_t *arg, asn1p_module_t *mod, const char *name) {
             if(strcmp(name, tc->Identifier) == 0)
 				break;
 
+			/*
+			 * In strict mode, an unqualified name MUST be listed
+			 * explicitly in the IMPORTS group's xp_members to be
+			 * considered as imported from this group.  This avoids
+			 * picking up a same-named type that happens to live in a
+			 * from-module that imports unrelated names.
+			 */
+			if(arg->flags & A1F_PREFER_IMPORT_SOURCE)
+				continue;
+
 			if(!fromModule)
 				continue;
 

--- a/libasn1fix/asn1fix_retrieve.c
+++ b/libasn1fix/asn1fix_retrieve.c
@@ -48,7 +48,7 @@ asn1p_module_t *
 asn1f_lookup_in_imports(arg_t *arg, asn1p_module_t *mod, const char *name) {
 	asn1p_xports_t *xp;
 
-	/*
+/*
 	 * Search in which exactly module this name is defined.
 	 */
 	TQ_FOR(xp, &(mod->imports), xp_next) {

--- a/libasn1fix/asn1fix_tags.c
+++ b/libasn1fix/asn1fix_tags.c
@@ -1,6 +1,7 @@
 #include "asn1fix_internal.h"
 #include <asn1_namespace.h>
 
+
 #define	ADD_TAG(skip, newtag)	do {					\
 	void *__p;							\
 	if(skip && !(flags & AFT_FULL_COLLECT)) {			\
@@ -166,6 +167,7 @@ asn1f_fetch_tags(asn1p_t *asn, asn1_namespace_t *ns, asn1p_module_t *mod, asn1p_
 	arg.ns = ns;
 	arg.mod = mod;
 	arg.expr = expr;
+	arg.flags = a1f_replace_me_with_proper_interface_arg.flags;
 
 	count = asn1f_fetch_tags_impl(&arg, &tags, 0, 0, flags);
 	if (count <= 0) {

--- a/tests/tests-asn1c-compiler/209-prefer-import-source-SE.asn1
+++ b/tests/tests-asn1c-compiler/209-prefer-import-source-SE.asn1
@@ -1,0 +1,79 @@
+-- ============================================================
+--  Demonstrates the whole-module-fallback bug that
+--  -fprefer-import-source fixes.
+--
+--  SecA imports DuplicateA FROM TerA and DuplicateB FROM TerB.
+--  Without -fprefer-import-source, resolving DuplicateB scans
+--  the TerA xp group first; DuplicateB is not listed there, so
+--  the fallback searches TerA's module body and finds
+--  TerA::DuplicateB (BOOLEAN) instead of TerB::DuplicateB
+--  (OCTET STRING).  SecB has the mirror cross-wiring.
+-- ============================================================
+
+Prim { 1 3 6 1 4 1 99999 1 1 1 }
+DEFINITIONS AUTOMATIC TAGS ::= BEGIN
+
+IMPORTS
+    SeqA
+        FROM SecA { 1 3 6 1 4 1 99999 2 1 1 }
+    SeqB
+        FROM SecB { 1 3 6 1 4 1 99999 2 2 1 };
+
+ChoiceField ::= CHOICE {
+    seqA    SeqA,
+    seqB    SeqB
+}
+
+END
+
+
+SecA { 1 3 6 1 4 1 99999 2 1 1 }
+DEFINITIONS AUTOMATIC TAGS ::= BEGIN
+
+IMPORTS
+    DuplicateA
+        FROM TerA { 1 3 6 1 4 1 99999 3 1 1 }
+    DuplicateB
+        FROM TerB { 1 3 6 1 4 1 99999 3 2 1 };
+
+SeqA ::= SEQUENCE {
+    fieldA  DuplicateA,
+    fieldB  DuplicateB
+}
+
+END
+
+
+SecB { 1 3 6 1 4 1 99999 2 2 1 }
+DEFINITIONS AUTOMATIC TAGS ::= BEGIN
+
+IMPORTS
+    DuplicateA
+        FROM TerB { 1 3 6 1 4 1 99999 3 2 1 }
+    DuplicateB
+        FROM TerA { 1 3 6 1 4 1 99999 3 1 1 };
+
+SeqB ::= SEQUENCE {
+    fieldA  DuplicateA,
+    fieldB  DuplicateB
+}
+
+END
+
+
+TerA { 1 3 6 1 4 1 99999 3 1 1 }
+DEFINITIONS AUTOMATIC TAGS ::= BEGIN
+
+    DuplicateA ::= INTEGER
+    DuplicateB ::= BOOLEAN
+
+END
+
+
+TerB { 1 3 6 1 4 1 99999 3 2 1 }
+DEFINITIONS AUTOMATIC TAGS ::= BEGIN
+
+    DuplicateA ::= ENUMERATED { alpha(0), beta(1), gamma(2) }
+    DuplicateB ::= OCTET STRING
+
+END

--- a/tests/tests-asn1c-compiler/209-prefer-import-source-SE.asn1.+-fcompound-names_-P
+++ b/tests/tests-asn1c-compiler/209-prefer-import-source-SE.asn1.+-fcompound-names_-P
@@ -1,0 +1,918 @@
+
+/*** <<< INCLUDES [ChoiceField] >>> ***/
+
+#include <constr_CHOICE.h>
+
+/*** <<< DEPS [ChoiceField] >>> ***/
+
+typedef enum ChoiceField_PR {
+	ChoiceField_PR_NOTHING,	/* No components present */
+	ChoiceField_PR_seqA,
+	ChoiceField_PR_seqB
+} ChoiceField_PR;
+
+/*** <<< FWD-DECLS [ChoiceField] >>> ***/
+
+struct SeqA;
+struct SeqB;
+
+/*** <<< TYPE-DECLS [ChoiceField] >>> ***/
+
+typedef struct ChoiceField {
+	ChoiceField_PR present;
+	union ChoiceField_u {
+		struct SeqA	*seqA;
+		struct SeqB	*seqB;
+	} choice;
+	
+	/* Context for parsing across buffer boundaries */
+	asn_struct_ctx_t _asn_ctx;
+} ChoiceField_t;
+
+/*** <<< FUNC-DECLS [ChoiceField] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_ChoiceField;
+
+/*** <<< POST-INCLUDE [ChoiceField] >>> ***/
+
+#include "SeqA.h"
+#include "SeqB.h"
+
+/*** <<< STAT-DEFS [ChoiceField] >>> ***/
+
+static asn_TYPE_member_t asn_MBR_ChoiceField_1[] = {
+	{ ATF_POINTER, 0, offsetof(struct ChoiceField, choice.seqA),
+		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
+		.tag_mode = -1,	/* IMPLICIT tag at current level */
+		.type = &asn_DEF_SeqA,
+		.type_selector = 0,
+		{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+			.oer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+			.per_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+			.jer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+			.general_constraints = 0
+		},
+		0, 0, /* No default value */
+		.name = "seqA"
+		},
+	{ ATF_POINTER, 0, offsetof(struct ChoiceField, choice.seqB),
+		.tag = (ASN_TAG_CLASS_CONTEXT | (1 << 2)),
+		.tag_mode = -1,	/* IMPLICIT tag at current level */
+		.type = &asn_DEF_SeqB,
+		.type_selector = 0,
+		{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+			.oer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+			.per_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+			.jer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+			.general_constraints = 0
+		},
+		0, 0, /* No default value */
+		.name = "seqB"
+		},
+};
+static const asn_TYPE_tag2member_t asn_MAP_ChoiceField_tag2el_1[] = {
+    { (ASN_TAG_CLASS_CONTEXT | (0 << 2)), 0, 0, 0 }, /* seqA */
+    { (ASN_TAG_CLASS_CONTEXT | (1 << 2)), 1, 0, 0 } /* seqB */
+};
+static asn_CHOICE_specifics_t asn_SPC_ChoiceField_specs_1 = {
+	sizeof(struct ChoiceField),
+	offsetof(struct ChoiceField, _asn_ctx),
+	offsetof(struct ChoiceField, present),
+	sizeof(((struct ChoiceField *)0)->present),
+	.tag2el = asn_MAP_ChoiceField_tag2el_1,
+	.tag2el_count = 2,	/* Count of tags in the map */
+	0, 0,
+	.first_extension = -1	/* Extensions start */
+};
+asn_TYPE_descriptor_t asn_DEF_ChoiceField = {
+	"ChoiceField",
+	"ChoiceField",
+	&asn_OP_CHOICE,
+	0,	/* No effective tags (pointer) */
+	0,	/* No effective tags (count) */
+	0,	/* No tags (pointer) */
+	0,	/* No tags (count) */
+	{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+		CHOICE_constraint
+	},
+	asn_MBR_ChoiceField_1,
+	2,	/* Elements count */
+	&asn_SPC_ChoiceField_specs_1	/* Additional specs */
+};
+
+
+/*** <<< INCLUDES [SeqA] >>> ***/
+
+#include "TerA_DuplicateA.h"
+#include "TerA_DuplicateB.h"
+#include <constr_SEQUENCE.h>
+
+/*** <<< TYPE-DECLS [SeqA] >>> ***/
+
+typedef struct SeqA {
+	TerA_DuplicateA_t	 fieldA;
+	TerA_DuplicateB_t	 fieldB;
+	
+	/* Context for parsing across buffer boundaries */
+	asn_struct_ctx_t _asn_ctx;
+} SeqA_t;
+
+/*** <<< FUNC-DECLS [SeqA] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_SeqA;
+extern asn_SEQUENCE_specifics_t asn_SPC_SeqA_specs_1;
+extern asn_TYPE_member_t asn_MBR_SeqA_1[2];
+
+/*** <<< STAT-DEFS [SeqA] >>> ***/
+
+asn_TYPE_member_t asn_MBR_SeqA_1[] = {
+	{ ATF_NOFLAGS, 0, offsetof(struct SeqA, fieldA),
+		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
+		.tag_mode = -1,	/* IMPLICIT tag at current level */
+		.type = &asn_DEF_TerA_DuplicateA,
+		.type_selector = 0,
+		{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+			.oer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+			.per_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+			.jer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+			.general_constraints = 0
+		},
+		0, 0, /* No default value */
+		.name = "fieldA"
+		},
+	{ ATF_NOFLAGS, 0, offsetof(struct SeqA, fieldB),
+		.tag = (ASN_TAG_CLASS_CONTEXT | (1 << 2)),
+		.tag_mode = -1,	/* IMPLICIT tag at current level */
+		.type = &asn_DEF_TerA_DuplicateB,
+		.type_selector = 0,
+		{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+			.oer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+			.per_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+			.jer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+			.general_constraints = 0
+		},
+		0, 0, /* No default value */
+		.name = "fieldB"
+		},
+};
+static const ber_tlv_tag_t asn_DEF_SeqA_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (16 << 2))
+};
+static const asn_TYPE_tag2member_t asn_MAP_SeqA_tag2el_1[] = {
+    { (ASN_TAG_CLASS_CONTEXT | (0 << 2)), 0, 0, 0 }, /* fieldA */
+    { (ASN_TAG_CLASS_CONTEXT | (1 << 2)), 1, 0, 0 } /* fieldB */
+};
+asn_SEQUENCE_specifics_t asn_SPC_SeqA_specs_1 = {
+	sizeof(struct SeqA),
+	offsetof(struct SeqA, _asn_ctx),
+	.tag2el = asn_MAP_SeqA_tag2el_1,
+	.tag2el_count = 2,	/* Count of tags in the map */
+	0, 0, 0,	/* Optional elements (not needed) */
+	-1,	/* First extension addition */
+};
+asn_TYPE_descriptor_t asn_DEF_SeqA = {
+	"SeqA",
+	"SeqA",
+	&asn_OP_SEQUENCE,
+	asn_DEF_SeqA_tags_1,
+	sizeof(asn_DEF_SeqA_tags_1)
+		/sizeof(asn_DEF_SeqA_tags_1[0]), /* 1 */
+	asn_DEF_SeqA_tags_1,	/* Same as above */
+	sizeof(asn_DEF_SeqA_tags_1)
+		/sizeof(asn_DEF_SeqA_tags_1[0]), /* 1 */
+	{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+		SEQUENCE_constraint
+	},
+	asn_MBR_SeqA_1,
+	2,	/* Elements count */
+	&asn_SPC_SeqA_specs_1	/* Additional specs */
+};
+
+
+/*** <<< INCLUDES [SeqB] >>> ***/
+
+#include "TerB_DuplicateA.h"
+#include "TerB_DuplicateB.h"
+#include <constr_SEQUENCE.h>
+
+/*** <<< TYPE-DECLS [SeqB] >>> ***/
+
+typedef struct SeqB {
+	TerB_DuplicateA_t	 fieldA;
+	TerB_DuplicateB_t	 fieldB;
+	
+	/* Context for parsing across buffer boundaries */
+	asn_struct_ctx_t _asn_ctx;
+} SeqB_t;
+
+/*** <<< FUNC-DECLS [SeqB] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_SeqB;
+extern asn_SEQUENCE_specifics_t asn_SPC_SeqB_specs_1;
+extern asn_TYPE_member_t asn_MBR_SeqB_1[2];
+
+/*** <<< STAT-DEFS [SeqB] >>> ***/
+
+asn_TYPE_member_t asn_MBR_SeqB_1[] = {
+	{ ATF_NOFLAGS, 0, offsetof(struct SeqB, fieldA),
+		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
+		.tag_mode = -1,	/* IMPLICIT tag at current level */
+		.type = &asn_DEF_TerB_DuplicateA,
+		.type_selector = 0,
+		{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+			.oer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+			.per_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+			.jer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+			.general_constraints = 0
+		},
+		0, 0, /* No default value */
+		.name = "fieldA"
+		},
+	{ ATF_NOFLAGS, 0, offsetof(struct SeqB, fieldB),
+		.tag = (ASN_TAG_CLASS_CONTEXT | (1 << 2)),
+		.tag_mode = -1,	/* IMPLICIT tag at current level */
+		.type = &asn_DEF_TerB_DuplicateB,
+		.type_selector = 0,
+		{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+			.oer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+			.per_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+			.jer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+			.general_constraints = 0
+		},
+		0, 0, /* No default value */
+		.name = "fieldB"
+		},
+};
+static const ber_tlv_tag_t asn_DEF_SeqB_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (16 << 2))
+};
+static const asn_TYPE_tag2member_t asn_MAP_SeqB_tag2el_1[] = {
+    { (ASN_TAG_CLASS_CONTEXT | (0 << 2)), 0, 0, 0 }, /* fieldA */
+    { (ASN_TAG_CLASS_CONTEXT | (1 << 2)), 1, 0, 0 } /* fieldB */
+};
+asn_SEQUENCE_specifics_t asn_SPC_SeqB_specs_1 = {
+	sizeof(struct SeqB),
+	offsetof(struct SeqB, _asn_ctx),
+	.tag2el = asn_MAP_SeqB_tag2el_1,
+	.tag2el_count = 2,	/* Count of tags in the map */
+	0, 0, 0,	/* Optional elements (not needed) */
+	-1,	/* First extension addition */
+};
+asn_TYPE_descriptor_t asn_DEF_SeqB = {
+	"SeqB",
+	"SeqB",
+	&asn_OP_SEQUENCE,
+	asn_DEF_SeqB_tags_1,
+	sizeof(asn_DEF_SeqB_tags_1)
+		/sizeof(asn_DEF_SeqB_tags_1[0]), /* 1 */
+	asn_DEF_SeqB_tags_1,	/* Same as above */
+	sizeof(asn_DEF_SeqB_tags_1)
+		/sizeof(asn_DEF_SeqB_tags_1[0]), /* 1 */
+	{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+		SEQUENCE_constraint
+	},
+	asn_MBR_SeqB_1,
+	2,	/* Elements count */
+	&asn_SPC_SeqB_specs_1	/* Additional specs */
+};
+
+
+/*** <<< INCLUDES [DuplicateA] >>> ***/
+
+#include <NativeInteger.h>
+
+/*** <<< TYPE-DECLS [DuplicateA] >>> ***/
+
+typedef long	 TerA_DuplicateA_t;
+
+/*** <<< FUNC-DECLS [DuplicateA] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_TerA_DuplicateA;
+asn_struct_free_f TerA_DuplicateA_free;
+asn_struct_print_f TerA_DuplicateA_print;
+asn_constr_check_f TerA_DuplicateA_constraint;
+ber_type_decoder_f TerA_DuplicateA_decode_ber;
+der_type_encoder_f TerA_DuplicateA_encode_der;
+xer_type_decoder_f TerA_DuplicateA_decode_xer;
+xer_type_encoder_f TerA_DuplicateA_encode_xer;
+cbor_type_decoder_f TerA_DuplicateA_decode_cbor;
+cbor_type_encoder_f TerA_DuplicateA_encode_cbor;
+
+/*** <<< CODE [DuplicateA] >>> ***/
+
+/*
+ * This type is implemented using NativeInteger,
+ * so here we adjust the DEF accordingly.
+ */
+
+/*** <<< STAT-DEFS [DuplicateA] >>> ***/
+
+static const ber_tlv_tag_t asn_DEF_TerA_DuplicateA_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (2 << 2))
+};
+asn_TYPE_descriptor_t asn_DEF_TerA_DuplicateA = {
+	"DuplicateA",
+	"DuplicateA",
+	&asn_OP_NativeInteger,
+	asn_DEF_TerA_DuplicateA_tags_1,
+	sizeof(asn_DEF_TerA_DuplicateA_tags_1)
+		/sizeof(asn_DEF_TerA_DuplicateA_tags_1[0]), /* 1 */
+	asn_DEF_TerA_DuplicateA_tags_1,	/* Same as above */
+	sizeof(asn_DEF_TerA_DuplicateA_tags_1)
+		/sizeof(asn_DEF_TerA_DuplicateA_tags_1[0]), /* 1 */
+	{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+		NativeInteger_constraint
+	},
+	0, 0,	/* No members */
+	0	/* No specifics */
+};
+
+
+/*** <<< INCLUDES [DuplicateB] >>> ***/
+
+#include <BOOLEAN.h>
+
+/*** <<< TYPE-DECLS [DuplicateB] >>> ***/
+
+typedef BOOLEAN_t	 TerA_DuplicateB_t;
+
+/*** <<< FUNC-DECLS [DuplicateB] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_TerA_DuplicateB;
+asn_struct_free_f TerA_DuplicateB_free;
+asn_struct_print_f TerA_DuplicateB_print;
+asn_constr_check_f TerA_DuplicateB_constraint;
+ber_type_decoder_f TerA_DuplicateB_decode_ber;
+der_type_encoder_f TerA_DuplicateB_encode_der;
+xer_type_decoder_f TerA_DuplicateB_decode_xer;
+xer_type_encoder_f TerA_DuplicateB_encode_xer;
+cbor_type_decoder_f TerA_DuplicateB_decode_cbor;
+cbor_type_encoder_f TerA_DuplicateB_encode_cbor;
+
+/*** <<< CODE [DuplicateB] >>> ***/
+
+/*
+ * This type is implemented using BOOLEAN,
+ * so here we adjust the DEF accordingly.
+ */
+
+/*** <<< STAT-DEFS [DuplicateB] >>> ***/
+
+static const ber_tlv_tag_t asn_DEF_TerA_DuplicateB_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (1 << 2))
+};
+asn_TYPE_descriptor_t asn_DEF_TerA_DuplicateB = {
+	"DuplicateB",
+	"DuplicateB",
+	&asn_OP_BOOLEAN,
+	asn_DEF_TerA_DuplicateB_tags_1,
+	sizeof(asn_DEF_TerA_DuplicateB_tags_1)
+		/sizeof(asn_DEF_TerA_DuplicateB_tags_1[0]), /* 1 */
+	asn_DEF_TerA_DuplicateB_tags_1,	/* Same as above */
+	sizeof(asn_DEF_TerA_DuplicateB_tags_1)
+		/sizeof(asn_DEF_TerA_DuplicateB_tags_1[0]), /* 1 */
+	{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+		BOOLEAN_constraint
+	},
+	0, 0,	/* No members */
+	0	/* No specifics */
+};
+
+
+/*** <<< INCLUDES [DuplicateA] >>> ***/
+
+#include <NativeEnumerated.h>
+
+/*** <<< DEPS [DuplicateA] >>> ***/
+
+typedef enum TerB_DuplicateA {
+	TerB_DuplicateA_alpha	= 0,
+	TerB_DuplicateA_beta	= 1,
+	TerB_DuplicateA_gamma	= 2
+} e_TerB_DuplicateA;
+
+/*** <<< TYPE-DECLS [DuplicateA] >>> ***/
+
+typedef long	 TerB_DuplicateA_t;
+
+/*** <<< FUNC-DECLS [DuplicateA] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_TerB_DuplicateA;
+extern const asn_INTEGER_specifics_t asn_SPC_TerB_DuplicateA_specs_1;
+asn_struct_free_f TerB_DuplicateA_free;
+asn_struct_print_f TerB_DuplicateA_print;
+asn_constr_check_f TerB_DuplicateA_constraint;
+ber_type_decoder_f TerB_DuplicateA_decode_ber;
+der_type_encoder_f TerB_DuplicateA_encode_der;
+xer_type_decoder_f TerB_DuplicateA_decode_xer;
+xer_type_encoder_f TerB_DuplicateA_encode_xer;
+cbor_type_decoder_f TerB_DuplicateA_decode_cbor;
+cbor_type_encoder_f TerB_DuplicateA_encode_cbor;
+
+/*** <<< CODE [DuplicateA] >>> ***/
+
+/*
+ * This type is implemented using NativeEnumerated,
+ * so here we adjust the DEF accordingly.
+ */
+
+/*** <<< STAT-DEFS [DuplicateA] >>> ***/
+
+static const asn_INTEGER_enum_map_t asn_MAP_TerB_DuplicateA_value2enum_1[] = {
+	{ 0,	5,	"alpha" },
+	{ 1,	4,	"beta" },
+	{ 2,	5,	"gamma" }
+};
+static int asn_validate_TerB_DuplicateA_1(const asn_TYPE_descriptor_t *td,
+                       const void *sptr,
+                       asn_app_constraint_failed_f *ctfailcb,
+                       void* app_key) {
+    if(! sptr) { return -1; }
+    e_TerB_DuplicateA value = *(e_TerB_DuplicateA*)sptr;
+    switch(value) {
+    case TerB_DuplicateA_alpha:
+    case TerB_DuplicateA_beta:
+    case TerB_DuplicateA_gamma:
+        return 0;
+    }
+    return -1;
+}
+static const unsigned int asn_MAP_TerB_DuplicateA_enum2value_1[] = {
+	0,	/* alpha(0) */
+	1,	/* beta(1) */
+	2	/* gamma(2) */
+};
+const asn_INTEGER_specifics_t asn_SPC_TerB_DuplicateA_specs_1 = {
+	asn_MAP_TerB_DuplicateA_value2enum_1,	/* "tag" => N; sorted by tag */
+	asn_MAP_TerB_DuplicateA_enum2value_1,	/* N => "tag"; sorted by N */
+	3,	/* Number of elements in the maps */
+	0,	/* Enumeration is not extensible */
+	1,	/* Strict enumeration */
+	0,	/* Native long size */
+	0
+};
+static const ber_tlv_tag_t asn_DEF_TerB_DuplicateA_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (10 << 2))
+};
+asn_TYPE_descriptor_t asn_DEF_TerB_DuplicateA = {
+	"DuplicateA",
+	"DuplicateA",
+	&asn_OP_NativeEnumerated,
+	asn_DEF_TerB_DuplicateA_tags_1,
+	sizeof(asn_DEF_TerB_DuplicateA_tags_1)
+		/sizeof(asn_DEF_TerB_DuplicateA_tags_1[0]), /* 1 */
+	asn_DEF_TerB_DuplicateA_tags_1,	/* Same as above */
+	sizeof(asn_DEF_TerB_DuplicateA_tags_1)
+		/sizeof(asn_DEF_TerB_DuplicateA_tags_1[0]), /* 1 */
+	{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+		asn_validate_TerB_DuplicateA_1
+	},
+	0, 0,	/* Defined elsewhere */
+	&asn_SPC_TerB_DuplicateA_specs_1	/* Additional specs */
+};
+
+
+/*** <<< INCLUDES [DuplicateB] >>> ***/
+
+#include <OCTET_STRING.h>
+
+/*** <<< TYPE-DECLS [DuplicateB] >>> ***/
+
+typedef OCTET_STRING_t	 TerB_DuplicateB_t;
+
+/*** <<< FUNC-DECLS [DuplicateB] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_TerB_DuplicateB;
+asn_struct_free_f TerB_DuplicateB_free;
+asn_struct_print_f TerB_DuplicateB_print;
+asn_constr_check_f TerB_DuplicateB_constraint;
+ber_type_decoder_f TerB_DuplicateB_decode_ber;
+der_type_encoder_f TerB_DuplicateB_encode_der;
+xer_type_decoder_f TerB_DuplicateB_decode_xer;
+xer_type_encoder_f TerB_DuplicateB_encode_xer;
+cbor_type_decoder_f TerB_DuplicateB_decode_cbor;
+cbor_type_encoder_f TerB_DuplicateB_encode_cbor;
+
+/*** <<< CODE [DuplicateB] >>> ***/
+
+/*
+ * This type is implemented using OCTET_STRING,
+ * so here we adjust the DEF accordingly.
+ */
+
+/*** <<< STAT-DEFS [DuplicateB] >>> ***/
+
+static const ber_tlv_tag_t asn_DEF_TerB_DuplicateB_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (4 << 2))
+};
+asn_TYPE_descriptor_t asn_DEF_TerB_DuplicateB = {
+	"DuplicateB",
+	"DuplicateB",
+	&asn_OP_OCTET_STRING,
+	asn_DEF_TerB_DuplicateB_tags_1,
+	sizeof(asn_DEF_TerB_DuplicateB_tags_1)
+		/sizeof(asn_DEF_TerB_DuplicateB_tags_1[0]), /* 1 */
+	asn_DEF_TerB_DuplicateB_tags_1,	/* Same as above */
+	sizeof(asn_DEF_TerB_DuplicateB_tags_1)
+		/sizeof(asn_DEF_TerB_DuplicateB_tags_1[0]), /* 1 */
+	{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+		OCTET_STRING_constraint
+	},
+	0, 0,	/* No members */
+	&asn_SPC_OCTET_STRING_specs	/* Additional specs */
+};
+
+
+/*** <<< INCLUDES [EXTERNAL] >>> ***/
+
+#include <OBJECT_IDENTIFIER.h>
+#include <NativeInteger.h>
+#include <ObjectDescriptor.h>
+#include <ANY.h>
+#include <OCTET_STRING.h>
+#include <BIT_STRING.h>
+#include <constr_CHOICE.h>
+#include <constr_SEQUENCE.h>
+
+/*** <<< DEPS [EXTERNAL] >>> ***/
+
+typedef enum EXTERNAL__encoding_PR {
+	EXTERNAL__encoding_PR_NOTHING,	/* No components present */
+	EXTERNAL__encoding_PR_single_ASN1_type,
+	EXTERNAL__encoding_PR_octet_aligned,
+	EXTERNAL__encoding_PR_arbitrary
+} EXTERNAL__encoding_PR;
+
+/*** <<< TYPE-DECLS [EXTERNAL] >>> ***/
+
+typedef struct EXTERNAL {
+	OBJECT_IDENTIFIER_t	*direct_reference;	/* OPTIONAL */
+	long	*indirect_reference;	/* OPTIONAL */
+	ObjectDescriptor_t	*data_value_descriptor;	/* OPTIONAL */
+	struct EXTERNAL__encoding {
+		EXTERNAL__encoding_PR present;
+		union EXTERNAL__encoding_u {
+			ANY_t	 single_ASN1_type;
+			OCTET_STRING_t	 octet_aligned;
+			BIT_STRING_t	 arbitrary;
+		} choice;
+		
+		/* Context for parsing across buffer boundaries */
+		asn_struct_ctx_t _asn_ctx;
+	} encoding;
+	
+	/* Context for parsing across buffer boundaries */
+	asn_struct_ctx_t _asn_ctx;
+} EXTERNAL_t;
+
+/*** <<< FUNC-DECLS [EXTERNAL] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_EXTERNAL;
+
+/*** <<< CODE [EXTERNAL] >>> ***/
+
+#ifndef ASN1C_NO_UNSUFFIXED_PDU_ALIAS
+#if defined(__ELF__) && (defined(__GNUC__) || defined(__clang__))
+extern asn_TYPE_descriptor_t asn_DEF_encoding __attribute__((weak, alias("asn_DEF_encoding_5")));
+#else
+static asn_TYPE_descriptor_t asn_DEF_encoding_5;
+static asn_TYPE_descriptor_t asn_DEF_encoding;
+__attribute__((constructor)) static void asn_DEF_encoding_5_alias_init(void) {
+	asn_DEF_encoding = asn_DEF_encoding_5;
+}
+#endif
+#endif /* ASN1C_NO_UNSUFFIXED_PDU_ALIAS */
+
+/*** <<< STAT-DEFS [EXTERNAL] >>> ***/
+
+static asn_TYPE_member_t asn_MBR_EXTERNAL__encoding_5[] = {
+	{ ATF_NOFLAGS, 0, offsetof(struct EXTERNAL__encoding, choice.single_ASN1_type),
+		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
+		.tag_mode = +1,	/* EXPLICIT tag at current level */
+		.type = &asn_DEF_ANY,
+		.type_selector = 0,
+		{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+			.oer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+			.per_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+			.jer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+			.general_constraints = 0
+		},
+		0, 0, /* No default value */
+		.name = "single-ASN1-type"
+		},
+	{ ATF_NOFLAGS, 0, offsetof(struct EXTERNAL__encoding, choice.octet_aligned),
+		.tag = (ASN_TAG_CLASS_CONTEXT | (1 << 2)),
+		.tag_mode = -1,	/* IMPLICIT tag at current level */
+		.type = &asn_DEF_OCTET_STRING,
+		.type_selector = 0,
+		{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+			.oer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+			.per_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+			.jer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+			.general_constraints = 0
+		},
+		0, 0, /* No default value */
+		.name = "octet-aligned"
+		},
+	{ ATF_NOFLAGS, 0, offsetof(struct EXTERNAL__encoding, choice.arbitrary),
+		.tag = (ASN_TAG_CLASS_CONTEXT | (2 << 2)),
+		.tag_mode = -1,	/* IMPLICIT tag at current level */
+		.type = &asn_DEF_BIT_STRING,
+		.type_selector = 0,
+		{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+			.oer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+			.per_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+			.jer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+			.general_constraints = 0
+		},
+		0, 0, /* No default value */
+		.name = "arbitrary"
+		},
+};
+static const asn_TYPE_tag2member_t asn_MAP_encoding_tag2el_5[] = {
+    { (ASN_TAG_CLASS_CONTEXT | (0 << 2)), 0, 0, 0 }, /* single-ASN1-type */
+    { (ASN_TAG_CLASS_CONTEXT | (1 << 2)), 1, 0, 0 }, /* octet-aligned */
+    { (ASN_TAG_CLASS_CONTEXT | (2 << 2)), 2, 0, 0 } /* arbitrary */
+};
+static asn_CHOICE_specifics_t asn_SPC_encoding_specs_5 = {
+	sizeof(struct EXTERNAL__encoding),
+	offsetof(struct EXTERNAL__encoding, _asn_ctx),
+	offsetof(struct EXTERNAL__encoding, present),
+	sizeof(((struct EXTERNAL__encoding *)0)->present),
+	.tag2el = asn_MAP_encoding_tag2el_5,
+	.tag2el_count = 3,	/* Count of tags in the map */
+	0, 0,
+	.first_extension = -1	/* Extensions start */
+};
+static /* Use -fall-defs-global to expose */
+asn_TYPE_descriptor_t asn_DEF_encoding_5 = {
+	"encoding",
+	"encoding",
+	&asn_OP_CHOICE,
+	0,	/* No effective tags (pointer) */
+	0,	/* No effective tags (count) */
+	0,	/* No tags (pointer) */
+	0,	/* No tags (count) */
+	{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+		CHOICE_constraint
+	},
+	asn_MBR_EXTERNAL__encoding_5,
+	3,	/* Elements count */
+	&asn_SPC_encoding_specs_5	/* Additional specs */
+};
+
+static asn_TYPE_member_t asn_MBR_EXTERNAL_1[] = {
+	{ ATF_POINTER, 3, offsetof(struct EXTERNAL, direct_reference),
+		.tag = (ASN_TAG_CLASS_UNIVERSAL | (6 << 2)),
+		.tag_mode = 0,
+		.type = &asn_DEF_OBJECT_IDENTIFIER,
+		.type_selector = 0,
+		{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+			.oer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+			.per_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+			.jer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+			.general_constraints = 0
+		},
+		0, 0, /* No default value */
+		.name = "direct-reference"
+		},
+	{ ATF_POINTER, 2, offsetof(struct EXTERNAL, indirect_reference),
+		.tag = (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)),
+		.tag_mode = 0,
+		.type = &asn_DEF_NativeInteger,
+		.type_selector = 0,
+		{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+			.oer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+			.per_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+			.jer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+			.general_constraints = 0
+		},
+		0, 0, /* No default value */
+		.name = "indirect-reference"
+		},
+	{ ATF_POINTER, 1, offsetof(struct EXTERNAL, data_value_descriptor),
+		.tag = (ASN_TAG_CLASS_UNIVERSAL | (7 << 2)),
+		.tag_mode = 0,
+		.type = &asn_DEF_ObjectDescriptor,
+		.type_selector = 0,
+		{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+			.oer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+			.per_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+			.jer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+			.general_constraints = 0
+		},
+		0, 0, /* No default value */
+		.name = "data-value-descriptor"
+		},
+	{ ATF_NOFLAGS, 0, offsetof(struct EXTERNAL, encoding),
+		.tag = -1 /* Ambiguous tag (CHOICE?) */,
+		.tag_mode = 0,
+		.type = &asn_DEF_encoding_5,
+		.type_selector = 0,
+		{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+			.oer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+			.per_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+			.jer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+			.general_constraints = 0
+		},
+		0, 0, /* No default value */
+		.name = "encoding"
+		},
+};
+static const ber_tlv_tag_t asn_DEF_EXTERNAL_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (8 << 2)),
+	(ASN_TAG_CLASS_UNIVERSAL | (16 << 2))
+};
+static const asn_TYPE_tag2member_t asn_MAP_EXTERNAL_tag2el_1[] = {
+    { (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)), 1, 0, 0 }, /* indirect-reference */
+    { (ASN_TAG_CLASS_UNIVERSAL | (6 << 2)), 0, 0, 0 }, /* direct-reference */
+    { (ASN_TAG_CLASS_UNIVERSAL | (7 << 2)), 2, 0, 0 }, /* data-value-descriptor */
+    { (ASN_TAG_CLASS_CONTEXT | (0 << 2)), 3, 0, 0 }, /* single-ASN1-type */
+    { (ASN_TAG_CLASS_CONTEXT | (1 << 2)), 3, 0, 0 }, /* octet-aligned */
+    { (ASN_TAG_CLASS_CONTEXT | (2 << 2)), 3, 0, 0 } /* arbitrary */
+};
+static asn_SEQUENCE_specifics_t asn_SPC_EXTERNAL_specs_1 = {
+	sizeof(struct EXTERNAL),
+	offsetof(struct EXTERNAL, _asn_ctx),
+	.tag2el = asn_MAP_EXTERNAL_tag2el_1,
+	.tag2el_count = 6,	/* Count of tags in the map */
+	0, 0, 0,	/* Optional elements (not needed) */
+	-1,	/* First extension addition */
+};
+asn_TYPE_descriptor_t asn_DEF_EXTERNAL = {
+	"EXTERNAL",
+	"EXTERNAL",
+	&asn_OP_SEQUENCE,
+	asn_DEF_EXTERNAL_tags_1,
+	sizeof(asn_DEF_EXTERNAL_tags_1)
+		/sizeof(asn_DEF_EXTERNAL_tags_1[0]) - 1, /* 1 */
+	asn_DEF_EXTERNAL_tags_1,	/* Same as above */
+	sizeof(asn_DEF_EXTERNAL_tags_1)
+		/sizeof(asn_DEF_EXTERNAL_tags_1[0]), /* 2 */
+	{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+		SEQUENCE_constraint
+	},
+	asn_MBR_EXTERNAL_1,
+	4,	/* Elements count */
+	&asn_SPC_EXTERNAL_specs_1	/* Additional specs */
+};
+

--- a/tests/tests-asn1c-compiler/209-prefer-import-source-SE.asn1.+-fcompound-names_-fprefer-import-source_-P
+++ b/tests/tests-asn1c-compiler/209-prefer-import-source-SE.asn1.+-fcompound-names_-fprefer-import-source_-P
@@ -1,0 +1,918 @@
+
+/*** <<< INCLUDES [ChoiceField] >>> ***/
+
+#include <constr_CHOICE.h>
+
+/*** <<< DEPS [ChoiceField] >>> ***/
+
+typedef enum ChoiceField_PR {
+	ChoiceField_PR_NOTHING,	/* No components present */
+	ChoiceField_PR_seqA,
+	ChoiceField_PR_seqB
+} ChoiceField_PR;
+
+/*** <<< FWD-DECLS [ChoiceField] >>> ***/
+
+struct SeqA;
+struct SeqB;
+
+/*** <<< TYPE-DECLS [ChoiceField] >>> ***/
+
+typedef struct ChoiceField {
+	ChoiceField_PR present;
+	union ChoiceField_u {
+		struct SeqA	*seqA;
+		struct SeqB	*seqB;
+	} choice;
+	
+	/* Context for parsing across buffer boundaries */
+	asn_struct_ctx_t _asn_ctx;
+} ChoiceField_t;
+
+/*** <<< FUNC-DECLS [ChoiceField] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_ChoiceField;
+
+/*** <<< POST-INCLUDE [ChoiceField] >>> ***/
+
+#include "SeqA.h"
+#include "SeqB.h"
+
+/*** <<< STAT-DEFS [ChoiceField] >>> ***/
+
+static asn_TYPE_member_t asn_MBR_ChoiceField_1[] = {
+	{ ATF_POINTER, 0, offsetof(struct ChoiceField, choice.seqA),
+		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
+		.tag_mode = -1,	/* IMPLICIT tag at current level */
+		.type = &asn_DEF_SeqA,
+		.type_selector = 0,
+		{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+			.oer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+			.per_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+			.jer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+			.general_constraints = 0
+		},
+		0, 0, /* No default value */
+		.name = "seqA"
+		},
+	{ ATF_POINTER, 0, offsetof(struct ChoiceField, choice.seqB),
+		.tag = (ASN_TAG_CLASS_CONTEXT | (1 << 2)),
+		.tag_mode = -1,	/* IMPLICIT tag at current level */
+		.type = &asn_DEF_SeqB,
+		.type_selector = 0,
+		{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+			.oer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+			.per_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+			.jer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+			.general_constraints = 0
+		},
+		0, 0, /* No default value */
+		.name = "seqB"
+		},
+};
+static const asn_TYPE_tag2member_t asn_MAP_ChoiceField_tag2el_1[] = {
+    { (ASN_TAG_CLASS_CONTEXT | (0 << 2)), 0, 0, 0 }, /* seqA */
+    { (ASN_TAG_CLASS_CONTEXT | (1 << 2)), 1, 0, 0 } /* seqB */
+};
+static asn_CHOICE_specifics_t asn_SPC_ChoiceField_specs_1 = {
+	sizeof(struct ChoiceField),
+	offsetof(struct ChoiceField, _asn_ctx),
+	offsetof(struct ChoiceField, present),
+	sizeof(((struct ChoiceField *)0)->present),
+	.tag2el = asn_MAP_ChoiceField_tag2el_1,
+	.tag2el_count = 2,	/* Count of tags in the map */
+	0, 0,
+	.first_extension = -1	/* Extensions start */
+};
+asn_TYPE_descriptor_t asn_DEF_ChoiceField = {
+	"ChoiceField",
+	"ChoiceField",
+	&asn_OP_CHOICE,
+	0,	/* No effective tags (pointer) */
+	0,	/* No effective tags (count) */
+	0,	/* No tags (pointer) */
+	0,	/* No tags (count) */
+	{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+		CHOICE_constraint
+	},
+	asn_MBR_ChoiceField_1,
+	2,	/* Elements count */
+	&asn_SPC_ChoiceField_specs_1	/* Additional specs */
+};
+
+
+/*** <<< INCLUDES [SeqA] >>> ***/
+
+#include "TerA_DuplicateA.h"
+#include "TerB_DuplicateB.h"
+#include <constr_SEQUENCE.h>
+
+/*** <<< TYPE-DECLS [SeqA] >>> ***/
+
+typedef struct SeqA {
+	TerA_DuplicateA_t	 fieldA;
+	TerB_DuplicateB_t	 fieldB;
+	
+	/* Context for parsing across buffer boundaries */
+	asn_struct_ctx_t _asn_ctx;
+} SeqA_t;
+
+/*** <<< FUNC-DECLS [SeqA] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_SeqA;
+extern asn_SEQUENCE_specifics_t asn_SPC_SeqA_specs_1;
+extern asn_TYPE_member_t asn_MBR_SeqA_1[2];
+
+/*** <<< STAT-DEFS [SeqA] >>> ***/
+
+asn_TYPE_member_t asn_MBR_SeqA_1[] = {
+	{ ATF_NOFLAGS, 0, offsetof(struct SeqA, fieldA),
+		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
+		.tag_mode = -1,	/* IMPLICIT tag at current level */
+		.type = &asn_DEF_TerA_DuplicateA,
+		.type_selector = 0,
+		{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+			.oer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+			.per_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+			.jer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+			.general_constraints = 0
+		},
+		0, 0, /* No default value */
+		.name = "fieldA"
+		},
+	{ ATF_NOFLAGS, 0, offsetof(struct SeqA, fieldB),
+		.tag = (ASN_TAG_CLASS_CONTEXT | (1 << 2)),
+		.tag_mode = -1,	/* IMPLICIT tag at current level */
+		.type = &asn_DEF_TerB_DuplicateB,
+		.type_selector = 0,
+		{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+			.oer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+			.per_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+			.jer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+			.general_constraints = 0
+		},
+		0, 0, /* No default value */
+		.name = "fieldB"
+		},
+};
+static const ber_tlv_tag_t asn_DEF_SeqA_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (16 << 2))
+};
+static const asn_TYPE_tag2member_t asn_MAP_SeqA_tag2el_1[] = {
+    { (ASN_TAG_CLASS_CONTEXT | (0 << 2)), 0, 0, 0 }, /* fieldA */
+    { (ASN_TAG_CLASS_CONTEXT | (1 << 2)), 1, 0, 0 } /* fieldB */
+};
+asn_SEQUENCE_specifics_t asn_SPC_SeqA_specs_1 = {
+	sizeof(struct SeqA),
+	offsetof(struct SeqA, _asn_ctx),
+	.tag2el = asn_MAP_SeqA_tag2el_1,
+	.tag2el_count = 2,	/* Count of tags in the map */
+	0, 0, 0,	/* Optional elements (not needed) */
+	-1,	/* First extension addition */
+};
+asn_TYPE_descriptor_t asn_DEF_SeqA = {
+	"SeqA",
+	"SeqA",
+	&asn_OP_SEQUENCE,
+	asn_DEF_SeqA_tags_1,
+	sizeof(asn_DEF_SeqA_tags_1)
+		/sizeof(asn_DEF_SeqA_tags_1[0]), /* 1 */
+	asn_DEF_SeqA_tags_1,	/* Same as above */
+	sizeof(asn_DEF_SeqA_tags_1)
+		/sizeof(asn_DEF_SeqA_tags_1[0]), /* 1 */
+	{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+		SEQUENCE_constraint
+	},
+	asn_MBR_SeqA_1,
+	2,	/* Elements count */
+	&asn_SPC_SeqA_specs_1	/* Additional specs */
+};
+
+
+/*** <<< INCLUDES [SeqB] >>> ***/
+
+#include "TerB_DuplicateA.h"
+#include "TerA_DuplicateB.h"
+#include <constr_SEQUENCE.h>
+
+/*** <<< TYPE-DECLS [SeqB] >>> ***/
+
+typedef struct SeqB {
+	TerB_DuplicateA_t	 fieldA;
+	TerA_DuplicateB_t	 fieldB;
+	
+	/* Context for parsing across buffer boundaries */
+	asn_struct_ctx_t _asn_ctx;
+} SeqB_t;
+
+/*** <<< FUNC-DECLS [SeqB] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_SeqB;
+extern asn_SEQUENCE_specifics_t asn_SPC_SeqB_specs_1;
+extern asn_TYPE_member_t asn_MBR_SeqB_1[2];
+
+/*** <<< STAT-DEFS [SeqB] >>> ***/
+
+asn_TYPE_member_t asn_MBR_SeqB_1[] = {
+	{ ATF_NOFLAGS, 0, offsetof(struct SeqB, fieldA),
+		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
+		.tag_mode = -1,	/* IMPLICIT tag at current level */
+		.type = &asn_DEF_TerB_DuplicateA,
+		.type_selector = 0,
+		{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+			.oer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+			.per_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+			.jer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+			.general_constraints = 0
+		},
+		0, 0, /* No default value */
+		.name = "fieldA"
+		},
+	{ ATF_NOFLAGS, 0, offsetof(struct SeqB, fieldB),
+		.tag = (ASN_TAG_CLASS_CONTEXT | (1 << 2)),
+		.tag_mode = -1,	/* IMPLICIT tag at current level */
+		.type = &asn_DEF_TerA_DuplicateB,
+		.type_selector = 0,
+		{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+			.oer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+			.per_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+			.jer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+			.general_constraints = 0
+		},
+		0, 0, /* No default value */
+		.name = "fieldB"
+		},
+};
+static const ber_tlv_tag_t asn_DEF_SeqB_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (16 << 2))
+};
+static const asn_TYPE_tag2member_t asn_MAP_SeqB_tag2el_1[] = {
+    { (ASN_TAG_CLASS_CONTEXT | (0 << 2)), 0, 0, 0 }, /* fieldA */
+    { (ASN_TAG_CLASS_CONTEXT | (1 << 2)), 1, 0, 0 } /* fieldB */
+};
+asn_SEQUENCE_specifics_t asn_SPC_SeqB_specs_1 = {
+	sizeof(struct SeqB),
+	offsetof(struct SeqB, _asn_ctx),
+	.tag2el = asn_MAP_SeqB_tag2el_1,
+	.tag2el_count = 2,	/* Count of tags in the map */
+	0, 0, 0,	/* Optional elements (not needed) */
+	-1,	/* First extension addition */
+};
+asn_TYPE_descriptor_t asn_DEF_SeqB = {
+	"SeqB",
+	"SeqB",
+	&asn_OP_SEQUENCE,
+	asn_DEF_SeqB_tags_1,
+	sizeof(asn_DEF_SeqB_tags_1)
+		/sizeof(asn_DEF_SeqB_tags_1[0]), /* 1 */
+	asn_DEF_SeqB_tags_1,	/* Same as above */
+	sizeof(asn_DEF_SeqB_tags_1)
+		/sizeof(asn_DEF_SeqB_tags_1[0]), /* 1 */
+	{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+		SEQUENCE_constraint
+	},
+	asn_MBR_SeqB_1,
+	2,	/* Elements count */
+	&asn_SPC_SeqB_specs_1	/* Additional specs */
+};
+
+
+/*** <<< INCLUDES [DuplicateA] >>> ***/
+
+#include <NativeInteger.h>
+
+/*** <<< TYPE-DECLS [DuplicateA] >>> ***/
+
+typedef long	 TerA_DuplicateA_t;
+
+/*** <<< FUNC-DECLS [DuplicateA] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_TerA_DuplicateA;
+asn_struct_free_f TerA_DuplicateA_free;
+asn_struct_print_f TerA_DuplicateA_print;
+asn_constr_check_f TerA_DuplicateA_constraint;
+ber_type_decoder_f TerA_DuplicateA_decode_ber;
+der_type_encoder_f TerA_DuplicateA_encode_der;
+xer_type_decoder_f TerA_DuplicateA_decode_xer;
+xer_type_encoder_f TerA_DuplicateA_encode_xer;
+cbor_type_decoder_f TerA_DuplicateA_decode_cbor;
+cbor_type_encoder_f TerA_DuplicateA_encode_cbor;
+
+/*** <<< CODE [DuplicateA] >>> ***/
+
+/*
+ * This type is implemented using NativeInteger,
+ * so here we adjust the DEF accordingly.
+ */
+
+/*** <<< STAT-DEFS [DuplicateA] >>> ***/
+
+static const ber_tlv_tag_t asn_DEF_TerA_DuplicateA_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (2 << 2))
+};
+asn_TYPE_descriptor_t asn_DEF_TerA_DuplicateA = {
+	"DuplicateA",
+	"DuplicateA",
+	&asn_OP_NativeInteger,
+	asn_DEF_TerA_DuplicateA_tags_1,
+	sizeof(asn_DEF_TerA_DuplicateA_tags_1)
+		/sizeof(asn_DEF_TerA_DuplicateA_tags_1[0]), /* 1 */
+	asn_DEF_TerA_DuplicateA_tags_1,	/* Same as above */
+	sizeof(asn_DEF_TerA_DuplicateA_tags_1)
+		/sizeof(asn_DEF_TerA_DuplicateA_tags_1[0]), /* 1 */
+	{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+		NativeInteger_constraint
+	},
+	0, 0,	/* No members */
+	0	/* No specifics */
+};
+
+
+/*** <<< INCLUDES [DuplicateB] >>> ***/
+
+#include <BOOLEAN.h>
+
+/*** <<< TYPE-DECLS [DuplicateB] >>> ***/
+
+typedef BOOLEAN_t	 TerA_DuplicateB_t;
+
+/*** <<< FUNC-DECLS [DuplicateB] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_TerA_DuplicateB;
+asn_struct_free_f TerA_DuplicateB_free;
+asn_struct_print_f TerA_DuplicateB_print;
+asn_constr_check_f TerA_DuplicateB_constraint;
+ber_type_decoder_f TerA_DuplicateB_decode_ber;
+der_type_encoder_f TerA_DuplicateB_encode_der;
+xer_type_decoder_f TerA_DuplicateB_decode_xer;
+xer_type_encoder_f TerA_DuplicateB_encode_xer;
+cbor_type_decoder_f TerA_DuplicateB_decode_cbor;
+cbor_type_encoder_f TerA_DuplicateB_encode_cbor;
+
+/*** <<< CODE [DuplicateB] >>> ***/
+
+/*
+ * This type is implemented using BOOLEAN,
+ * so here we adjust the DEF accordingly.
+ */
+
+/*** <<< STAT-DEFS [DuplicateB] >>> ***/
+
+static const ber_tlv_tag_t asn_DEF_TerA_DuplicateB_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (1 << 2))
+};
+asn_TYPE_descriptor_t asn_DEF_TerA_DuplicateB = {
+	"DuplicateB",
+	"DuplicateB",
+	&asn_OP_BOOLEAN,
+	asn_DEF_TerA_DuplicateB_tags_1,
+	sizeof(asn_DEF_TerA_DuplicateB_tags_1)
+		/sizeof(asn_DEF_TerA_DuplicateB_tags_1[0]), /* 1 */
+	asn_DEF_TerA_DuplicateB_tags_1,	/* Same as above */
+	sizeof(asn_DEF_TerA_DuplicateB_tags_1)
+		/sizeof(asn_DEF_TerA_DuplicateB_tags_1[0]), /* 1 */
+	{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+		BOOLEAN_constraint
+	},
+	0, 0,	/* No members */
+	0	/* No specifics */
+};
+
+
+/*** <<< INCLUDES [DuplicateA] >>> ***/
+
+#include <NativeEnumerated.h>
+
+/*** <<< DEPS [DuplicateA] >>> ***/
+
+typedef enum TerB_DuplicateA {
+	TerB_DuplicateA_alpha	= 0,
+	TerB_DuplicateA_beta	= 1,
+	TerB_DuplicateA_gamma	= 2
+} e_TerB_DuplicateA;
+
+/*** <<< TYPE-DECLS [DuplicateA] >>> ***/
+
+typedef long	 TerB_DuplicateA_t;
+
+/*** <<< FUNC-DECLS [DuplicateA] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_TerB_DuplicateA;
+extern const asn_INTEGER_specifics_t asn_SPC_TerB_DuplicateA_specs_1;
+asn_struct_free_f TerB_DuplicateA_free;
+asn_struct_print_f TerB_DuplicateA_print;
+asn_constr_check_f TerB_DuplicateA_constraint;
+ber_type_decoder_f TerB_DuplicateA_decode_ber;
+der_type_encoder_f TerB_DuplicateA_encode_der;
+xer_type_decoder_f TerB_DuplicateA_decode_xer;
+xer_type_encoder_f TerB_DuplicateA_encode_xer;
+cbor_type_decoder_f TerB_DuplicateA_decode_cbor;
+cbor_type_encoder_f TerB_DuplicateA_encode_cbor;
+
+/*** <<< CODE [DuplicateA] >>> ***/
+
+/*
+ * This type is implemented using NativeEnumerated,
+ * so here we adjust the DEF accordingly.
+ */
+
+/*** <<< STAT-DEFS [DuplicateA] >>> ***/
+
+static const asn_INTEGER_enum_map_t asn_MAP_TerB_DuplicateA_value2enum_1[] = {
+	{ 0,	5,	"alpha" },
+	{ 1,	4,	"beta" },
+	{ 2,	5,	"gamma" }
+};
+static int asn_validate_TerB_DuplicateA_1(const asn_TYPE_descriptor_t *td,
+                       const void *sptr,
+                       asn_app_constraint_failed_f *ctfailcb,
+                       void* app_key) {
+    if(! sptr) { return -1; }
+    e_TerB_DuplicateA value = *(e_TerB_DuplicateA*)sptr;
+    switch(value) {
+    case TerB_DuplicateA_alpha:
+    case TerB_DuplicateA_beta:
+    case TerB_DuplicateA_gamma:
+        return 0;
+    }
+    return -1;
+}
+static const unsigned int asn_MAP_TerB_DuplicateA_enum2value_1[] = {
+	0,	/* alpha(0) */
+	1,	/* beta(1) */
+	2	/* gamma(2) */
+};
+const asn_INTEGER_specifics_t asn_SPC_TerB_DuplicateA_specs_1 = {
+	asn_MAP_TerB_DuplicateA_value2enum_1,	/* "tag" => N; sorted by tag */
+	asn_MAP_TerB_DuplicateA_enum2value_1,	/* N => "tag"; sorted by N */
+	3,	/* Number of elements in the maps */
+	0,	/* Enumeration is not extensible */
+	1,	/* Strict enumeration */
+	0,	/* Native long size */
+	0
+};
+static const ber_tlv_tag_t asn_DEF_TerB_DuplicateA_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (10 << 2))
+};
+asn_TYPE_descriptor_t asn_DEF_TerB_DuplicateA = {
+	"DuplicateA",
+	"DuplicateA",
+	&asn_OP_NativeEnumerated,
+	asn_DEF_TerB_DuplicateA_tags_1,
+	sizeof(asn_DEF_TerB_DuplicateA_tags_1)
+		/sizeof(asn_DEF_TerB_DuplicateA_tags_1[0]), /* 1 */
+	asn_DEF_TerB_DuplicateA_tags_1,	/* Same as above */
+	sizeof(asn_DEF_TerB_DuplicateA_tags_1)
+		/sizeof(asn_DEF_TerB_DuplicateA_tags_1[0]), /* 1 */
+	{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+		asn_validate_TerB_DuplicateA_1
+	},
+	0, 0,	/* Defined elsewhere */
+	&asn_SPC_TerB_DuplicateA_specs_1	/* Additional specs */
+};
+
+
+/*** <<< INCLUDES [DuplicateB] >>> ***/
+
+#include <OCTET_STRING.h>
+
+/*** <<< TYPE-DECLS [DuplicateB] >>> ***/
+
+typedef OCTET_STRING_t	 TerB_DuplicateB_t;
+
+/*** <<< FUNC-DECLS [DuplicateB] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_TerB_DuplicateB;
+asn_struct_free_f TerB_DuplicateB_free;
+asn_struct_print_f TerB_DuplicateB_print;
+asn_constr_check_f TerB_DuplicateB_constraint;
+ber_type_decoder_f TerB_DuplicateB_decode_ber;
+der_type_encoder_f TerB_DuplicateB_encode_der;
+xer_type_decoder_f TerB_DuplicateB_decode_xer;
+xer_type_encoder_f TerB_DuplicateB_encode_xer;
+cbor_type_decoder_f TerB_DuplicateB_decode_cbor;
+cbor_type_encoder_f TerB_DuplicateB_encode_cbor;
+
+/*** <<< CODE [DuplicateB] >>> ***/
+
+/*
+ * This type is implemented using OCTET_STRING,
+ * so here we adjust the DEF accordingly.
+ */
+
+/*** <<< STAT-DEFS [DuplicateB] >>> ***/
+
+static const ber_tlv_tag_t asn_DEF_TerB_DuplicateB_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (4 << 2))
+};
+asn_TYPE_descriptor_t asn_DEF_TerB_DuplicateB = {
+	"DuplicateB",
+	"DuplicateB",
+	&asn_OP_OCTET_STRING,
+	asn_DEF_TerB_DuplicateB_tags_1,
+	sizeof(asn_DEF_TerB_DuplicateB_tags_1)
+		/sizeof(asn_DEF_TerB_DuplicateB_tags_1[0]), /* 1 */
+	asn_DEF_TerB_DuplicateB_tags_1,	/* Same as above */
+	sizeof(asn_DEF_TerB_DuplicateB_tags_1)
+		/sizeof(asn_DEF_TerB_DuplicateB_tags_1[0]), /* 1 */
+	{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+		OCTET_STRING_constraint
+	},
+	0, 0,	/* No members */
+	&asn_SPC_OCTET_STRING_specs	/* Additional specs */
+};
+
+
+/*** <<< INCLUDES [EXTERNAL] >>> ***/
+
+#include <OBJECT_IDENTIFIER.h>
+#include <NativeInteger.h>
+#include <ObjectDescriptor.h>
+#include <ANY.h>
+#include <OCTET_STRING.h>
+#include <BIT_STRING.h>
+#include <constr_CHOICE.h>
+#include <constr_SEQUENCE.h>
+
+/*** <<< DEPS [EXTERNAL] >>> ***/
+
+typedef enum EXTERNAL__encoding_PR {
+	EXTERNAL__encoding_PR_NOTHING,	/* No components present */
+	EXTERNAL__encoding_PR_single_ASN1_type,
+	EXTERNAL__encoding_PR_octet_aligned,
+	EXTERNAL__encoding_PR_arbitrary
+} EXTERNAL__encoding_PR;
+
+/*** <<< TYPE-DECLS [EXTERNAL] >>> ***/
+
+typedef struct EXTERNAL {
+	OBJECT_IDENTIFIER_t	*direct_reference;	/* OPTIONAL */
+	long	*indirect_reference;	/* OPTIONAL */
+	ObjectDescriptor_t	*data_value_descriptor;	/* OPTIONAL */
+	struct EXTERNAL__encoding {
+		EXTERNAL__encoding_PR present;
+		union EXTERNAL__encoding_u {
+			ANY_t	 single_ASN1_type;
+			OCTET_STRING_t	 octet_aligned;
+			BIT_STRING_t	 arbitrary;
+		} choice;
+		
+		/* Context for parsing across buffer boundaries */
+		asn_struct_ctx_t _asn_ctx;
+	} encoding;
+	
+	/* Context for parsing across buffer boundaries */
+	asn_struct_ctx_t _asn_ctx;
+} EXTERNAL_t;
+
+/*** <<< FUNC-DECLS [EXTERNAL] >>> ***/
+
+extern asn_TYPE_descriptor_t asn_DEF_EXTERNAL;
+
+/*** <<< CODE [EXTERNAL] >>> ***/
+
+#ifndef ASN1C_NO_UNSUFFIXED_PDU_ALIAS
+#if defined(__ELF__) && (defined(__GNUC__) || defined(__clang__))
+extern asn_TYPE_descriptor_t asn_DEF_encoding __attribute__((weak, alias("asn_DEF_encoding_5")));
+#else
+static asn_TYPE_descriptor_t asn_DEF_encoding_5;
+static asn_TYPE_descriptor_t asn_DEF_encoding;
+__attribute__((constructor)) static void asn_DEF_encoding_5_alias_init(void) {
+	asn_DEF_encoding = asn_DEF_encoding_5;
+}
+#endif
+#endif /* ASN1C_NO_UNSUFFIXED_PDU_ALIAS */
+
+/*** <<< STAT-DEFS [EXTERNAL] >>> ***/
+
+static asn_TYPE_member_t asn_MBR_EXTERNAL__encoding_5[] = {
+	{ ATF_NOFLAGS, 0, offsetof(struct EXTERNAL__encoding, choice.single_ASN1_type),
+		.tag = (ASN_TAG_CLASS_CONTEXT | (0 << 2)),
+		.tag_mode = +1,	/* EXPLICIT tag at current level */
+		.type = &asn_DEF_ANY,
+		.type_selector = 0,
+		{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+			.oer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+			.per_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+			.jer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+			.general_constraints = 0
+		},
+		0, 0, /* No default value */
+		.name = "single-ASN1-type"
+		},
+	{ ATF_NOFLAGS, 0, offsetof(struct EXTERNAL__encoding, choice.octet_aligned),
+		.tag = (ASN_TAG_CLASS_CONTEXT | (1 << 2)),
+		.tag_mode = -1,	/* IMPLICIT tag at current level */
+		.type = &asn_DEF_OCTET_STRING,
+		.type_selector = 0,
+		{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+			.oer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+			.per_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+			.jer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+			.general_constraints = 0
+		},
+		0, 0, /* No default value */
+		.name = "octet-aligned"
+		},
+	{ ATF_NOFLAGS, 0, offsetof(struct EXTERNAL__encoding, choice.arbitrary),
+		.tag = (ASN_TAG_CLASS_CONTEXT | (2 << 2)),
+		.tag_mode = -1,	/* IMPLICIT tag at current level */
+		.type = &asn_DEF_BIT_STRING,
+		.type_selector = 0,
+		{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+			.oer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+			.per_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+			.jer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+			.general_constraints = 0
+		},
+		0, 0, /* No default value */
+		.name = "arbitrary"
+		},
+};
+static const asn_TYPE_tag2member_t asn_MAP_encoding_tag2el_5[] = {
+    { (ASN_TAG_CLASS_CONTEXT | (0 << 2)), 0, 0, 0 }, /* single-ASN1-type */
+    { (ASN_TAG_CLASS_CONTEXT | (1 << 2)), 1, 0, 0 }, /* octet-aligned */
+    { (ASN_TAG_CLASS_CONTEXT | (2 << 2)), 2, 0, 0 } /* arbitrary */
+};
+static asn_CHOICE_specifics_t asn_SPC_encoding_specs_5 = {
+	sizeof(struct EXTERNAL__encoding),
+	offsetof(struct EXTERNAL__encoding, _asn_ctx),
+	offsetof(struct EXTERNAL__encoding, present),
+	sizeof(((struct EXTERNAL__encoding *)0)->present),
+	.tag2el = asn_MAP_encoding_tag2el_5,
+	.tag2el_count = 3,	/* Count of tags in the map */
+	0, 0,
+	.first_extension = -1	/* Extensions start */
+};
+static /* Use -fall-defs-global to expose */
+asn_TYPE_descriptor_t asn_DEF_encoding_5 = {
+	"encoding",
+	"encoding",
+	&asn_OP_CHOICE,
+	0,	/* No effective tags (pointer) */
+	0,	/* No effective tags (count) */
+	0,	/* No tags (pointer) */
+	0,	/* No tags (count) */
+	{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+		CHOICE_constraint
+	},
+	asn_MBR_EXTERNAL__encoding_5,
+	3,	/* Elements count */
+	&asn_SPC_encoding_specs_5	/* Additional specs */
+};
+
+static asn_TYPE_member_t asn_MBR_EXTERNAL_1[] = {
+	{ ATF_POINTER, 3, offsetof(struct EXTERNAL, direct_reference),
+		.tag = (ASN_TAG_CLASS_UNIVERSAL | (6 << 2)),
+		.tag_mode = 0,
+		.type = &asn_DEF_OBJECT_IDENTIFIER,
+		.type_selector = 0,
+		{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+			.oer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+			.per_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+			.jer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+			.general_constraints = 0
+		},
+		0, 0, /* No default value */
+		.name = "direct-reference"
+		},
+	{ ATF_POINTER, 2, offsetof(struct EXTERNAL, indirect_reference),
+		.tag = (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)),
+		.tag_mode = 0,
+		.type = &asn_DEF_NativeInteger,
+		.type_selector = 0,
+		{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+			.oer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+			.per_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+			.jer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+			.general_constraints = 0
+		},
+		0, 0, /* No default value */
+		.name = "indirect-reference"
+		},
+	{ ATF_POINTER, 1, offsetof(struct EXTERNAL, data_value_descriptor),
+		.tag = (ASN_TAG_CLASS_UNIVERSAL | (7 << 2)),
+		.tag_mode = 0,
+		.type = &asn_DEF_ObjectDescriptor,
+		.type_selector = 0,
+		{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+			.oer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+			.per_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+			.jer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+			.general_constraints = 0
+		},
+		0, 0, /* No default value */
+		.name = "data-value-descriptor"
+		},
+	{ ATF_NOFLAGS, 0, offsetof(struct EXTERNAL, encoding),
+		.tag = -1 /* Ambiguous tag (CHOICE?) */,
+		.tag_mode = 0,
+		.type = &asn_DEF_encoding_5,
+		.type_selector = 0,
+		{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+			.oer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+			.per_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+			.jer_constraints = 0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+			.general_constraints = 0
+		},
+		0, 0, /* No default value */
+		.name = "encoding"
+		},
+};
+static const ber_tlv_tag_t asn_DEF_EXTERNAL_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (8 << 2)),
+	(ASN_TAG_CLASS_UNIVERSAL | (16 << 2))
+};
+static const asn_TYPE_tag2member_t asn_MAP_EXTERNAL_tag2el_1[] = {
+    { (ASN_TAG_CLASS_UNIVERSAL | (2 << 2)), 1, 0, 0 }, /* indirect-reference */
+    { (ASN_TAG_CLASS_UNIVERSAL | (6 << 2)), 0, 0, 0 }, /* direct-reference */
+    { (ASN_TAG_CLASS_UNIVERSAL | (7 << 2)), 2, 0, 0 }, /* data-value-descriptor */
+    { (ASN_TAG_CLASS_CONTEXT | (0 << 2)), 3, 0, 0 }, /* single-ASN1-type */
+    { (ASN_TAG_CLASS_CONTEXT | (1 << 2)), 3, 0, 0 }, /* octet-aligned */
+    { (ASN_TAG_CLASS_CONTEXT | (2 << 2)), 3, 0, 0 } /* arbitrary */
+};
+static asn_SEQUENCE_specifics_t asn_SPC_EXTERNAL_specs_1 = {
+	sizeof(struct EXTERNAL),
+	offsetof(struct EXTERNAL, _asn_ctx),
+	.tag2el = asn_MAP_EXTERNAL_tag2el_1,
+	.tag2el_count = 6,	/* Count of tags in the map */
+	0, 0, 0,	/* Optional elements (not needed) */
+	-1,	/* First extension addition */
+};
+asn_TYPE_descriptor_t asn_DEF_EXTERNAL = {
+	"EXTERNAL",
+	"EXTERNAL",
+	&asn_OP_SEQUENCE,
+	asn_DEF_EXTERNAL_tags_1,
+	sizeof(asn_DEF_EXTERNAL_tags_1)
+		/sizeof(asn_DEF_EXTERNAL_tags_1[0]) - 1, /* 1 */
+	asn_DEF_EXTERNAL_tags_1,	/* Same as above */
+	sizeof(asn_DEF_EXTERNAL_tags_1)
+		/sizeof(asn_DEF_EXTERNAL_tags_1[0]), /* 2 */
+	{
+#if !defined(ASN_DISABLE_OER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_OER_SUPPORT) */
+#if !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_UPER_SUPPORT) || !defined(ASN_DISABLE_APER_SUPPORT) */
+#if !defined(ASN_DISABLE_JER_SUPPORT)
+		0,
+#endif  /* !defined(ASN_DISABLE_JER_SUPPORT) */
+		SEQUENCE_constraint
+	},
+	asn_MBR_EXTERNAL_1,
+	4,	/* Elements count */
+	&asn_SPC_EXTERNAL_specs_1	/* Additional specs */
+};
+


### PR DESCRIPTION
## Wrong type selected when two modules export the same name

#533 

**Severity:** Incorrect code generation (silent wrong-type binding, no error emitted)
**Affects:** v1.4.2 and earlier (confirmed on `vlm_master`)
**Fixed in:** branch `bug/incorrect-type-selected`

---

### Description

When two modules both export a type with the same name, and a consumer module imports one type from each, asn1c silently binds both to the wrong module's version.

The root cause is in `asn1f_lookup_in_imports`: after checking `xp_members` of an IMPORTS group, the resolver falls back to scanning the full body of the FROM module (`asn1f_lookup_in_module`). When the first group's module also happens to contain a symbol with the requested name (because it exports both `DuplicateA` and `DuplicateB`), the fallback fires and returns the wrong module's definition.

---

### Minimal reproducer

```asn1
-- TerA exports DuplicateA ::= INTEGER and DuplicateB ::= BOOLEAN
-- TerB exports DuplicateA ::= ENUMERATED and DuplicateB ::= OCTET STRING
-- SecA imports DuplicateA FROM TerA, DuplicateB FROM TerB
-- SecB imports DuplicateA FROM TerB, DuplicateB FROM TerA
```

Full schema: `tests/tests-asn1c-compiler/209-prefer-import-source-SE.asn1`

```bash
asn1c -fcompound-names -P 209-prefer-import-source-SE.asn1
```

---

### Expected output (with fix)

```
SeqA.fieldA → TerA_DuplicateA  (INTEGER)   ✓  imported FROM TerA
SeqA.fieldB → TerB_DuplicateB  (OCTET STRING) ✓  imported FROM TerB
SeqB.fieldA → TerB_DuplicateA  (ENUMERATED)  ✓  imported FROM TerB
SeqB.fieldB → TerA_DuplicateB  (BOOLEAN)   ✓  imported FROM TerA
```

### Actual output (without fix)

```
SeqA.fieldA → TerA_DuplicateA  (INTEGER)       ✓
SeqA.fieldB → TerA_DuplicateB  (BOOLEAN)       ✗  should be TerB_DuplicateB
SeqB.fieldA → TerB_DuplicateA  (ENUMERATED)    ✓
SeqB.fieldB → TerB_DuplicateB  (OCTET STRING)  ✗  should be TerA_DuplicateB
```

The `fieldB` members in both `SeqA` and `SeqB` are bound to the wrong module.

---

### Root cause

`asn1f_lookup_in_imports` (`libasn1fix/asn1fix_retrieve.c`) iterates IMPORTS groups:

```c
TQ_FOR(tc, &(xp->xp_members), next) {
    if(strcmp(name, tc->Identifier) == 0) break;   // exact match
    // fallback: scan the full FROM module body
    asn1p_expr_t *v = asn1f_lookup_in_module(fromModule, name);
    if(v) break;   // ← binds to wrong module when name found here
}
```

When processing `SecA`'s `IMPORTS DuplicateB FROM TerB`, the resolver iterates the `TerA` group first. `DuplicateB` is not in `TerA`'s `xp_members`, so the fallback scans `TerA`'s module body and finds `TerA::DuplicateB` — contradicting the `FROM TerB` declaration.

A secondary issue: the flag needed to suppress this fallback (`A1F_PREFER_IMPORT_SOURCE`) was not propagated through the `_ex` wrapper functions or across the `memset` that clears `a1f_replace_me_with_proper_interface_arg` at the end of `asn1f_process`. All compiler-phase lookups therefore ran with `flags=0`, ignoring the flag entirely.

---

### Fix

**`libasn1fix/asn1fix_retrieve.c`** — new flag `A1F_PREFER_IMPORT_SOURCE`: when set, skip the whole-module fallback and require an explicit `xp_members` match:

```c
if(arg->flags & A1F_PREFER_IMPORT_SOURCE)
    continue;   // do not fall back to full-module scan
```

**`libasn1fix/asn1fix.c`** — save and restore `.eh`, `.debug`, `.flags` across the `memset` of the global arg so the compiler phase inherits them.

**`libasn1fix/asn1fix_export.c`**, **`asn1fix_tags.c`** — copy `.flags` from the global in every `_ex` wrapper and in `asn1f_fetch_tags`.

**`libasn1fix/asn1fix_internal.h`** — declare `a1f_replace_me_with_proper_interface_arg` as `extern` once in the shared header.

**CLI:** `-fprefer-import-source` (opt-in; default behaviour unchanged).

---

### Test

`tests/tests-asn1c-compiler/209-prefer-import-source-SE.asn1` with two reference files:

| Variant | Expected result |
|---------|----------------|
| `+-fcompound-names_-P` | Bug output — wrong `fieldB` bindings |
| `+-fcompound-names_-fprefer-import-source_-P` | Fix output — correct bindings, 6-line diff |

`make check` passes on branch `bug/incorrect-type-selected`.