### PR TITLE
Fix APER INTEGER constrained length determinant

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -37,6 +37,15 @@
 	  (Severity: high; Security impact: low)
 
 	FIXES:
+	* Restored the X.691 section 13.2.6 constrained length determinant
+	  for APER constrained INTEGER values whose range is greater than
+	  65536.  A previous fix for wide INTEGER constraint handling changed
+	  this path to the general APER length determinant, producing and
+	  expecting non-conformant encodings such as 01 20 instead of 00 20
+	  for INTEGER (0..4294967295) ::= 32.  The decoder and encoder now
+	  use the constrained len-1 bit field followed by octet alignment
+	  while preserving the unsigned offset accumulation and negative lower
+	  bound checks needed for 64-bit ranges.
 	* Fixed tests/tests-asn1c-compiler subdirectory checks so they build
 	  asn1c before running scripts that invoke it.  This prevents
 	  check-parsing.sh from comparing references against empty output when

--- a/skeletons/INTEGER_aper.c
+++ b/skeletons/INTEGER_aper.c
@@ -6,6 +6,20 @@
 #include <asn_internal.h>
 #include <INTEGER.h>
 
+/* Return ceil(log2(v)) for positive v. */
+static unsigned
+aper_log2_ceil_size(size_t v) {
+    unsigned bits = 0;
+    size_t power = 1;
+
+    while(power < v) {
+        power <<= 1;
+        bits++;
+    }
+
+    return bits;
+}
+
 asn_dec_rval_t
 INTEGER_decode_aper(const asn_codec_ctx_t *opt_codec_ctx,
                     const asn_TYPE_descriptor_t *td,
@@ -79,21 +93,26 @@ INTEGER_decode_aper(const asn_codec_ctx_t *opt_codec_ctx,
             if (ct->range_bits > 16) {
                 /*
                  * X.691 13.2.6: constrained whole number with range > 65536.
-                 * The value is encoded as an APER length determinant followed
-                 * by the minimum number of octets needed for the offset.
+                 * The offset length is encoded as a constrained length
+                 * determinant (len - 1), then the value octets are aligned.
                  */
                 size_t max_range_bytes = ((size_t)ct->range_bits + 7) >> 3;
+                unsigned length_bits = aper_log2_ceil_size(max_range_bytes);
+                int len_minus_one;
                 ssize_t len;
                 uintmax_t offset = 0;
                 intmax_t value;
 
-                len = aper_get_length(pd, -1, -1, -1, &repeat);
-                if(len < 0) ASN__DECODE_STARVED;
-                if(repeat || len <= 0 || (size_t)len > max_range_bytes
+                len_minus_one = per_get_few_bits(pd, length_bits);
+                if(len_minus_one < 0) ASN__DECODE_STARVED;
+                len = (ssize_t)len_minus_one + 1;
+                if(len <= 0 || (size_t)len > max_range_bytes
                    || (size_t)len > sizeof(offset))
                     ASN__DECODE_FAILED;
-                ASN_DEBUG("Constrained INTEGER>16 decode: range_bits=%d max_bytes=%" ASN_PRI_SIZE " len=%" ASN_PRI_SSIZE,
-                          ct->range_bits, max_range_bytes, len);
+                ASN_DEBUG("Constrained INTEGER>16 decode: range_bits=%d max_bytes=%" ASN_PRI_SIZE " len_bits=%u len=%" ASN_PRI_SSIZE,
+                          ct->range_bits, max_range_bytes, length_bits, len);
+
+                if(aper_get_align(pd) < 0) ASN__DECODE_FAILED;
 
                 while(len-- > 0) {
                     int buf = per_get_few_bits(pd, 8);
@@ -352,11 +371,10 @@ INTEGER_encode_aper(const asn_TYPE_descriptor_t *td,
         } else {
             /* X.691 13.2.6: constrained whole number with range > 65536. */
             size_t max_range_bytes = ((size_t)ct->range_bits + 7) >> 3;
+            unsigned length_bits = aper_log2_ceil_size(max_range_bytes);
             size_t num_bytes = 0;
             uint8_t buf[sizeof(v)];
             uintmax_t tmp = v;
-            int need_eom = 0;
-            ssize_t may_encode;
 
             do {
                 num_bytes++;
@@ -365,8 +383,8 @@ INTEGER_encode_aper(const asn_TYPE_descriptor_t *td,
 
             if(num_bytes > max_range_bytes || num_bytes > sizeof(buf))
                 ASN__ENCODE_FAILED;
-            ASN_DEBUG("Constrained INTEGER>16 encode: range_bits=%d max_bytes=%" ASN_PRI_SIZE " len=%" ASN_PRI_SIZE " offset=%" ASN_PRIuMAX,
-                      ct->range_bits, max_range_bytes, num_bytes, v);
+            ASN_DEBUG("Constrained INTEGER>16 encode: range_bits=%d max_bytes=%" ASN_PRI_SIZE " len_bits=%u len=%" ASN_PRI_SIZE " offset=%" ASN_PRIuMAX,
+                      ct->range_bits, max_range_bytes, length_bits, num_bytes, v);
 
             tmp = v;
             {
@@ -377,8 +395,9 @@ INTEGER_encode_aper(const asn_TYPE_descriptor_t *td,
                 }
             }
 
-            may_encode = aper_put_length(po, -1, -1, num_bytes, &need_eom);
-            if(may_encode < 0 || (size_t)may_encode != num_bytes || need_eom)
+            if(per_put_few_bits(po, num_bytes - 1, length_bits))
+                ASN__ENCODE_FAILED;
+            if(aper_put_align(po) < 0)
                 ASN__ENCODE_FAILED;
             if(per_put_many_bits(po, buf, 8 * num_bytes))
                 ASN__ENCODE_FAILED;

--- a/tests/tests-skeletons/check-APER-INTEGER-f1ap.c
+++ b/tests/tests-skeletons/check-APER-INTEGER-f1ap.c
@@ -120,43 +120,43 @@ int main() {
     printf("=== F1AP INTEGER (0..4294967295) APER Encoding Test ===\n\n");
     
     /* Test case 1 from issue: value 32 (0x20) */
-    /* Expected: 01 20 (APER length determinant, then value byte) */
-    uint8_t expected_32[] = {0x01, 0x20};
+    /* Expected: 00 20 (2-bit constrained length "00", align, then value byte) */
+    uint8_t expected_32[] = {0x00, 0x20};
     check_f1ap_id_encoding(__LINE__, 32, expected_32, sizeof(expected_32));
     
     /* Test case 2 from issue: value 1 (0x01) */
-    /* Expected: 01 01 (APER length determinant, then value byte) */
-    uint8_t expected_1[] = {0x01, 0x01};
+    /* Expected: 00 01 (2-bit constrained length "00", align, then value byte) */
+    uint8_t expected_1[] = {0x00, 0x01};
     check_f1ap_id_encoding(__LINE__, 1, expected_1, sizeof(expected_1));
     
     /* Additional test cases */
     
-    /* Value 0: Expected 01 00 (APER length determinant, then value 0x00) */
-    uint8_t expected_0[] = {0x01, 0x00};
+    /* Value 0: Expected 00 00 */
+    uint8_t expected_0[] = {0x00, 0x00};
     check_f1ap_id_encoding(__LINE__, 0, expected_0, sizeof(expected_0));
     
-    /* Value 255 (0xFF): Expected 01 FF (APER length determinant, then value 0xFF) */
-    uint8_t expected_255[] = {0x01, 0xFF};
+    /* Value 255 (0xFF): Expected 00 FF */
+    uint8_t expected_255[] = {0x00, 0xFF};
     check_f1ap_id_encoding(__LINE__, 255, expected_255, sizeof(expected_255));
     
-    /* Value 256 (0x0100): Expected 02 01 00 */
-    uint8_t expected_256[] = {0x02, 0x01, 0x00};
+    /* Value 256 (0x0100): Expected 40 01 00 */
+    uint8_t expected_256[] = {0x40, 0x01, 0x00};
     check_f1ap_id_encoding(__LINE__, 256, expected_256, sizeof(expected_256));
     
-    /* Value 65535 (0xFFFF): Expected 02 FF FF */
-    uint8_t expected_65535[] = {0x02, 0xFF, 0xFF};
+    /* Value 65535 (0xFFFF): Expected 40 FF FF */
+    uint8_t expected_65535[] = {0x40, 0xFF, 0xFF};
     check_f1ap_id_encoding(__LINE__, 65535, expected_65535, sizeof(expected_65535));
     
-    /* Value 65536 (0x010000): Expected 03 01 00 00 */
-    uint8_t expected_65536[] = {0x03, 0x01, 0x00, 0x00};
+    /* Value 65536 (0x010000): Expected 80 01 00 00 */
+    uint8_t expected_65536[] = {0x80, 0x01, 0x00, 0x00};
     check_f1ap_id_encoding(__LINE__, 65536, expected_65536, sizeof(expected_65536));
     
-    /* Value 16777215 (0xFFFFFF): Expected 03 FF FF FF */
-    uint8_t expected_16777215[] = {0x03, 0xFF, 0xFF, 0xFF};
+    /* Value 16777215 (0xFFFFFF): Expected 80 FF FF FF */
+    uint8_t expected_16777215[] = {0x80, 0xFF, 0xFF, 0xFF};
     check_f1ap_id_encoding(__LINE__, 16777215, expected_16777215, sizeof(expected_16777215));
     
-    /* Max value 4294967295 (0xFFFFFFFF): Expected 04 FF FF FF FF */
-    uint8_t expected_max[] = {0x04, 0xFF, 0xFF, 0xFF, 0xFF};
+    /* Max value 4294967295 (0xFFFFFFFF): Expected C0 FF FF FF FF */
+    uint8_t expected_max[] = {0xC0, 0xFF, 0xFF, 0xFF, 0xFF};
     check_f1ap_id_encoding(__LINE__, 4294967295UL, expected_max, sizeof(expected_max));
     
     printf("=== All F1AP tests passed! ===\n");

--- a/tests/tests-skeletons/check-APER-INTEGER-x691-range.c
+++ b/tests/tests-skeletons/check-APER-INTEGER-x691-range.c
@@ -28,7 +28,7 @@ struct test_case {
 };
 
 struct test_case_signed {
-    long value;
+    intmax_t value;
     const uint8_t *expected;
     size_t expected_len;
 };
@@ -126,7 +126,7 @@ check_x691_constrained_range_signed(const char *label, int lineno,
 
     encoded_len = (size_t)(po.buffer - po.tmpspace) + ((po.nboff + 7) / 8);
 
-    printf("%s:%d value=%ld expected_len=%zu got_len=%zu\n", label, lineno,
+    printf("%s:%d value=%" ASN_PRIdMAX " expected_len=%zu got_len=%zu\n", label, lineno,
            tc->value, tc->expected_len, encoded_len);
 
     assert(encoded_len == tc->expected_len);
@@ -153,13 +153,13 @@ check_x691_constrained_range_signed(const char *label, int lineno,
 
 static void
 test_range_bits_36(void) {
-    static const uint8_t exp_0[] = {0x01, 0x00};
-    static const uint8_t exp_1[] = {0x01, 0x01};
-    static const uint8_t exp_255[] = {0x01, 0xFF};
-    static const uint8_t exp_256[] = {0x02, 0x01, 0x00};
-    static const uint8_t exp_65535[] = {0x02, 0xFF, 0xFF};
-    static const uint8_t exp_65536[] = {0x03, 0x01, 0x00, 0x00};
-    static const uint8_t exp_max[] = {0x05, 0x0F, 0xFF, 0xFF, 0xFF, 0xFF};
+    static const uint8_t exp_0[] = {0x00, 0x00};
+    static const uint8_t exp_1[] = {0x00, 0x01};
+    static const uint8_t exp_255[] = {0x00, 0xFF};
+    static const uint8_t exp_256[] = {0x20, 0x01, 0x00};
+    static const uint8_t exp_65535[] = {0x20, 0xFF, 0xFF};
+    static const uint8_t exp_65536[] = {0x40, 0x01, 0x00, 0x00};
+    static const uint8_t exp_max[] = {0x80, 0x0F, 0xFF, 0xFF, 0xFF, 0xFF};
 
     static const struct test_case cases[] = {
         {0, exp_0, sizeof(exp_0)},
@@ -192,13 +192,13 @@ test_range_bits_36(void) {
  */
 static void
 test_range_bits_17(void) {
-    static const uint8_t exp_0[] = {0x01, 0x00};
-    static const uint8_t exp_1[] = {0x01, 0x01};
-    static const uint8_t exp_255[] = {0x01, 0xFF};
-    static const uint8_t exp_256[] = {0x02, 0x01, 0x00};
-    static const uint8_t exp_65535[] = {0x02, 0xFF, 0xFF};
+    static const uint8_t exp_0[] = {0x00, 0x00};
+    static const uint8_t exp_1[] = {0x00, 0x01};
+    static const uint8_t exp_255[] = {0x00, 0xFF};
+    static const uint8_t exp_256[] = {0x40, 0x01, 0x00};
+    static const uint8_t exp_65535[] = {0x40, 0xFF, 0xFF};
     /* 131071 = 0x01FFFF, 3 value bytes */
-    static const uint8_t exp_max[] = {0x03, 0x01, 0xFF, 0xFF};
+    static const uint8_t exp_max[] = {0x80, 0x01, 0xFF, 0xFF};
 
     static const struct test_case cases[] = {
         {0, exp_0, sizeof(exp_0)},
@@ -232,15 +232,15 @@ test_range_bits_17(void) {
 static void
 test_range_bits_17_offset(void) {
     /* offset 0 */
-    static const uint8_t exp_lo[] = {0x01, 0x00};
+    static const uint8_t exp_lo[] = {0x00, 0x00};
     /* offset 1 */
-    static const uint8_t exp_lo1[] = {0x01, 0x01};
+    static const uint8_t exp_lo1[] = {0x00, 0x01};
     /* offset 255 */
-    static const uint8_t exp_255[] = {0x01, 0xFF};
+    static const uint8_t exp_255[] = {0x00, 0xFF};
     /* offset 256: 2 value bytes */
-    static const uint8_t exp_256[] = {0x02, 0x01, 0x00};
+    static const uint8_t exp_256[] = {0x40, 0x01, 0x00};
     /* offset 99000 = 0x0182B8: 3 value bytes */
-    static const uint8_t exp_hi[] = {0x03, 0x01, 0x82, 0xB8};
+    static const uint8_t exp_hi[] = {0x80, 0x01, 0x82, 0xB8};
 
     static const struct test_case cases[] = {
         {1000, exp_lo, sizeof(exp_lo)},   {1001, exp_lo1, sizeof(exp_lo1)},
@@ -271,13 +271,13 @@ test_range_bits_17_offset(void) {
 static void
 test_range_bits_17_signed(void) {
     /* offset 0 */
-    static const uint8_t exp_lo[] = {0x01, 0x00};
+    static const uint8_t exp_lo[] = {0x00, 0x00};
     /* offset 1 */
-    static const uint8_t exp_lo1[] = {0x01, 0x01};
+    static const uint8_t exp_lo1[] = {0x00, 0x01};
     /* offset 50000 = 0xC350: 2 value bytes */
-    static const uint8_t exp_mid[] = {0x02, 0xC3, 0x50};
+    static const uint8_t exp_mid[] = {0x40, 0xC3, 0x50};
     /* offset 100000 = 0x0186A0: 3 value bytes */
-    static const uint8_t exp_hi[] = {0x03, 0x01, 0x86, 0xA0};
+    static const uint8_t exp_hi[] = {0x80, 0x01, 0x86, 0xA0};
 
     static const struct test_case_signed cases[] = {
         {-50000, exp_lo, sizeof(exp_lo)},
@@ -302,11 +302,199 @@ test_range_bits_17_signed(void) {
     }
 }
 
+static void
+test_x691_note_example(void) {
+    static const uint8_t exp_zero_offset[] = {0x00, 0x00};
+    static const struct test_case tc = {
+        256, exp_zero_offset, sizeof(exp_zero_offset)
+    };
+    asn_per_constraints_t cts;
+
+    memset(&cts, 0, sizeof(cts));
+    cts.value.flags = APC_CONSTRAINED;
+    cts.value.range_bits = 21;
+    cts.value.effective_bits = 21;
+    cts.value.lower_bound = 256;
+    cts.value.upper_bound = 1234567;
+
+    check_x691_constrained_range("x691-note", __LINE__, &cts, &tc);
+}
+
+static void
+test_65535_65536_boundary(void) {
+    static const uint8_t exp_65535[] = {0xFF, 0xFF};
+    static const uint8_t exp_65536[] = {0x80, 0x01, 0x00, 0x00};
+    static const struct test_case tc16 = {
+        65535, exp_65535, sizeof(exp_65535)
+    };
+    static const struct test_case tc17 = {
+        65536, exp_65536, sizeof(exp_65536)
+    };
+    asn_per_constraints_t cts;
+
+    memset(&cts, 0, sizeof(cts));
+    cts.value.flags = APC_CONSTRAINED;
+    cts.value.range_bits = 16;
+    cts.value.effective_bits = 16;
+    cts.value.lower_bound = 0;
+    cts.value.upper_bound = 65535;
+    check_x691_constrained_range("range16-boundary", __LINE__, &cts, &tc16);
+
+    memset(&cts, 0, sizeof(cts));
+    cts.value.flags = APC_CONSTRAINED;
+    cts.value.range_bits = 17;
+    cts.value.effective_bits = 17;
+    cts.value.lower_bound = 0;
+    cts.value.upper_bound = 65536;
+    check_x691_constrained_range("range17-boundary", __LINE__, &cts, &tc17);
+}
+
+static void
+test_unaligned_length_field(void) {
+    static const uint8_t expected[] = {0xA8, 0x01, 0x00};
+    INTEGER_t st;
+    INTEGER_t *decoded_st = 0;
+    struct asn_INTEGER_specifics_s specs;
+    asn_per_constraints_t cts;
+    asn_enc_rval_t enc_rval;
+    asn_dec_rval_t dec_rval;
+    asn_per_outp_t po;
+    asn_per_data_t pd;
+    size_t encoded_len;
+    uint64_t decoded_value = 0;
+
+    memset(&st, 0, sizeof(st));
+    memset(&specs, 0, sizeof(specs));
+    memset(&cts, 0, sizeof(cts));
+    memset(&po, 0, sizeof(po));
+    memset(&pd, 0, sizeof(pd));
+
+    asn_uint642INTEGER(&st, 256);
+
+    po.buffer = po.tmpspace;
+    po.nboff = 0;
+    po.nbits = 8 * sizeof(po.tmpspace);
+    po.output = FailOut;
+
+    assert(per_put_few_bits(&po, 0x5, 3) == 0);
+
+    specs.field_width = sizeof(uint64_t);
+    specs.field_unsigned = 1;
+    asn_DEF_INTEGER.specifics = &specs;
+
+    cts.value.flags = APC_CONSTRAINED;
+    cts.value.range_bits = 32;
+    cts.value.effective_bits = 32;
+    cts.value.lower_bound = 0;
+    cts.value.upper_bound = UINT64_C(4294967295);
+
+    enc_rval = INTEGER_encode_aper(&asn_DEF_INTEGER, &cts, &st, &po);
+    assert(enc_rval.encoded >= 0);
+
+    encoded_len = (size_t)(po.buffer - po.tmpspace) + ((po.nboff + 7) / 8);
+    assert(encoded_len == sizeof(expected));
+    assert(memcmp(po.tmpspace, expected, sizeof(expected)) == 0);
+
+    pd.buffer = po.tmpspace;
+    pd.nboff = 0;
+    pd.nbits = 8 * encoded_len;
+    pd.moved = 0;
+
+    assert(per_get_few_bits(&pd, 3) == 0x5);
+    dec_rval = INTEGER_decode_aper(0, &asn_DEF_INTEGER, &cts,
+                                   (void **)&decoded_st, &pd);
+    assert(dec_rval.code == RC_OK);
+    asn_INTEGER2uint64(decoded_st, &decoded_value);
+    assert(decoded_value == 256);
+
+    ASN_STRUCT_RESET(asn_DEF_INTEGER, &st);
+    ASN_STRUCT_FREE(asn_DEF_INTEGER, decoded_st);
+}
+
+static void
+test_extensible_root_value(void) {
+    static const uint8_t exp_32[] = {0x00, 0x20};
+    static const struct test_case tc = {32, exp_32, sizeof(exp_32)};
+    asn_per_constraints_t cts;
+
+    memset(&cts, 0, sizeof(cts));
+    cts.value.flags = APC_CONSTRAINED | APC_EXTENSIBLE;
+    cts.value.range_bits = 32;
+    cts.value.effective_bits = 32;
+    cts.value.lower_bound = 0;
+    cts.value.upper_bound = UINT64_C(4294967295);
+
+    check_x691_constrained_range("extensible-root", __LINE__, &cts, &tc);
+}
+
+static void
+test_range_bits_64_signed_offsets(void) {
+    static const uint8_t enc_min[] = {0x00, 0x00};
+    static const uint8_t enc_minus_one[] = {
+        0xE0, 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
+    };
+    static const uint8_t enc_max[] = {
+        0xE0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
+    };
+    struct decode_case {
+        const uint8_t *encoded;
+        size_t encoded_len;
+        intmax_t expected;
+    };
+    static const struct decode_case cases[] = {
+        {enc_min, sizeof(enc_min), INTMAX_MIN},
+        {enc_minus_one, sizeof(enc_minus_one), -1},
+        {enc_max, sizeof(enc_max), INTMAX_MAX},
+    };
+    size_t i;
+
+    for(i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        INTEGER_t *decoded_st = 0;
+        struct asn_INTEGER_specifics_s specs;
+        asn_per_constraints_t cts;
+        asn_dec_rval_t dec_rval;
+        asn_per_data_t pd;
+        intmax_t decoded_value = 0;
+
+        memset(&specs, 0, sizeof(specs));
+        memset(&cts, 0, sizeof(cts));
+        memset(&pd, 0, sizeof(pd));
+
+        specs.field_width = sizeof(intmax_t);
+        specs.field_unsigned = 0;
+        asn_DEF_INTEGER.specifics = &specs;
+
+        cts.value.flags = APC_CONSTRAINED;
+        cts.value.range_bits = 64;
+        cts.value.effective_bits = 64;
+        cts.value.lower_bound = INTMAX_MIN;
+        cts.value.upper_bound = INTMAX_MAX;
+
+        pd.buffer = cases[i].encoded;
+        pd.nboff = 0;
+        pd.nbits = 8 * cases[i].encoded_len;
+        pd.moved = 0;
+
+        dec_rval = INTEGER_decode_aper(0, &asn_DEF_INTEGER, &cts,
+                                       (void **)&decoded_st, &pd);
+        assert(dec_rval.code == RC_OK);
+        asn_INTEGER2imax(decoded_st, &decoded_value);
+        assert(decoded_value == cases[i].expected);
+
+        ASN_STRUCT_FREE(asn_DEF_INTEGER, decoded_st);
+    }
+}
+
 int
 main(void) {
     test_range_bits_17();
     test_range_bits_17_offset();
     test_range_bits_17_signed();
     test_range_bits_36();
+    test_x691_note_example();
+    test_65535_65536_boundary();
+    test_unaligned_length_field();
+    test_extensible_root_value();
+    test_range_bits_64_signed_offsets();
     return 0;
 }


### PR DESCRIPTION
## Summary

- Restore the X.691 section 13.2.6 constrained length determinant for APER constrained INTEGER values whose finite range exceeds 65536.
- Preserve the unsigned offset accumulation and negative lower-bound rebasing added by [`632dfa0e`](https://github.com/mouse07410/asn1c/commit/632dfa0ecf5d790fc4c13bb4768a4d04c1cfa9ff), which remains needed for wide constraints.
- Update byte-exact APER INTEGER regression vectors, including F1AP-style 32-bit IDs, 5-octet ranges, boundary cases, extensible-root values, unaligned starts, and 64-bit decode edges.

## Details

Commit `632dfa0e` switched the `range_bits > 16` APER INTEGER path to the general APER length determinant. That encodes `INTEGER (0..4294967295) ::= 32` as `01 20`, but X.691 section 13.2.6 a) requires a constrained length determinant: two length bits `00`, octet alignment, then `20`, yielding `00 20`.

This change restores the constrained `len - 1` bit-field followed by APER octet alignment before the value octets. It keeps the value-side improvements from `632dfa0e`, including `uintmax_t` offset accumulation and checked rebasing for negative lower bounds.

## Test plan (by Cursor)

- `autoreconf -ivf && ./configure && make -j"$(nproc)"`
- `make check-APER-INTEGER-f1ap check-APER-INTEGER-x691-range && ./check-APER-INTEGER-f1ap && ./check-APER-INTEGER-x691-range` from `tests/tests-skeletons`
- `./run.sh` from `tests/tests-integer-native`
- `make -j"$(nproc)" check` from `tests/tests-skeletons` was run; the APER INTEGER tests passed, while unrelated existing sanitizer/assertion failures remain in `check-OCTET_STRING`, `check-BER-NativeInteger-uint64`, `check-XER-octstr-auto`, `check-XER-octstr-pdu`, `check-JER`, and `check-UPER-PrintableString`.
- Bugbot review: no bugs found.
- Security review: no medium/high/critical findings.