### PR TITLE
tests/tests-randomized: emit tab with printf, not echo

### DIFF
--- a/tests/tests-randomized/check-bundles.sh
+++ b/tests/tests-randomized/check-bundles.sh
@@ -439,7 +439,7 @@ asn_compile() {
     echo "include converter-example.mk"
     echo
     echo "random-test-driver.o: random-test-driver.c"
-    echo "\t\$(CC) \$(CFLAGS) \$(DEPFLAGS) -DASN1_TEXT='\$(ASN1_TEXT)' -o \$@ -c \$<"
+    printf "\t\$(CC) \$(CFLAGS) \$(DEPFLAGS) -DASN1_TEXT='\$(ASN1_TEXT)' -o \$@ -c \$<\n"
     echo
     echo "all-tests-succeeded: ${abs_top_builddir}/asn1c/asn1c \$(ASN_PROGRAM_SRCS) \\"
     echo "    \$(ASN_MODULE_SRCS) \$(ASN_MODULE_HDRS)"


### PR DESCRIPTION
## Summary

`tests/tests-randomized/check-bundles.sh` generates one Makefile per random type bundle. Line 442 emits the recipe indentation for the `random-test-driver.o` rule using `echo "\t..."`, which depends on the running shell's `echo` builtin interpreting `\t` as a tab.

Under POSIX-strict shells such as `dash` (Debian/Ubuntu default for `/bin/sh`) that works. Under `bash` — which is `/bin/sh` on Arch, Fedora, RHEL, most container base images — the builtin `echo` emits `\t` literally by default, producing a Makefile whose recipe line begins with a literal backslash-t instead of a real tab. GNU `make` rejects it with

```
Makefile:8: *** missing separator.  Stop.
```

and every randomized bundle fails with `Cannot compile C for T ::= ...` before any actual test runs.

## Fix

Switch that one line from `echo` to `printf`. `printf` is POSIX-required to interpret backslash escapes, so the tab lands correctly regardless of which shell is running the script. The trailing `\n` (previously supplied implicitly by `echo`) is added to the format string.

No other lines in the file need changing — every other `echo` uses either plain literal text or backslash-escaped shell variables, none rely on `\t`.

## Reproduction (before the fix)

```
$ ls -l /bin/sh
lrwxrwxrwx ... /bin/sh -> bash
$ cd tests/tests-randomized && make check TESTS=bundles/00-NULL-bundle.txt
...
Makefile:8: *** missing separator.  Stop.
FAIL bundles/00-NULL-bundle.txt (exit status: 1)
```

## Test plan

- [x] `make check` on a host where `/bin/sh -> bash` — all 19 randomized bundles now proceed past the compile stage. Previously all 19 failed at the `missing separator` error.
- [x] `bash -c 'printf "\t%s\n" hello' | cat -A` — confirms tab is emitted correctly.

## Notes

Independent of #558 and #557 — this bug pre-exists both. Filed as a separate PR so it can be reviewed and merged on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)